### PR TITLE
remove NewRelic gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem 'settingslogic'
 gem 'simple_form_object'
 gem 'turbolinks'
 gem 'uglifier'
-gem 'newrelic_rpm'
 
 group :test, :development do
   gem 'database_cleaner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,6 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
-    newrelic_rpm (3.9.9.275)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
     notiffany (0.0.3)
@@ -324,7 +323,6 @@ DEPENDENCIES
   haml
   jquery-rails
   mail_view
-  newrelic_rpm
   omniauth-myusa!
   pg
   pry-byebug


### PR DESCRIPTION
Not in use right now... we can always re-add it if needed.