### PR TITLE
87948180: Email sent on all rejections

### DIFF
--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -62,12 +62,11 @@ class Approval < ActiveRecord::Base
   # Used by the state machine
   def on_rejected_entry(new_state, event)
     self.cart.reject!
-    Dispatcher.on_approval_status_change(self)  # todo - move this out
   end
 
   # Used by the state machine
   def on_approved_entry(new_state, event)
     self.cart.partial_approve!
-    Dispatcher.on_approval_status_change(self)  # todo - move this out
+    Dispatcher.on_approval_approved(self)
   end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -240,9 +240,16 @@ class Cart < ActiveRecord::Base
   end
 
   # Used by the state machine
-  def on_pending_entry(new_state, event)
+  def on_pending_entry(prev_state, event)
     if self.all_approvals_received?
       self.approve!
+    end
+  end
+
+  # Used by the state machine
+  def on_rejected_entry(prev_state, event)
+    if prev_state.name != :rejected
+      Dispatcher.on_cart_rejected(self)
     end
   end
 end

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -19,16 +19,23 @@ class Dispatcher
     self.email_sent_confirmation(cart)
   end
 
-  def on_approval_status_change(approval)
-    if self.requires_approval_notice?(approval) || approval.rejected?
+  def requires_approval_notice?(approval)
+    true
+  end
+
+  def on_cart_rejected(cart)
+    rejection = cart.rejections.first
+    # @todo rewrite this email so a "rejection approval" isn't needed
+    CommunicartMailer.approval_reply_received_email(rejection).deliver
+    self.email_observers(cart)
+  end
+
+  def on_approval_approved(approval)
+    if self.requires_approval_notice?(approval)
       CommunicartMailer.approval_reply_received_email(approval).deliver
     end
 
     self.email_observers(approval.cart)
-  end
-
-  def requires_approval_notice?(approval)
-    true
   end
 
   def self.initialize_dispatcher(cart)
@@ -49,11 +56,15 @@ class Dispatcher
     dispatcher.deliver_new_cart_emails(cart)
   end
 
-  def self.on_approval_status_change(approval)
-    dispatcher = self.initialize_dispatcher(approval.cart)
-    dispatcher.on_approval_status_change(approval)
+  def self.on_cart_rejected(cart)
+    dispatcher = self.initialize_dispatcher(cart)
+    dispatcher.on_cart_rejected(cart)
   end
 
+  def self.on_approval_approved(approval)
+    dispatcher = self.initialize_dispatcher(approval.cart)
+    dispatcher.on_approval_approved(approval)
+  end
 
   private
 

--- a/lib/linear_dispatcher.rb
+++ b/lib/linear_dispatcher.rb
@@ -19,7 +19,7 @@ class LinearDispatcher < Dispatcher
     super
   end
 
-  def on_approval_status_change(approval)
+  def on_approval_approved(approval)
     self.email_next_pending_approver(approval.cart)
     super
   end

--- a/spec/lib/linear_dispatcher_spec.rb
+++ b/spec/lib/linear_dispatcher_spec.rb
@@ -26,7 +26,7 @@ describe LinearDispatcher do
     it "returns nil if the cart is rejected" do
       next_app = cart.approvals.create!(position: 5, role: 'approver')
       expect(dispatcher.next_pending_approval(cart)).to eq(next_app)
-      cart.reject!
+      next_app.update_attribute(:status, 'rejected')  # skip state machine
       expect(dispatcher.next_pending_approval(cart)).to eq(nil)
     end
 
@@ -66,9 +66,12 @@ describe LinearDispatcher do
     end
   end
 
-  xdescribe '#on_approval_status_change' do
+  describe '#on_approval_approved' do
     it "sends to the requester and the next approver" do
-      dispatcher.on_approval_status_change(cart.approvals.first)
+      cart = FactoryGirl.create(:cart_with_approvals)
+      approval = cart.approvals.first
+      approval.update_attribute(:status, 'approved')  # avoiding state machine
+      dispatcher.on_approval_approved(approval)
       expect(email_recipients).to eq([
         'approver2@some-dot-gov.gov',
         'requester@some-dot-gov.gov'

--- a/spec/lib/parallel_dispatcher_spec.rb
+++ b/spec/lib/parallel_dispatcher_spec.rb
@@ -25,9 +25,9 @@ describe ParallelDispatcher do
     end
   end
 
-  describe '#on_approval_status_change' do
+  describe '#on_approval_approved' do
     it "sends to the requester" do
-      dispatcher.on_approval_status_change(cart.approvals.first)
+      dispatcher.on_approval_approved(cart.approvals.first)
       expect(email_recipients).to eq(['requester@some-dot-gov.gov'])
     end
   end

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -124,4 +124,17 @@ describe Cart do
 
   end
 
+  describe '#on_rejected_entry' do
+    it 'sends only one rejection email' do
+      cart = FactoryGirl.create(:cart_with_approvals)
+      # skip workflow
+      cart.approver_approvals.first.update_attribute(:status, 'rejected')
+      cart.reject!
+      expect(email_recipients).to eq(['requester@some-dot-gov.gov'])
+
+      cart.reject!
+      expect(email_recipients).to eq(['requester@some-dot-gov.gov'])
+    end
+  end
+
 end


### PR DESCRIPTION
Leverages #210 by sending an email on *cart* rejection, regardless of approval state. To do this, I split out approvals and rejections in the dispatcher class, instead of running all approval changes through the same method.