### PR TITLE
[#84708218] Remove old BPA image

### DIFF
--- a/app/assets/stylesheets/common/communicarts.css.scss
+++ b/app/assets/stylesheets/common/communicarts.css.scss
@@ -358,15 +358,6 @@ ul.result-tag li {
   list-style: none;
 }
 
-.bpa {
-  background-image: url('https://www.gsaadvantage.gov/images/adv12/images/new_icons/bpa.gif');
-  background-repeat: no-repeat;
-  padding-left: 38px;
-  display: inline-block;
-  width: 29px;
-  height: 18px;
-}
-
 span.green {
   background-repeat: no-repeat;
   display: inline-block;


### PR DESCRIPTION
Removed old style that pulls in BPA icon into approval emails.
