### PR TITLE
[#86662046] display cart name on show page

### DIFF
--- a/app/views/carts/_cart.html.erb
+++ b/app/views/carts/_cart.html.erb
@@ -1,12 +1,15 @@
 <div class="inset">
   <div class="row">
 
-    <div class="col-md-8 col-xs-12">
+    <div class="col-md-12 col-xs-12">
       <h1 class="communicart_header">
-        Purchase Request <%= cart.id %>
+        <%= cart.name %>
       </h1>
 
       <div class="communicart_description">
+        <p>
+          Purchase Request: <strong>#<%= cart.id %></strong>
+        </p>
         <p>
           Requested by:
           <strong><%= cart.requester.full_name %></strong>


### PR DESCRIPTION
Debating about which layout I like best:

a)

![screen shot 2015-01-29 at 4 09 36 pm](https://cloud.githubusercontent.com/assets/86842/5966344/98bc4c18-a7d1-11e4-943a-ab7dca6983ef.png)

b)

![screen shot 2015-01-29 at 4 07 04 pm](https://cloud.githubusercontent.com/assets/86842/5966346/9b1e5596-a7d1-11e4-8375-a98eddb1d5ce.png)

c) (in this commit)

![screen shot 2015-01-29 at 4 06 34 pm](https://cloud.githubusercontent.com/assets/86842/5966348/9c879fbe-a7d1-11e4-8ff0-36d6212c9718.png)

d)

![screen shot 2015-01-29 at 4 16 36 pm](https://cloud.githubusercontent.com/assets/86842/5966434/3c9c847e-a7d2-11e4-875e-96005020ec5b.png)

I don't have a sense of how long these descriptions will be on average, which I think would help us decide. The ones I saw were pretty short (not even a full sentence). @ericadeahl Thoughts?