### PR TITLE
Conditionally display the portal link

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -40,6 +40,6 @@ module ApplicationHelper
 
   def excluded_portal_link
     controller_name == 'home' ||
-    controller_name == 'carts' && action_name == 'index'
+    current_page?(carts_path)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,4 +37,9 @@ module ApplicationHelper
       [key, flash_message(val)]
     end
   end
+
+  def excluded_portal_link
+    controller_name == 'home' ||
+    controller_name == 'carts' && action_name == 'index'
+  end
 end

--- a/app/views/layouts/_communicart_header.html.erb
+++ b/app/views/layouts/_communicart_header.html.erb
@@ -32,6 +32,8 @@
   </div>
 </div>
 
-<ul id='breadcrumb-nav'>
-  <li><%= link_to "Back to main portal", carts_path %></li>
-</ul>
+<%- unless excluded_portal_link %>
+  <ul id='breadcrumb-nav'>
+    <li><%= link_to "Back to main portal", carts_path %></li>
+  </ul>
+<%- end %>


### PR DESCRIPTION
While testing, I realized the 'Back to main portal' link is showing up on the homepage as well as on the very page it links to. Added a quick way to handle this.