### PR TITLE
display detailed status on cart index page

### DIFF
--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -12,7 +12,7 @@ class CartsController < ApplicationController
     # TODO: handle role on a cart-by-cart basis
     # (including action buttons in approver/open case)
     @role = requester_or_approver
-    @carts = current_user.carts.where(approvals: { role: @role }).order('created_at DESC')
+    @carts = current_user.carts.order('created_at DESC')
   end
 
   def archive

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -9,22 +9,12 @@ class CartsController < ApplicationController
   end
 
   def index
-    # TODO: handle role on a cart-by-cart basis
-    # (including action buttons in approver/open case)
-    @role = requester_or_approver
+    # TODO: include action buttons for approvers
     @carts = current_user.carts.order('created_at DESC')
   end
 
   def archive
     @role = params[:role] || 'requester'
     @closed_cart_full_list = current_user.carts.where(approvals: {role: @role}).closed.order('created_at DESC')
-  end
-
-  private
-
-  def requester_or_approver
-    ['requester','approver'].each do |role|
-      break role if current_user.carts.where(approvals: { role: role }).any?
-    end
   end
 end

--- a/app/helpers/carts_helper.rb
+++ b/app/helpers/carts_helper.rb
@@ -1,8 +1,24 @@
 module CartsHelper
-  def display_status(cart)
+  # need to pass in the user because the current_user controller helper can't be stubbed
+  # https://github.com/rspec/rspec-rails/issues/1076
+  def display_status(cart, user)
     if cart.pending?
-      names = cart.awaiting_approvals.map{|approval| approval.user.full_name }
-      "Waiting for approval from: #{names.join(', ')}"
+      if cart.parallel?
+        approvers = cart.awaiting_approvers
+        if approvers.include?(user)
+          "Waiting for approval"
+        else
+          names = approvers.map{|approver| approver.full_name }
+          "Waiting for approval from: #{names.join(', ')}"
+        end
+      else # linear
+        approver = cart.ordered_awaiting_approvals.first.user
+        if approver == user
+          "Waiting for approval"
+        else
+          "Waiting for approval from: #{approver.full_name}"
+        end
+      end
     else
       cart.status.titlecase
     end

--- a/app/helpers/carts_helper.rb
+++ b/app/helpers/carts_helper.rb
@@ -5,10 +5,10 @@ module CartsHelper
     if cart.pending?
       approvers = cart.currently_awaiting_approvers
       if approvers.include?(user)
-        "Waiting for approval"
+        content_tag('strong', "Please review")
       else
         names = approvers.map{|approver| approver.full_name }
-        "Waiting for approval from: #{names.join(', ')}"
+        content_tag('em', "Waiting for review from:") + ' ' + names.join(', ')
       end
     else
       cart.status.titlecase

--- a/app/helpers/carts_helper.rb
+++ b/app/helpers/carts_helper.rb
@@ -1,21 +1,10 @@
 module CartsHelper
-
-  def show_appropriate_approval_emails(cart, role, show_closed)
-    emails = []
-    if role == 'approver'
-      cart.approvals.each do |approval|
-        if approval.role != role
-          emails.push(approval.user.email_address)
-        end
-      end
+  def display_status(cart)
+    if cart.pending?
+      names = cart.awaiting_approvals.map{|approval| approval.user.full_name }
+      "Waiting for approval from: #{names.join(', ')}"
     else
-      cart.approvals.each do |approval|
-        # when we're a requester, if cart is closed, we show all emails. If not, we just show ones for which  we're awaiting response
-        if approval.role != role && (show_closed || approval.pending?)
-          emails.push(approval.user.email_address)
-        end
-      end
+      cart.status.titlecase
     end
-    emails
   end
 end

--- a/app/helpers/carts_helper.rb
+++ b/app/helpers/carts_helper.rb
@@ -3,21 +3,12 @@ module CartsHelper
   # https://github.com/rspec/rspec-rails/issues/1076
   def display_status(cart, user)
     if cart.pending?
