### PR TITLE
fix Proposal migration to not rely on models

### DIFF
--- a/db/migrate/20141214220050_create_proposals.rb
+++ b/db/migrate/20141214220050_create_proposals.rb
@@ -1,4 +1,16 @@
 class CreateProposals < ActiveRecord::Migration
+  ## http://makandracards.com/makandra/15575-how-to-write-complex-migrations-in-rails ##
+  class TempCart < ActiveRecord::Base
+    self.table_name = 'carts'
+    belongs_to :temp_proposal, foreign_key: 'proposal_id'
+  end
+
+  class TempProposal < ActiveRecord::Base
+    self.table_name = 'proposals'
+    has_many :temp_carts
+  end
+  ######################################################################################
+
   def change
     create_table :proposals do |t|
       t.string :status
@@ -8,11 +20,12 @@ class CreateProposals < ActiveRecord::Migration
     add_reference :carts, :proposal
 
     reversible do |dir|
-      Cart.reset_column_information
+      TempCart.reset_column_information
+      TempProposal.reset_column_information
 
       dir.up do
-        Cart.find_each do |cart|
-          cart.create_proposal!(
+        TempCart.find_each do |cart|
+          cart.create_temp_proposal!(
             status: cart.status,
             flow: cart.flow,
             created_at: cart.created_at,
@@ -22,8 +35,8 @@ class CreateProposals < ActiveRecord::Migration
       end
 
       dir.down do
-        Proposal.find_each do |proposal|
-          proposal.cart.update_attributes!(
+        TempProposal.find_each do |proposal|
+          proposal.temp_cart.update_attributes!(
             status: proposal.status,
             flow: proposal.flow
           )

--- a/db/migrate/20141214220050_create_proposals.rb
+++ b/db/migrate/20141214220050_create_proposals.rb
@@ -45,8 +45,5 @@ class CreateProposals < ActiveRecord::Migration
         end
       end
     end
-
-    remove_column :carts, :flow, :string
-    remove_column :carts, :status, :string
   end
 end

--- a/db/migrate/20141214220050_create_proposals.rb
+++ b/db/migrate/20141214220050_create_proposals.rb
@@ -1,3 +1,4 @@
+# This migration splits the `carts` table in two, moving half of the columns to a `proposals` table, and setting the foreign key on the Carts.
 class CreateProposals < ActiveRecord::Migration
   ## http://makandracards.com/makandra/15575-how-to-write-complex-migrations-in-rails ##
   class TempCart < ActiveRecord::Base

--- a/db/migrate/20141214220050_create_proposals.rb
+++ b/db/migrate/20141214220050_create_proposals.rb
@@ -8,7 +8,7 @@ class CreateProposals < ActiveRecord::Migration
 
   class TempProposal < ActiveRecord::Base
     self.table_name = 'proposals'
-    has_many :temp_carts
+    has_one :temp_cart, foreign_key: 'proposal_id'
   end
   ######################################################################################
 
@@ -32,6 +32,7 @@ class CreateProposals < ActiveRecord::Migration
             created_at: cart.created_at,
             updated_at: cart.updated_at
           )
+          cart.save!
         end
       end
 

--- a/db/migrate/20150303052026_remove_flow_and_status_from_carts.rb
+++ b/db/migrate/20150303052026_remove_flow_and_status_from_carts.rb
@@ -1,0 +1,6 @@
+class RemoveFlowAndStatusFromCarts < ActiveRecord::Migration
+  def change
+    remove_column :carts, :flow, :string
+    remove_column :carts, :status, :string
+  end
+end

--- a/db/migrate/20150303052026_remove_flow_and_status_from_carts.rb
+++ b/db/migrate/20150303052026_remove_flow_and_status_from_carts.rb
@@ -1,6 +1,18 @@
 class RemoveFlowAndStatusFromCarts < ActiveRecord::Migration
-  def change
-    remove_column :carts, :flow, :string
-    remove_column :carts, :status, :string
+  COLUMNS = [:flow, :status]
+
+  def up
+    # since these columns were removed in on older version of the CreateProposals migration, handle both cases
+    COLUMNS.each do |column|
+      if column_exists?(:carts, column)
+        remove_column :carts, column
+      end
+    end
+  end
+
+  def down
+    COLUMNS.each do |column|
+      add_column :carts, column, :string
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141214220050) do
+ActiveRecord::Schema.define(version: 20141114190008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,7 +76,8 @@ ActiveRecord::Schema.define(version: 20141214220050) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "external_id"
-    t.integer  "proposal_id"
+    t.string   "status"
+    t.string   "flow"
   end
 
   create_table "comments", force: true do |t|
@@ -93,13 +94,6 @@ ActiveRecord::Schema.define(version: 20141214220050) do
     t.text    "value"
     t.integer "hasproperties_id"
     t.string  "hasproperties_type"
-  end
-
-  create_table "proposals", force: true do |t|
-    t.string   "status"
-    t.string   "flow"
-    t.datetime "created_at"
-    t.datetime "updated_at"
   end
 
   create_table "user_roles", force: true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141214220050) do
+ActiveRecord::Schema.define(version: 20150303052026) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,8 +76,6 @@ ActiveRecord::Schema.define(version: 20141214220050) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "external_id"
-    t.string   "status"
-    t.string   "flow"
     t.integer  "proposal_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141114190008) do
+ActiveRecord::Schema.define(version: 20141214220050) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 20141114190008) do
     t.integer  "external_id"
     t.string   "status"
     t.string   "flow"
+    t.integer  "proposal_id"
   end
 
   create_table "comments", force: true do |t|
@@ -94,6 +95,13 @@ ActiveRecord::Schema.define(version: 20141114190008) do
     t.text    "value"
     t.integer "hasproperties_id"
     t.string  "hasproperties_type"
+  end
+
+  create_table "proposals", force: true do |t|
+    t.string   "status"
+    t.string   "flow"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "user_roles", force: true do |t|


### PR DESCRIPTION
Before this change, I was getting an exception during the `up` part of the migration that `delegate` needs the associated object to be present... in other words, a :chicken: and :egg: problem of the Proposal needing to exist for every Cart in order for the associated Proposals to be created.

This solution is a bit of a hack, but it's certainly easier than writing raw SQL. @phirefly Mind checking out this branch locally and giving it a try?