### PR TITLE
Simplified route to carts/index to work with c783bb5e

### DIFF
--- a/app/views/layouts/_communicart_header.html.erb
+++ b/app/views/layouts/_communicart_header.html.erb
@@ -25,7 +25,7 @@
     <%- if signed_in? %>
       <div class="mycart-link">
         <ul class="header-nav">
-            <li><%= link_to("My Requests", "/carts/index") %> <%= image_tag "img-cart.png", width: '18px', height:'16px' %></li>
+            <li><%= link_to("My Requests", carts_path) %> <%= image_tag "img-cart.png", width: '18px', height:'16px' %></li>
         </ul>
       </div>
     <%- end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,6 @@ C2::Application.routes.draw do
   match "/auth/:provider/callback" => "home#oauth_callback", via: [:get]
   post "/logout" => "home#logout"
   get 'overlay', to: "overlay#index"
-  get 'carts/index' => "carts#index"
   get 'carts/archive' => 'carts#archive'
 
   resources :carts do


### PR DESCRIPTION
Noticed that [this commit](https://github.com/18F/C2/commit/c783bb5e) didn't account for the route `/carts/index`. Simplified the route for the carts#index page by taking advantage of the existing `resources :carts` routes definition.