### PR TITLE
simplify OAuth specs

### DIFF
--- a/spec/integration/set_user_after_login_spec.rb
+++ b/spec/integration/set_user_after_login_spec.rb
@@ -1,41 +1,19 @@
 describe 'User creation when logging in with Oauth to view a protected page' do
-  let(:mock_raw_info) { double }
-
-  let(:extra_mock) {
-    double(raw_info: mock_raw_info )
-  }
-
-  let(:credentials_mock) {
-    double(token: '1a2b3c4d')
-  }
-
   before do
-    allow(OmniAuth.config.mock_auth[:myusa]).to receive(:extra).and_return(extra_mock)
-    allow(OmniAuth.config.mock_auth[:myusa]).to receive(:credentials).and_return(credentials_mock)
+    setup_mock_auth
   end
 
   it 'creates a new user if the current user does not already exist' do
-    allow(mock_raw_info).to receive(:to_hash).and_return(
-      'email'=>'a-brand-spankin-new-email@some-dot-gov.gov',
-      'first_name'=>'Brand',
-      'last_name'=>'Newsom'
-    )
-
     expect(User.count).to eq 0
     get '/auth/myusa/callback'
     get '/approval_groups/new'
 
     expect(User.count).to eq 1
-    expect(User.last.email_address).to eq 'a-brand-spankin-new-email@some-dot-gov.gov'
+    expect(User.last.email_address).to eq('george.jetson@some-dot-gov.gov')
   end
 
   it 'does not create a user if the current user already exists' do
-    FactoryGirl.create(:user, email_address: 'approver1@some-dot-gov.gov')
-    allow(mock_raw_info).to receive(:to_hash).and_return(
-      'email'=>'approver1@some-dot-gov.gov',
-      'first_name'=>'Someone',
-      'last_name' =>'Exists'
-    )
+    FactoryGirl.create(:user, email_address: 'george.jetson@some-dot-gov.gov')
 
     expect(User.count).to eq 1
     get '/auth/myusa/callback'

--- a/spec/integration_spec_helper.rb
+++ b/spec/integration_spec_helper.rb
@@ -1,27 +1,31 @@
 module IntegrationSpecHelper
-  def login_with_oauth(service = :myusa)
-    mock_raw_info = double("raw_info_mock")
-
-    allow(mock_raw_info).to receive(:to_hash).and_return(
-      email: 'george.jetson@some-dot-gov.gov',
-      first_name: "George",
-      last_name: "Jetson"
+  def setup_mock_auth(service_name = :myusa)
+    OmniAuth.config.mock_auth[service_name] = OmniAuth::AuthHash.new(
+      provider: service_name.to_s,
+      raw_info: {
+        'name' => "George Jetson"
+      },
+      uid: '12345',
+      nickname: 'georgejetsonmyusa',
+      extra: {
+        'raw_info' => {
+          'email' => 'george.jetson@some-dot-gov.gov',
+          'first_name' => 'George',
+          'last_name' => 'Jetson'
+        }
+      },
+      credentials: {
+        'token' => '1a2b3c4d'
+      }
     )
+  end
 
-    extra_mock = double("mock_extra",
-      raw_info: mock_raw_info
-    )
-
-    credentials_mock = double("myusa_creds",
-      token: '1a2b3c4d'
-    )
-
-    OmniAuth.config.mock_auth[:myusa].extra = extra_mock
-    OmniAuth.config.mock_auth[:myusa].credentials = credentials_mock
+  def login_with_oauth(service_name = :myusa)
+    setup_mock_auth(service_name)
 
     user = @user ||= FactoryGirl.create(:user)
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
-    visit "/auth/#{service}"
+    visit "/auth/#{service_name}"
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,14 +75,10 @@ RSpec.configure do |config|
   config.after(:each) do
     DatabaseCleaner.clean
     ActionMailer::Base.deliveries.clear
+    OmniAuth.config.mock_auth[:myusa] = nil
   end
 
 
   Capybara.default_host = 'http://localhost:3000'
   OmniAuth.config.test_mode = true
-  OmniAuth.config.add_mock(:myusa, {
-    :raw_info => {"name"=>"George Jetson"},
-    :uid => '12345',
-    :nickname => 'georgejetsonmyusa'
-  })
 end


### PR DESCRIPTION
Session state is now reset between specs, and a common setup helper method is being used.
