### PR TITLE
[#87139776] Update icon image helper for emails to account for linear

### DIFF
--- a/app/assets/stylesheets/modules/shared/email_status.scss
+++ b/app/assets/stylesheets/modules/shared/email_status.scss
@@ -35,7 +35,7 @@
     padding: 0 60px 0 0;
 
     &.last {
-      img.approved, img.pending, img.rejected {
+      img.approved.linear, img.pending.linear, img.rejected.linear {
         background-image: none;
       }
 
@@ -55,15 +55,15 @@
     img {
       float: left;
       padding-top: 2px;
-      &.approved {
+      &.approved.linear {
         background-image: image-url('bg_approved_status.gif');
       }
 
-      &.pending {
+      &.pending.linear {
         background-image: image-url('bg_pending_status.gif');
       }
 
-      &.rejected {
+      &.rejected.linear {
         background-image: image-url('bg_rejected_status.gif');
       }
     }

--- a/app/helpers/communicart_mailer_helper.rb
+++ b/app/helpers/communicart_mailer_helper.rb
@@ -1,6 +1,6 @@
 module CommunicartMailerHelper
-  def status_icon_tag(status)
-    image_tag("icon-#{status}.png", class: "status-icon #{status}")
+  def status_icon_tag(status, linear=false)
+    image_tag("icon-#{status}.png", class: "status-icon #{status} #{'linear' if linear}")
   end
 
   def generate_bookend_class(index, count)

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -250,6 +250,10 @@ class Cart < ActiveRecord::Base
     self.flow == 'parallel'
   end
 
+  def linear?
+    self.flow == 'linear'
+  end
+
   def pending?
     # TODO validates :status, inclusion: {in: Approval::STATUSES}
     self.status.blank? || self.status == 'pending'

--- a/app/views/shared/_email_status.html.erb
+++ b/app/views/shared/_email_status.html.erb
@@ -25,7 +25,7 @@
                 <td
                   <%= generate_bookend_class(index, @cart.approvals_in_list_order.count) %>
                 >
-                  <%= status_icon_tag(approval.status) %>
+                  <%= status_icon_tag(approval.status, @cart.linear?) %>
                   <span class="approver">
                     <%= mail_to approval.user_email_address, approval.user_full_name %>
                   </span>


### PR DESCRIPTION
In anticipation of us reconciling the two treatments for linear/parallel status displays, I kept this simple by just removing the vertical line between approvals.

Before:
![screen shot 2015-02-10 at 10 55 12 am](https://cloud.githubusercontent.com/assets/11333/6131701/6839d8e4-b113-11e4-93f3-aaa311f9063c.png)

After:
![screen shot 2015-02-10 at 10 54 48 am](https://cloud.githubusercontent.com/assets/11333/6131695/5de12910-b113-11e4-8ae2-50e2ee6b62ef.png)