-      if cart.parallel?
-        approvers = cart.awaiting_approvers
-        if approvers.include?(user)
-          "Waiting for approval"
-        else
-          names = approvers.map{|approver| approver.full_name }
-          "Waiting for approval from: #{names.join(', ')}"
-        end
-      else # linear
-        approver = cart.ordered_awaiting_approvals.first.user
-        if approver == user
-          "Waiting for approval"
-        else
-          "Waiting for approval from: #{approver.full_name}"
-        end
+      approvers = cart.currently_awaiting_approvers
+      if approvers.include?(user)
+        "Waiting for approval"
+      else
+        names = approvers.map{|approver| approver.full_name }
+        "Waiting for approval from: #{names.join(', ')}"
       end
     else
       cart.status.titlecase

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -66,6 +66,16 @@ class Cart < ActiveRecord::Base
     self.ordered_approvals.pending
   end
 
+  # users with outstanding cart_notification_emails
+  def currently_awaiting_approvers
+    if self.parallel?
+      self.awaiting_approvers
+    else # linear
+      approval = self.ordered_awaiting_approvals.first
+      [approval.user]
+    end
+  end
+
   def approved_approvals
     self.approver_approvals.where(status: 'approved')
   end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -230,4 +230,9 @@ class Cart < ActiveRecord::Base
   def public_identifier
     self.send(self.public_identifier_method)
   end
+
+  def pending?
+    # TODO validates :status, inclusion: {in: Approval::STATUSES}
+    self.status.blank? || self.status == 'pending'
+  end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -53,6 +53,11 @@ class Cart < ActiveRecord::Base
     self.approver_approvals.pending
   end
 
+  def awaiting_approvers
+    # TODO do through SQL
+    self.awaiting_approvals.map(&:user)
+  end
+
   def ordered_approvals
     self.approver_approvals.order('position ASC')
   end
@@ -229,6 +234,10 @@ class Cart < ActiveRecord::Base
 
   def public_identifier
     self.send(self.public_identifier_method)
+  end
+
+  def parallel?
+    self.flow == 'parallel'
   end
 
   def pending?

--- a/app/views/carts/_cart_list.html.erb
+++ b/app/views/carts/_cart_list.html.erb
@@ -21,7 +21,7 @@
       <td class="first"><a href="/carts/<%= cart.id %>"><%= cart.name %></a></td>
       <td class="sixth"><%= number_to_currency(cart.decorate.total_price) %></td>
       <td class="sixth">
-        <p><%= display_status(cart) %></p>
+        <p><%= display_status(cart, current_user) %></p>
       </td>
       <td class="sixth"><%= date_with_tooltip(cart.created_at) %></td>
     </tr>

--- a/app/views/carts/_cart_list.html.erb
+++ b/app/views/carts/_cart_list.html.erb
@@ -7,7 +7,7 @@
     <th class="sixth" scope="col"><h5>ID</h5></th>
     <th class="first" scope="col"><h5>Request</h5></th>
     <th class="sixth" scope="col"><h5>Total Price</h5></th>
-    <th class="sixth" scope="col"><h5><%= if role=='requester' then 'To' else 'From' end%> </h5></th>
+    <th class="sixth" scope="col"><h5>Status</h5></th>
     <th class="sixth" scope="col"><h5>Submitted</h5></th>
   </tr>
   <%- if defined? limit %>
@@ -21,9 +21,7 @@
       <td class="first"><a href="/carts/<%= cart.id %>"><%= cart.name %></a></td>
       <td class="sixth"><%= number_to_currency(cart.decorate.total_price) %></td>
       <td class="sixth">
-        <%- show_appropriate_approval_emails(cart, role, closed).each do |email| %>
-          <p><%= email %></p>
-        <%- end %>
+        <p><%= display_status(cart) %></p>
       </td>
       <td class="sixth"><%= date_with_tooltip(cart.created_at) %></td>
     </tr>

--- a/app/views/carts/index.html.erb
+++ b/app/views/carts/index.html.erb
@@ -20,8 +20,7 @@
   <%- if @carts.closed.any? %>
     <div class="row">
       <div class="col-sm-12">
-        <%= render partial: "cart_list", locals: { carts: @carts.closed, role: @role, closed: true,
-                                                          limit: CartsController::CLOSED_CART_LIMIT} %>
+        <%= render partial: "cart_list", locals: { carts: @carts.closed, limit: CartsController::CLOSED_CART_LIMIT} %>
       </div>
     </div>
 

