### PR TITLE
Use proposal_id in this migration so that it can be ran in order

### DIFF
--- a/db/migrate/20150311092117_associate_api_tokens_with_approvals.rb
+++ b/db/migrate/20150311092117_associate_api_tokens_with_approvals.rb
@@ -7,17 +7,20 @@ class AssociateApiTokensWithApprovals < ActiveRecord::Migration
         execute <<-SQL
           UPDATE api_tokens
           SET approval_id = approvals.id
-          FROM approvals
-          WHERE api_tokens.cart_id = approvals.cart_id AND api_tokens.user_id = approvals.user_id;
+          FROM approvals, carts
+          WHERE approvals.proposal_id = carts.proposal_id
+            AND carts.id = api_tokens.cart_id
+            AND api_tokens.user_id = approvals.user_id;
         SQL
       end
 
       dir.down do
         execute <<-SQL
           UPDATE api_tokens
-          SET cart_id = approvals.cart_id, user_id = approvals.user_id
-          FROM approvals
-          WHERE api_tokens.approval_id = approvals.id;
+          SET cart_id = carts.id, user_id = approvals.user_id
+          FROM approvals, carts
+          WHERE api_tokens.approval_id = approvals.id
+            AND carts.proposal_id = approvals.proposal_id;
         SQL
       end
     end


### PR DESCRIPTION
Two branches were developed in parallel. When applied sequentially, migrations was breaking. This patch fixes that, at least from a schema perspective. I've relatively confident that the logic is maintained, but if you could verify it's doing what you intended @afeld, that'd be wonderful.