### PR TITLE
[#87250330] sign the user in via token

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,12 +10,23 @@ class ApplicationController < ActionController::Base
     @current_user ||= User.find_or_create_by(email_address: session[:user]['email']) if session[:user] && session[:user]['email']
   end
 
+  def sign_in(user)
+    session[:user] ||= {}
+    session[:user]['email'] = user.email_address
+    @current_user = user
+  end
+
+  def sign_out
+    reset_session
+    @current_user = nil
+  end
+
   def signed_in?
     !!current_user
   end
 
   def authenticate_user!
-    unless current_user
+    unless signed_in?
       session[:return_to] = request.fullpath
       redirect_to root_url, :alert => 'You need to sign in for access to this page.'
     end

--- a/app/controllers/communicarts_controller.rb
+++ b/app/controllers/communicarts_controller.rb
@@ -63,6 +63,8 @@ private
       raise AuthenticationError.new(msg: 'Something went wrong with the user (wrong person)')
     elsif @token.cart_id != params[:cart_id].to_i
       raise AuthenticationError.new(msg: 'Something went wrong with the cart (wrong cart)')
+    else
+      sign_in(@token.user)
     end
   end
 

--- a/app/controllers/communicarts_controller.rb
+++ b/app/controllers/communicarts_controller.rb
@@ -38,14 +38,14 @@ class CommunicartsController < ApplicationController
   end
 
   def approval_response
-    @cart = Cart.find(params[:cart_id]).decorate
-    @approval = @cart.approvals.find_by(user_id: params[:user_id])
-    @show_comments = true
+    cart = Cart.find(params[:cart_id]).decorate
+    approval = cart.approvals.find_by(user_id: params[:user_id])
 
-    Commands::Approval::UpdateFromApprovalResponse.new.perform(@approval, approval_response_status)
+    Commands::Approval::UpdateFromApprovalResponse.new.perform(approval, approval_response_status)
     @token.update_attribute(:used_at, Time.now)
 
-    flash[:success] = "You have #{approval_response_status} Cart #{@cart.public_identifier}."
+    flash[:success] = "You have #{approval_response_status} Cart #{cart.public_identifier}."
+    redirect_to cart_path(cart)
   end
 
 

--- a/app/controllers/communicarts_controller.rb
+++ b/app/controllers/communicarts_controller.rb
@@ -43,7 +43,7 @@ class CommunicartsController < ApplicationController
     @show_comments = true
 
     Commands::Approval::UpdateFromApprovalResponse.new.perform(@approval, approval_response_status)
-    @token.update_attributes(used_at: Time.now)
+    @token.update_attribute(:used_at, Time.now)
 
     flash[:success] = "You have #{approval_response_status} Cart #{@cart.public_identifier}."
   end

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -2,6 +2,7 @@ class ApiToken < ActiveRecord::Base
   before_create :generate_token
   validates_presence_of :user_id, :cart_id
   belongs_to :cart
+  belongs_to :user
 
   scope :unexpired, -> { where('expires_at >= ?', Time.now) }
   scope :unused, -> { where(used_at: nil) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,4 +25,9 @@ class User < ActiveRecord::Base
   def last_requested_cart
     self.requested_carts.order('carts.created_at DESC').first
   end
+
+  def self.from_oauth_hash(auth_hash)
+    user_data = auth_hash.extra.raw_info.to_hash
+    self.find_or_create_by(email_address: user_data['email'])
+  end
 end

--- a/app/views/communicarts/approval_response.html.erb
+++ b/app/views/communicarts/approval_response.html.erb
@@ -1,1 +1,0 @@
-<%= render partial: "carts/cart", locals: {cart: @cart} %>

--- a/spec/acceptance/cart_approval_from_link.feature
+++ b/spec/acceptance/cart_approval_from_link.feature
@@ -23,10 +23,27 @@ Feature: Approving a cart from approval link
 
     Given the user is 'supervisor3@test.gov'
     And a valid token
+    And I go to '/'
+    And I click 'Logout'
     When I go to the approval_response page with token
     Then I should see alert text 'You have approved Cart 109876.'
     And I should see 'Request approved by'
     And I should not see 'Waiting for approval from'
+    And I should see 'Logout'
+    And I should not see 'Sign in'
+
+  Scenario: Cannot reuse a token
+    Given the user is associated with one of the cart's approvals
+    And a valid token
+    And I go to '/'
+    And I click 'Logout'
+    When I go to the approval_response page with token
+    Then I should see alert text 'You have approved Cart 109876.'
+    When I go to the approval_response page with token again
+    Then I should see alert text 'You have approved Cart 109876.'
+    When I click 'Logout'
+    And I go to the approval_response page with token again
+    Then I should see alert text 'something went wrong with the token (nonexistent)'
 
   Scenario: Viewing existing comments
     Given the user is associated with one of the cart's approvals

--- a/spec/acceptance/cart_approval_from_link.feature
+++ b/spec/acceptance/cart_approval_from_link.feature
@@ -27,6 +27,7 @@ Feature: Approving a cart from approval link
     And I click 'Logout'
     When I go to the approval_response page with token
     Then I should see alert text 'You have approved Cart 109876.'
+    And I should see 'supervisor3@test.gov'
     And I should see 'Request approved by'
     And I should not see 'Waiting for approval from'
     And I should see 'Logout'

--- a/spec/controllers/communicarts_controller_spec.rb
+++ b/spec/controllers/communicarts_controller_spec.rb
@@ -74,9 +74,7 @@ describe CommunicartsController do
       end
     end
 
-    context 'no approval_group is indicated' do
-      #TODO: Write specs
-    end
+    skip 'no approval_group is indicated'
 
     context 'nonexistent approval_group is specified' do
       it 'should return 400 error' do
@@ -265,21 +263,23 @@ describe CommunicartsController do
     context 'valid params' do
       before do
         expect(ApiToken).to receive(:find_by).with(access_token: "5a4b3c2d1ee1d2c3b4a5").and_return(token)
+        approver
+        expect_any_instance_of(Approval).to receive(:update_attributes)
       end
 
       it 'will be successful' do
-        approver
-        expect_any_instance_of(Approval).to receive(:update_attributes)
         put 'approval_response', @json_approval_params_with_token
         expect(response.status).to eq 200
       end
 
       it 'successfully validates the user_id and cart_id with the token' do
-        approver
-        expect_any_instance_of(Approval).to receive(:update_attributes)
         expect { put 'approval_response', @json_approval_params_with_token }.not_to raise_error
       end
 
+      it "signs the user in" do
+        put 'approval_response', @json_approval_params_with_token
+        expect(controller.send(:signed_in?)).to eq(true)
+      end
     end
 
     context 'Request token' do

--- a/spec/controllers/communicarts_controller_spec.rb
+++ b/spec/controllers/communicarts_controller_spec.rb
@@ -303,7 +303,17 @@ describe CommunicartsController do
         expect { put 'approval_response', @json_approval_params_with_token }.to raise_error(AuthenticationError)
       end
 
-      skip 'marks a token as used'
+      it 'marks a token as used' do
+        expect(ApiToken).to receive(:find_by).with(access_token: "5a4b3c2d1ee1d2c3b4a5").and_return(token)
+        expect_any_instance_of(Approval).to receive(:update_attributes)
+        approver
+
+        put 'approval_response', @json_approval_params_with_token
+
+        expect(response.status).to eq(200)
+        token.reload
+        expect(token.used_at).to_not eq(nil)
+      end
     end
   end
 

--- a/spec/controllers/communicarts_controller_spec.rb
+++ b/spec/controllers/communicarts_controller_spec.rb
@@ -269,7 +269,7 @@ describe CommunicartsController do
 
       it 'will be successful' do
         put 'approval_response', @json_approval_params_with_token
-        expect(response.status).to eq 200
+        expect(response).to redirect_to(cart_path(cart))
       end
 
       it 'successfully validates the user_id and cart_id with the token' do
@@ -310,7 +310,7 @@ describe CommunicartsController do
 
         put 'approval_response', @json_approval_params_with_token
 
-        expect(response.status).to eq(200)
+        expect(response).to redirect_to(cart_path(cart))
         token.reload
         expect(token.used_at).to_not eq(nil)
       end


### PR DESCRIPTION
When the approver clicks approve/reject from the notification email, 1019568 now logs that user in to the system via the token. With 3552747, they now get redirected to the normal cart show page, instead of rendering a different view at a different URL.

Checked w/ @cmc333333 and @NoahKunin [in #cybersec](https://18f.slack.com/archives/cybersec/p1422567486000148) to verify that this is ok, security-wise.