--- a/spec/controllers/carts_controller_spec.rb
+++ b/spec/controllers/carts_controller_spec.rb
@@ -18,9 +18,16 @@ describe CartsController do
 
     it 'sets @carts' do
       approval_group1
+
+      cart2 = FactoryGirl.create(:cart)
+      cart2.approvals.create!(role: 'approver', user: user)
+
+      cart3 = FactoryGirl.create(:cart)
+      cart3.approvals.create!(role: 'observer', user: user)
+
       session[:user]['email'] = user.email_address
       get :index
-      expect(assigns(:carts)).to eq [@cart1]
+      expect(assigns(:carts).sort).to eq [@cart1, cart2, cart3]
     end
   end
 

--- a/spec/controllers/carts_controller_spec.rb
+++ b/spec/controllers/carts_controller_spec.rb
@@ -10,12 +10,6 @@ describe CartsController do
   end
 
   describe '#index' do
-    it 'sets @role' do
-      session[:user]['email'] = user.email_address
-      get :index
-      expect(assigns(:role)).to eq 'requester'
-    end
-
     it 'sets @carts' do
       approval_group1
 
@@ -45,19 +39,6 @@ describe CartsController do
       end
       get :archive
       expect(assigns(:closed_cart_full_list).size).to eq(3)
-    end
-  end
-
-  describe '#requester_or_approver helper' do
-    it 'returns requester role set on approval' do
-      session[:user]['email'] = user.email_address
-      expect(controller.send(:requester_or_approver)).to eq 'requester'
-    end
-
-    it 'returns approver role set on approval' do
-      user.approvals.first.update_attributes(role: 'approver')
-      session[:user]['email'] = user.email_address
-      expect(controller.send(:requester_or_approver)).to eq 'approver'
     end
   end
 end

--- a/spec/helpers/carts_helper_spec.rb
+++ b/spec/helpers/carts_helper_spec.rb
@@ -16,38 +16,38 @@ describe CartsHelper do
       context "parallel" do
         it "displays outstanding approvers" do
           cart = FactoryGirl.create(:cart_with_approvals, flow: 'parallel')
-          expect(helper.display_status(cart, current_user)).to eq("Waiting for approval from: Liono Approver1, Liono Approver2")
+          expect(helper.display_status(cart, current_user)).to eq("<em>Waiting for review from:</em> Liono Approver1, Liono Approver2")
         end
 
         it "excludes approved approvals" do
           cart = FactoryGirl.create(:cart_with_approvals, flow: 'parallel')
           cart.approvals.first.update_attribute(:status, 'approved')
-          expect(helper.display_status(cart, current_user)).to eq("Waiting for approval from: Liono Approver2")
+          expect(helper.display_status(cart, current_user)).to eq("<em>Waiting for review from:</em> Liono Approver2")
         end
 
         it "references the current user" do
           cart = FactoryGirl.create(:cart_with_approvals, flow: 'parallel')
           current_user = cart.approvers.first
-          expect(helper.display_status(cart, current_user)).to eq("Waiting for approval")
+          expect(helper.display_status(cart, current_user)).to eq("<strong>Please review</strong>")
         end
       end
 
       context "linear" do
         it "displays the first approver" do
           cart = FactoryGirl.create(:cart_with_approvals, flow: 'linear')
-          expect(helper.display_status(cart, current_user)).to eq("Waiting for approval from: Liono Approver1")
+          expect(helper.display_status(cart, current_user)).to eq("<em>Waiting for review from:</em> Liono Approver1")
         end
 
         it "excludes approved approvals" do
           cart = FactoryGirl.create(:cart_with_approvals, flow: 'linear')
           cart.approvals.first.update_attribute(:status, 'approved')
-          expect(helper.display_status(cart, current_user)).to eq("Waiting for approval from: Liono Approver2")
+          expect(helper.display_status(cart, current_user)).to eq("<em>Waiting for review from:</em> Liono Approver2")
         end
 
         it "references the current user" do
           cart = FactoryGirl.create(:cart_with_approvals, flow: 'linear')
           current_user = cart.approvers.first
-          expect(helper.display_status(cart, current_user)).to eq("Waiting for approval")
+          expect(helper.display_status(cart, current_user)).to eq("<strong>Please review</strong>")
         end
       end
     end

