### PR TITLE
add rake task to generate ssh config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ group :test, :development do
 end
 
 group :development do
+  gem 'aws-sdk', '2.0.6.pre', require: false
   gem 'guard-rspec', require: false
   gem 'mail_view'
   gem 'railroady'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,15 @@ GEM
     autoprefixer-rails (4.0.1.1)
       execjs
     awesome_print (1.2.0)
+    aws-sdk (2.0.6.pre)
+      aws-sdk-resources (= 2.0.6.pre)
+    aws-sdk-core (2.0.6)
+      builder (~> 3.0)
+      jmespath (~> 1.0)
+      multi_json (~> 1.0)
+      multi_xml (~> 0.5)
+    aws-sdk-resources (2.0.6.pre)
+      aws-sdk-core (= 2.0.6)
     bootstrap-sass (3.3.1.0)
       sass (~> 3.2)
     builder (3.2.2)
@@ -111,6 +120,8 @@ GEM
     hike (1.2.3)
     hitimes (1.2.2)
     i18n (0.6.11)
+    jmespath (1.0.2)
+      multi_json (~> 1.0)
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
@@ -264,6 +275,7 @@ DEPENDENCIES
   acts_as_list
   autoprefixer-rails
   awesome_print
+  aws-sdk (= 2.0.6.pre)
   bootstrap-sass (~> 3.3.0)
   capybara
   codeclimate-test-reporter

--- a/lib/tasks/aws.rake
+++ b/lib/tasks/aws.rake
@@ -1,0 +1,43 @@
+namespace :aws do
+  namespace :ssh do
+    desc "Display a sample SSH config for connecting to CAP AWS machines"
+    task :config do
+      require 'active_support/core_ext/string/strip'
+      require 'aws-sdk'
+
+
+      def find_by_name(instances, name)
+        instances.find do |instance|
+          instance.tags.any? do |tag|
+            tag.key == 'Name' && tag.value == name
+          end
+        end
+      end
+
+
+      ec2 = Aws::EC2::Client.new(region: 'us-west-2')
+      resp = ec2.describe_instances(
+        filters: [
+          {
+            name: 'tag:Description',
+            values: ['cap-dev']
+          }
+        ]
+      )
+      instances = resp.reservations.flat_map(&:instances)
+      nat = find_by_name(instances, 'cf-cap-dev-nat')
+      asg = find_by_name(instances, 'cf-cap-dev-asg')
+
+      puts <<-SSH.strip_heredoc
+        Host cap-dev-nat
+          HostName #{nat.public_ip_address}
+          User ec2-user
+          ForwardAgent yes
+        Host cap-dev
+          HostName #{asg.private_ip_address}
+          User ubuntu
+          ProxyCommand ssh cap-dev-nat nc %h %p
+      SSH
+    end
+  end
+end


### PR DESCRIPTION
It's really obnoxious to have to look up the new IP addresses any time one of our servers is re-built... this task is a first step at making things a little easier.

I'm looking into doing more, like being able to run one-off commands like copying the production database to the local one, opening a bash, Rails, or database console, etc.

/cc @dlapiduz 
