### PR TITLE
86055782 ncr send email after request

### DIFF
--- a/app/mailers/communicart_mailer.rb
+++ b/app/mailers/communicart_mailer.rb
@@ -14,6 +14,11 @@ class CommunicartMailer < ActionMailer::Base
     send_cart_email(email, cart)
   end
 
+  def sent_confirmation(cart)
+    @cart = cart.decorate
+    @user = cart.requester
+  end
+
   def approval_reply_received_email(approval)
     cart = approval.cart
     @approval = approval

--- a/app/mailers/communicart_mailer.rb
+++ b/app/mailers/communicart_mailer.rb
@@ -19,7 +19,6 @@ class CommunicartMailer < ActionMailer::Base
     @approval = approval
     @cart = cart.decorate
     to_address = cart.requester.email_address
-    #TODO: Handle carts without approval groups (only emails passed)
     #TODO: Add a specific 'rejection' text block for the requester
 
     set_attachments(cart)

--- a/app/mailers/communicart_mailer.rb
+++ b/app/mailers/communicart_mailer.rb
@@ -14,7 +14,7 @@ class CommunicartMailer < ActionMailer::Base
     send_cart_email(email, cart)
   end
 
-  def sent_confirmation(cart)
+  def sent_confirmation_email(cart)
     @cart = cart.decorate
     @user = cart.requester
   end

--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -5,6 +5,7 @@ class Approval < ActiveRecord::Base
   belongs_to :user
   has_one :approval_group, through: :cart
   delegate :full_name, :email_address, :to => :user, :prefix => true
+  delegate :approvals, :to => :cart, :prefix => true
 
   acts_as_list scope: :cart
 

--- a/app/views/communicart_mailer/sent_confirmation_email
+++ b/app/views/communicart_mailer/sent_confirmation_email
@@ -1,0 +1,8 @@
+<body class="communicart-notification">
+  <div>
+    Hi <%= cart.requester.full_name %>,<br/>
+    You just submitted a request for approval. Here is are details about your request:
+  </div>
+  <%= render partial: @cart.cart_template_name, locals: {cart: @cart, title:
+  "Purchase Request"} %>
+</body>

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -15,7 +15,9 @@ class Dispatcher
   end
 
   def on_approval_status_change(approval)
-    CommunicartMailer.approval_reply_received_email(approval).deliver if self.requires_approval_notice? approval
+    if self.requires_approval_notice?(approval) || approval.status == 'rejected'
+      CommunicartMailer.approval_reply_received_email(approval).deliver
+    end
 
     self.email_observers(approval.cart)
   end

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -10,8 +10,13 @@ class Dispatcher
     end
   end
 
+  def email_sent_confirmation(cart)
+    CommunicartMailer.sent_confirmation_email(cart).deliver
+  end
+
   def deliver_new_cart_emails(cart)
     self.email_observers(cart)
+    self.email_sent_confirmation(cart)
   end
 
   def on_approval_status_change(approval)

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -15,8 +15,13 @@ class Dispatcher
   end
 
   def on_approval_status_change(approval)
-    CommunicartMailer.approval_reply_received_email(approval).deliver
+    CommunicartMailer.approval_reply_received_email(approval).deliver if self.requires_approval_notice? approval
+
     self.email_observers(approval.cart)
+  end
+
+  def requires_approval_notice?(approval)
+    true
   end
 
   def self.initialize_dispatcher(cart)
@@ -24,7 +29,11 @@ class Dispatcher
     when 'parallel'
       ParallelDispatcher.new
     when 'linear'
-      LinearDispatcher.new
+      if cart.getProp('origin') == 'ncr'
+        NcrDispatcher.new
+      else
+        LinearDispatcher.new
+      end
     end
   end
 

--- a/lib/linear_dispatcher.rb
+++ b/lib/linear_dispatcher.rb
@@ -4,8 +4,7 @@ class LinearDispatcher < Dispatcher
   end
 
   def email_next_approver(cart)
-    approval = self.next_approval(cart)
-    if approval
+    if approval = self.next_approval(cart)
       self.email_approver(approval)
     end
   end

--- a/lib/ncr_dispatcher.rb
+++ b/lib/ncr_dispatcher.rb
@@ -1,0 +1,6 @@
+class NcrDispatcher < LinearDispatcher
+
+  def requires_approval_notice? approval
+    [approval.cart.approvals.first, approval.cart.approvals.last].include? approval
+  end
+end

--- a/lib/ncr_dispatcher.rb
+++ b/lib/ncr_dispatcher.rb
@@ -1,6 +1,6 @@
 class NcrDispatcher < LinearDispatcher
 
   def requires_approval_notice? approval
-    [approval.cart.approvals.first, approval.cart.approvals.last].include? approval
+    [approval.cart_approvals.first, approval.cart_approvals.last].include? approval
   end
 end

--- a/lib/parallel_dispatcher.rb
+++ b/lib/parallel_dispatcher.rb
@@ -9,4 +9,5 @@ class ParallelDispatcher < Dispatcher
     self.email_all_approvers(cart)
     super
   end
+
 end

--- a/lib/parallel_dispatcher.rb
+++ b/lib/parallel_dispatcher.rb
@@ -9,5 +9,4 @@ class ParallelDispatcher < Dispatcher
     self.email_all_approvers(cart)
     super
   end
-
 end


### PR DESCRIPTION
Don't merge. Just posting for feedback as I finish the second part of the story. In a nutshell, adding ncr-specific logic for when to send out notification emails while allowing for a default set for Linear approvals.

Feedback welcome.