### PR TITLE
Mention commenting in the footer link

### DIFF
--- a/app/views/communicart_mailer/_reply_section.html.erb
+++ b/app/views/communicart_mailer/_reply_section.html.erb
@@ -3,7 +3,7 @@
     <td colspan=2 align="center">
       <p>
         <strong>
-          <%= link_to "Or, view this request in your browser", cart_url(cart) %>
+          <%= link_to "Comment on this request, or view it in your browser", cart_url(cart) %>
         </strong>
       </p>
     </td>

--- a/app/views/communicart_mailer/cart_notification_email.html.erb
+++ b/app/views/communicart_mailer/cart_notification_email.html.erb
@@ -37,7 +37,7 @@
         </p>
         <p>
           <strong>
-            <%= link_to "Or, view this request in your browser", cart_url(@cart) %>
+            <%= link_to "Comment on this request, or view this request in your browser", cart_url(@cart) %>
           </strong>
         </p>
       </td>

--- a/app/views/communicart_mailer/cart_notification_email.html.erb
+++ b/app/views/communicart_mailer/cart_notification_email.html.erb
@@ -37,7 +37,7 @@
         </p>
         <p>
           <strong>
-            <%= link_to "Comment on this request, or view this request in your browser", cart_url(@cart) %>
+            <%= link_to "Comment on this request, or view it in your browser", cart_url(@cart) %>
           </strong>
         </p>
       </td>


### PR DESCRIPTION
Mention commenting in the footer link for emails. This lets the user know how to comment.

![screen shot 2015-02-02 at 12 29 17 pm](https://cloud.githubusercontent.com/assets/326918/6006312/1f2f2c86-aad7-11e4-9bfe-f1c669d04f86.png)