--- a/spec/helpers/carts_helper_spec.rb
+++ b/spec/helpers/carts_helper_spec.rb
@@ -1,0 +1,20 @@
+describe CartsHelper do
+  describe '#display_status' do
+    it "displays approved status" do
+      cart = FactoryGirl.create(:cart, status: 'approved')
+      expect(helper.display_status(cart)).to eq('Approved')
+    end
+
+    it "displays rejected status" do
+      cart = FactoryGirl.create(:cart, status: 'rejected')
+      expect(helper.display_status(cart)).to eq('Rejected')
+    end
+
+    it "displays outstanding approvers" do
+      cart = FactoryGirl.create(:cart_with_approvals)
+      cart.approvals.first.update_attribute(:status, 'approved')
+
+      expect(helper.display_status(cart)).to eq("Waiting for approval from: Liono Approver2")
+    end
+  end
+end

--- a/spec/helpers/carts_helper_spec.rb
+++ b/spec/helpers/carts_helper_spec.rb
@@ -1,20 +1,55 @@
 describe CartsHelper do
   describe '#display_status' do
+    let(:current_user) { FactoryGirl.create(:user) }
+
     it "displays approved status" do
       cart = FactoryGirl.create(:cart, status: 'approved')
-      expect(helper.display_status(cart)).to eq('Approved')
+      expect(helper.display_status(cart, current_user)).to eq('Approved')
     end
 
     it "displays rejected status" do
       cart = FactoryGirl.create(:cart, status: 'rejected')
-      expect(helper.display_status(cart)).to eq('Rejected')
+      expect(helper.display_status(cart, current_user)).to eq('Rejected')
     end
 
-    it "displays outstanding approvers" do
-      cart = FactoryGirl.create(:cart_with_approvals)
-      cart.approvals.first.update_attribute(:status, 'approved')
+    context "pending" do
+      context "parallel" do
+        it "displays outstanding approvers" do
+          cart = FactoryGirl.create(:cart_with_approvals, flow: 'parallel')
+          expect(helper.display_status(cart, current_user)).to eq("Waiting for approval from: Liono Approver1, Liono Approver2")
+        end
 
-      expect(helper.display_status(cart)).to eq("Waiting for approval from: Liono Approver2")
+        it "excludes approved approvals" do
+          cart = FactoryGirl.create(:cart_with_approvals, flow: 'parallel')
+          cart.approvals.first.update_attribute(:status, 'approved')
+          expect(helper.display_status(cart, current_user)).to eq("Waiting for approval from: Liono Approver2")
+        end
+
+        it "references the current user" do
+          cart = FactoryGirl.create(:cart_with_approvals, flow: 'parallel')
+          current_user = cart.approvers.first
+          expect(helper.display_status(cart, current_user)).to eq("Waiting for approval")
+        end
+      end
+
+      context "linear" do
+        it "displays the first approver" do
+          cart = FactoryGirl.create(:cart_with_approvals, flow: 'linear')
+          expect(helper.display_status(cart, current_user)).to eq("Waiting for approval from: Liono Approver1")
+        end
+
+        it "excludes approved approvals" do
+          cart = FactoryGirl.create(:cart_with_approvals, flow: 'linear')
+          cart.approvals.first.update_attribute(:status, 'approved')
+          expect(helper.display_status(cart, current_user)).to eq("Waiting for approval from: Liono Approver2")
+        end
+
+        it "references the current user" do
+          cart = FactoryGirl.create(:cart_with_approvals, flow: 'linear')
+          current_user = cart.approvers.first
+          expect(helper.display_status(cart, current_user)).to eq("Waiting for approval")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
In [a previous commit](https://github.com/18F/C2/commit/ce8d72294607d27eb72bf1457f22c7bb9dd753a6#commitcomment-9500132), @phirefly mentioned that we didn't have a spec for the helper method that gathered the email addresses to be displayed for each cart on the index page. Instead of verifying the existing functionality, this PR:

* Displays all carts the current_user is involved with, whether they are an approver, a requester, or an observer
* Lists the approver(s) who are being waited on for the cart to progress

This screenshot shows all the different states: 

![screen shot 2015-01-30 at 2 04 48 am](https://cloud.githubusercontent.com/assets/86842/5972269/6f48d92a-a824-11e4-84a0-1d3ae7b941d2.png)
