### PR TITLE
86218872: Add guard when sending emails in linear flow

### DIFF
--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -70,7 +70,7 @@ class Cart < ActiveRecord::Base
   def currently_awaiting_approvers
     if self.parallel?
       self.awaiting_approvers
-    else # linear
+    else # linear. Assumes the cart is open
       approval = self.ordered_awaiting_approvals.first
       [approval.user]
     end

--- a/lib/linear_dispatcher.rb
+++ b/lib/linear_dispatcher.rb
@@ -2,7 +2,9 @@ class LinearDispatcher < Dispatcher
   def next_pending_approval(cart)
     # we don't care how the cart was approved/rejected
     if cart.pending?
-      return cart.ordered_awaiting_approvals.first
+      cart.ordered_awaiting_approvals.first
+    else
+      nil
     end
   end
 

--- a/lib/linear_dispatcher.rb
+++ b/lib/linear_dispatcher.rb
@@ -1,21 +1,24 @@
 class LinearDispatcher < Dispatcher
-  def next_approval(cart)
-    cart.ordered_awaiting_approvals.first
+  def next_pending_approval(cart)
+    # we don't care how the cart was approved/rejected
+    if cart.pending?
+      return cart.ordered_awaiting_approvals.first
+    end
   end
 
-  def email_next_approver(cart)
-    if approval = self.next_approval(cart)
+  def email_next_pending_approver(cart)
+    if approval = self.next_pending_approval(cart)
       self.email_approver(approval)
     end
   end
 
   def deliver_new_cart_emails(cart)
-    self.email_next_approver(cart)
+    self.email_next_pending_approver(cart)
     super
   end
 
   def on_approval_status_change(approval)
-    self.email_next_approver(approval.cart)
+    self.email_next_pending_approver(approval.cart)
     super
   end
 end

--- a/spec/integration/cart_linear_approval_spec.rb
+++ b/spec/integration/cart_linear_approval_spec.rb
@@ -135,10 +135,7 @@ describe "Approving a cart with multiple approvers in parallel" do
       reject
 
       expect(cart.approvals.where(status: 'approved').count).to eq 1
-      expect(email_recipients).to eq([
-        'approver3@some-dot-gov.gov',
-        'test-requester@some-dot-gov.gov'
-        ])
+      expect(email_recipients).to eq(['test-requester@some-dot-gov.gov'])
 
     end
 

--- a/spec/lib/linear_dispatcher_spec.rb
+++ b/spec/lib/linear_dispatcher_spec.rb
@@ -4,37 +4,44 @@ describe LinearDispatcher do
   let(:requester) { FactoryGirl.create(:user, email_address: 'requester@some-dot-gov-domain.gov') }
   let(:approver) { FactoryGirl.create(:user, email_address: 'approver@some-dot-gov-domain.gov') }
 
-  describe '#next_approval' do
+  describe '#next_pending_approval' do
     context "no approvals" do
       it "returns nil" do
-        expect(dispatcher.next_approval(cart)).to eq(nil)
+        expect(dispatcher.next_pending_approval(cart)).to eq(nil)
       end
     end
 
     it "returns nil if all are non-pending" do
       cart.approvals.create!(role: 'approver', status: 'approved')
-      expect(dispatcher.next_approval(cart)).to eq(nil)
+      expect(dispatcher.next_pending_approval(cart)).to eq(nil)
     end
 
     it "returns the first pending approval by position" do
       cart.approvals.create!(position: 6, role: 'approver')
       last_approval = cart.approvals.create!(position: 5, role: 'approver')
 
-      expect(dispatcher.next_approval(cart)).to eq(last_approval)
+      expect(dispatcher.next_pending_approval(cart)).to eq(last_approval)
+    end
+
+    it "returns nil if the cart is rejected" do
+      next_app = cart.approvals.create!(position: 5, role: 'approver')
+      expect(dispatcher.next_pending_approval(cart)).to eq(next_app)
+      cart.status = 'rejected'
+      expect(dispatcher.next_pending_approval(cart)).to eq(nil)
     end
 
     it "skips approved approvals" do
       first_approval = cart.approvals.create!(position: 6, role: 'approver')
       cart.approvals.create!(position: 5, role: 'approver', status: 'approved')
 
-      expect(dispatcher.next_approval(cart)).to eq(first_approval)
+      expect(dispatcher.next_pending_approval(cart)).to eq(first_approval)
     end
 
     it "skips non-approvers" do
       cart.approvals.create!(role: 'observer')
       approval = cart.approvals.create!(role: 'approver')
 
-      expect(dispatcher.next_approval(cart)).to eq(approval)
+      expect(dispatcher.next_pending_approval(cart)).to eq(approval)
     end
   end
 


### PR DESCRIPTION
If a cart gets approved or rejected, don't send emails to the "next" approver. I'm not restricting to "rejected" in case there's ever a way to approve the whole cart outside of the normal work flow.