### PR TITLE
Redirect to carts after logging in

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -11,7 +11,7 @@ class HomeController < ApplicationController
     handle_new_users_from_oauth
     session[:token] = auth.credentials.token
     flash[:success] = "You successfully signed in"
-    redirect_to return_to || root_url
+    redirect_to return_to || carts_path
   end
 
   def index

--- a/spec/integration/set_user_after_login_spec.rb
+++ b/spec/integration/set_user_after_login_spec.rb
@@ -22,4 +22,12 @@ describe 'User creation when logging in with Oauth to view a protected page' do
     get '/approval_groups/new'
     expect(User.count).to eq 1
   end
+
+  it 'redirects a newly logged in user to the carts screen' do
+    FactoryGirl.create(:user, email_address: 'george-test@some-dot-gov.gov')
+
+    expect(User.count).to eq 1
+    get '/auth/myusa/callback'
+    expect(response).to redirect_to('/carts')
+  end
 end


### PR DESCRIPTION
This does not override a `return_to` if the page the user came from specifies one.