### PR TITLE
remove use of rspec-activemodel-mocks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ group :test, :development do
   gem 'letter_opener', require: false
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'rspec-activemodel-mocks'
   gem 'rspec-rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,10 +205,6 @@ GEM
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
       rspec-mocks (~> 3.1.0)
-    rspec-activemodel-mocks (1.0.1)
-      activemodel (>= 3.0)
-      activesupport (>= 3.0)
-      rspec-mocks (>= 2.99, < 4.0)
     rspec-core (3.1.7)
       rspec-support (~> 3.1.0)
     rspec-expectations (3.1.2)
@@ -295,7 +291,6 @@ DEPENDENCIES
   railroady
   rails (~> 4.1.7)
   roadie (~> 2.4)
-  rspec-activemodel-mocks
   rspec-rails
   rvm-capistrano
   sass-rails (>= 3.2)

--- a/spec/controllers/communicarts_controller_spec.rb
+++ b/spec/controllers/communicarts_controller_spec.rb
@@ -277,12 +277,13 @@ describe CommunicartsController do
         allow(cart).to receive_message_chain(:approval_group, :approvers, :where).and_return([approver])
         allow(cart).to receive(:update_approval_status)
 
-        mock_comment = mock_model(Comment)
-        allow(mock_comment).to receive(:[]=)
-        allow(mock_comment).to receive(:has_attribute?).with('commentable_id').and_return(true)
-        allow(mock_comment).to receive(:save)
-        expect(Comment).to receive(:new).with(user_id: approver.id, comment_text: 'Test Approval Comment').and_return(mock_comment)
-        post 'approval_reply_received', @json_approval_params
+        expect {
+          post 'approval_reply_received', @json_approval_params
+        }.to change { Comment.count }.from(0).to(1)
+
+        comment = Comment.last
+        expect(comment.user_id).to eq(approver.id)
+        expect(comment.comment_text).to eq('Test Approval Comment')
       end
 
       it 'does not create a comment when not given a comment param' do


### PR DESCRIPTION
Not really that useful.
