### PR TITLE
[Delivers #89169198] split observers and requester from Approval model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'acts_as_list'
+gem 'ar_outer_joins'
 gem 'autoprefixer-rails'
 gem 'awesome_print'
 gem 'bootstrap-sass', '~> 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,8 @@ GEM
     acts_as_list (0.6.0)
       activerecord (>= 3.0)
     addressable (2.3.6)
+    ar_outer_joins (0.2.0)
+      activerecord (>= 3.2)
     arel (5.0.1.20140414130214)
     autoprefixer-rails (4.0.2.2)
       execjs
@@ -343,6 +345,7 @@ PLATFORMS
 DEPENDENCIES
   acts_as_list
   addressable
+  ar_outer_joins
   autoprefixer-rails
   awesome_print
   aws-sdk (= 2.0.6.pre)

--- a/app/controllers/carts_controller.rb
+++ b/app/controllers/carts_controller.rb
@@ -15,7 +15,6 @@ class CartsController < ApplicationController
   end
 
   def archive
-    @role = params[:role] || 'requester'
-    @closed_cart_full_list = current_user.carts.where(approvals: {role: @role}).closed.order('created_at DESC')
+    @closed_cart_full_list = current_user.carts.closed.order('created_at DESC')
   end
 end

--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -14,15 +14,10 @@ class Approval < ActiveRecord::Base
 
   acts_as_list scope: :proposal
 
-  validates :role, presence: true, inclusion: {in: UserRole::ROLES}
   # TODO validates_uniqueness_of :user_id, scope: cart_id
 
-  scope :approvable, -> { where(role: 'approver') }
-  scope :observing, -> { where(role: 'observer') }
-  scope :requesting, -> { where(role: 'requester') }
-
   self.statuses.each do |status|
-    scope status, -> { approvable.where(status: status) }
+    scope status, -> { where(status: status) }
   end
   scope :received, ->   { approvable.where.not(status: 'pending') }
 
@@ -35,14 +30,6 @@ class Approval < ActiveRecord::Base
   # TODO remove
   def cart_id
     self.proposal.cart.id
-  end
-
-  def self.new_from_user_role(user_role)
-    self.new(
-      position: user_role.position,
-      role: user_role.role,
-      user_id: user_role.user_id
-    )
   end
 
   # TODO we should probably store this value

--- a/app/models/concerns/proposal_delegate.rb
+++ b/app/models/concerns/proposal_delegate.rb
@@ -4,7 +4,11 @@ module ProposalDelegate
   included do
     belongs_to :proposal
     has_many :approvals, through: :proposal
+    # TODO change to :approvers
     has_many :approval_users, through: :approvals, source: :user
+    has_many :observations, through: :proposal
+    has_many :observers, through: :observations, source: :user
+    has_one :requester, through: :proposal
 
     accepts_nested_attributes_for :proposal
 

--- a/app/models/gsa18f/proposal_form.rb
+++ b/app/models/gsa18f/proposal_form.rb
@@ -6,7 +6,7 @@ module Gsa18f
 
     URGENCY = DATA['URGENCY']
     OFFICES = DATA['OFFICES']
-    
+
     attribute :requester, :user
     attribute :office, :string
     attribute :justification, :text
@@ -32,7 +32,7 @@ module Gsa18f
       ENV['GSA18F_APPROVER_EMAIL'] || '18fapprover@gsa.gov'
     end
 
-    def set_approver_on(cart) 
+    def set_approver_on(cart)
       cart.add_approver(self.approver_email)
     end
 
@@ -58,7 +58,7 @@ module Gsa18f
     def update_cart(cart)
       cart.name = self.product_name_and_description
       if cart.save
-        cart.approver_approvals.destroy_all
+        cart.proposal.approvals.destroy_all
         # @todo: do we actually want to clear all properties?
         cart.clear_props!
         self.set_props_on(cart)
@@ -68,7 +68,7 @@ module Gsa18f
       end
       cart
     end
-    
+
     def set_props_on(cart)
       cart.set_props(
         office: self.office,

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -45,7 +45,7 @@ module Ncr
 
     def update_cart(approver_email, description, cart)
       cart.name = description
-      cart.approver_approvals.destroy_all
+      cart.proposal.approvals.destroy_all
       self.add_approvals(approver_email)
       cart.restart!
       cart
@@ -118,4 +118,3 @@ module Ncr
 
   end
 end
-

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -1,0 +1,6 @@
+class Observation < ActiveRecord::Base
+  belongs_to :proposal
+  belongs_to :user
+
+  delegate :full_name, :email_address, to: :user, prefix: true
+end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -6,7 +6,9 @@ class Proposal < ActiveRecord::Base
   has_one :cart
   has_many :approvals
   has_many :approval_users, through: :approvals, source: :user
+  has_many :observations
   belongs_to :client_data, polymorphic: true
+  belongs_to :requester, class_name: 'User'
 
   validates :flow, presence: true, inclusion: {in: ApprovalGroup::FLOWS}
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -15,6 +15,7 @@ class Proposal < ActiveRecord::Base
            :name, to: :client_data_legacy
 
   validates :flow, presence: true, inclusion: {in: ApprovalGroup::FLOWS}
+  # TODO validates :requester_id, presence: true
 
   self.statuses.each do |status|
     scope status, -> { where(status: status) }

--- a/db/migrate/20150324015230_split_approvals.rb
+++ b/db/migrate/20150324015230_split_approvals.rb
@@ -1,0 +1,71 @@
+class SplitApprovals < ActiveRecord::Migration
+  class TempApproval < ActiveRecord::Base
+    self.table_name = 'approvals'
+  end
+
+  class TempObservation < ActiveRecord::Base
+    self.table_name = 'observations'
+  end
+
+  class TempProposal < ActiveRecord::Base
+    self.table_name = 'proposals'
+  end
+
+  def change
+    create_table :observations do |t|
+      t.references :proposal
+      t.references :user
+      t.timestamps
+    end
+    add_column :proposals, :requester_id, :integer
+
+    reversible do |dir|
+      dir.up do
+        TempApproval.where(role: 'observer').each do |approval|
+          TempObservation.create!(
+            proposal_id: approval.proposal_id,
+            user_id: approval.user_id,
+            created_at: approval.created_at,
+            updated_at: approval.updated_at
+          )
+
+          approval.destroy!
+        end
+
+        TempProposal.reset_column_information
+
+        TempApproval.where(role: 'requester').each do |approval|
+          proposal = TempProposal.find(approval.proposal_id)
+          proposal.requester_id = approval.user_id
+          proposal.save!
+
+          approval.destroy!
+        end
+      end
+
+      dir.down do
+        TempObservation.find_each do |observation|
+          TempApproval.create!(
+            role: 'observer',
+            proposal_id: observation.proposal_id,
+            user_id: observation.user_id,
+            created_at: observation.created_at,
+            updated_at: observation.updated_at
+          )
+        end
+
+        TempProposal.find_each do |proposal|
+          TempApproval.create!(
+            role: 'requester',
+            proposal_id: proposal.id,
+            user_id: proposal.requester_id,
+            created_at: proposal.created_at
+            # note that updated_at will be incorrect
+          )
+        end
+      end
+    end
+
+    remove_column :approvals, :role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150323152603) do
+ActiveRecord::Schema.define(version: 20150324015230) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,7 +43,6 @@ ActiveRecord::Schema.define(version: 20150323152603) do
     t.string   "status"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "role"
     t.integer  "position"
     t.integer  "proposal_id"
   end
@@ -77,6 +76,13 @@ ActiveRecord::Schema.define(version: 20150323152603) do
     t.string  "code"
   end
 
+  create_table "observations", force: true do |t|
+    t.integer  "proposal_id"
+    t.integer  "user_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
   create_table "properties", force: true do |t|
     t.text    "property"
     t.text    "value"
@@ -91,6 +97,7 @@ ActiveRecord::Schema.define(version: 20150323152603) do
     t.datetime "updated_at"
     t.integer  "client_data_id"
     t.string   "client_data_type"
+    t.integer  "requester_id"
   end
 
   add_index "proposals", ["client_data_id", "client_data_type"], name: "index_proposals_on_client_data_id_and_client_data_type", using: :btree

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -5,8 +5,8 @@ class Dispatcher
   end
 
   def email_observers(cart)
-    cart.approvals.observing.each do |observer|
-      CommunicartMailer.cart_observer_email(observer.user_email_address, cart).deliver
+    cart.observations.each do |observation|
+      CommunicartMailer.cart_observer_email(observation.user_email_address, cart).deliver
     end
   end
 

--- a/spec/controllers/carts_controller_spec.rb
+++ b/spec/controllers/carts_controller_spec.rb
@@ -4,8 +4,8 @@ describe CartsController do
 
   before do
     UserRole.create!(user_id: user.id, approval_group_id: approval_group1.id, role: 'requester')
-    p = {'approvalGroup' => 'test-approval-group1', 'cartName' => 'cart1' }
-    @cart1 = Commands::Approval::InitiateCartApproval.new.perform(p)
+    params = {'approvalGroup' => 'test-approval-group1', 'cartName' => 'cart1' }
+    @cart1 = Commands::Approval::InitiateCartApproval.new.perform(params)
     login_as(user)
   end
 
@@ -14,10 +14,10 @@ describe CartsController do
       approval_group1
 
       cart2 = FactoryGirl.create(:cart)
-      cart2.proposal.approvals.create!(role: 'approver', user: user)
+      cart2.proposal.approvals.create!(user: user)
 
       cart3 = FactoryGirl.create(:cart)
-      cart3.proposal.approvals.create!(role: 'observer', user: user)
+      cart3.proposal.observations.create!(user: user)
 
       get :index
       expect(assigns(:carts).sort).to eq [@cart1, cart2, cart3]
@@ -28,10 +28,10 @@ describe CartsController do
     it 'should show all the closed carts' do
       carts = Array.new
       (1..4).each do |i|
-        p = {}
-        p['approvalGroup'] =  'test-approval-group1'
-        p['cartName'] = "cart#{i}"
-        temp_cart = Commands::Approval::InitiateCartApproval.new.perform(p)
+        params = {}
+        params['approvalGroup'] =  'test-approval-group1'
+        params['cartName'] = "cart#{i}"
+        temp_cart = Commands::Approval::InitiateCartApproval.new.perform(params)
         temp_cart.approve! unless i==3
         carts.push(temp_cart)
       end

--- a/spec/factories/approval_groups.rb
+++ b/spec/factories/approval_groups.rb
@@ -14,16 +14,24 @@ FactoryGirl.define do
       end
     end
 
-    factory :approval_group_with_approvals do
+    factory :approval_group_with_approver_and_requester_approvals do
       after :create do |approval_group|
         approver1 = User.find_by(email_address: 'approver1@some-dot-gov.gov') || FactoryGirl.create(:user, email_address: 'approver1@some-dot-gov.gov')
         approver2 = User.find_by(email_address: 'approver2@some-dot-gov.gov') || FactoryGirl.create(:user, email_address: 'approver2@some-dot-gov.gov')
+        requester1 = User.find_by(email_address: 'requester1@some-dot-gov.gov') || FactoryGirl.create(:user, email_address: 'requester1@some-dot-gov.gov')
 
         UserRole.create!(user_id: approver1.id, approval_group_id: approval_group.id, role: 'approver')
         UserRole.create!(user_id: approver2.id, approval_group_id: approval_group.id, role: 'approver')
+        UserRole.create!(user_id: requester1.id, approval_group_id: approval_group.id, role: 'requester')
 
+        # TODO don't create if proposal isn't present
         Approval.create!(user_id: approver1.id, proposal_id: approval_group.proposal_id, status: 'pending')
         Approval.create!(user_id: approver2.id, proposal_id: approval_group.proposal_id, status: 'pending')
+
+        proposal = approval_group.proposal
+        if proposal
+          proposal.update_attributes!(requester_id: requester1.id)
+        end
       end
     end
   end

--- a/spec/factories/approval_groups.rb
+++ b/spec/factories/approval_groups.rb
@@ -14,36 +14,16 @@ FactoryGirl.define do
       end
     end
 
-    factory :approval_group_with_approver_and_requester_approvals do
+    factory :approval_group_with_approvals do
       after :create do |approval_group|
         approver1 = User.find_by(email_address: 'approver1@some-dot-gov.gov') || FactoryGirl.create(:user, email_address: 'approver1@some-dot-gov.gov')
         approver2 = User.find_by(email_address: 'approver2@some-dot-gov.gov') || FactoryGirl.create(:user, email_address: 'approver2@some-dot-gov.gov')
-        requester1 = User.find_by(email_address: 'requester1@some-dot-gov.gov') || FactoryGirl.create(:user, email_address: 'requester1@some-dot-gov.gov')
+
         UserRole.create!(user_id: approver1.id, approval_group_id: approval_group.id, role: 'approver')
         UserRole.create!(user_id: approver2.id, approval_group_id: approval_group.id, role: 'approver')
-        UserRole.create!(user_id: requester1.id, approval_group_id: approval_group.id, role: 'requester')
 
-        Approval.create!(user_id: approver1.id, proposal_id: approval_group.proposal_id, role: 'approver', status: 'pending')
-        Approval.create!(user_id: approver2.id, proposal_id: approval_group.proposal_id, role: 'approver', status: 'pending')
-        Approval.create!(user_id: requester1.id, proposal_id: approval_group.proposal_id, role: 'requester', status: 'pending')
-      end
-    end
-
-    factory :approval_group_with_approvers_observers_and_requester do
-      after :create do |approval_group|
-        for i in 1..2
-          approver = User.find_by(email_address: 'approver#{i}@some-dot-gov.gov') || FactoryGirl.create(:user, email_address: 'approver#{i}@some-dot-gov.gov')
-          UserRole.create!(user_id: approver.id, approval_group_id: approval_group.id, role: 'approver')
-        end
-
-        for i in 1..3
-          observer = User.find_by(email_address: "observer#{i}@some-dot-gov.gov") || FactoryGirl.create(:user, email_address: "observer#{i}@some-dot-gov.gov")
-            UserRole.create!(user_id: observer.id, approval_group_id: approval_group.id, role: 'observer')
-        end
-
-        requester1 = User.find_by(email_address: 'requester1@some-dot-gov.gov') || FactoryGirl.create(:user, email_address: 'requester1@some-dot-gov.gov', first_name: "Radar", last_name: "O'Reilly")
-
-        UserRole.create!(user_id: requester1.id, approval_group_id: approval_group.id, role: 'requester')
+        Approval.create!(user_id: approver1.id, proposal_id: approval_group.proposal_id, status: 'pending')
+        Approval.create!(user_id: approver2.id, proposal_id: approval_group.proposal_id, status: 'pending')
       end
     end
   end

--- a/spec/factories/approvals.rb
+++ b/spec/factories/approvals.rb
@@ -3,15 +3,10 @@ FactoryGirl.define do
     proposal_id 1
     user_id 1
     status 'pending'
-    role 'approver'
 
     factory :approval_with_user do
       user
     end
-
-    # after :build do |approval|
-    #   approval.cart ||= FactoryGirl.create(:cart)
-    # end
 
     trait :with_cart do
       association :proposal, :with_cart

--- a/spec/factories/carts.rb
+++ b/spec/factories/carts.rb
@@ -19,9 +19,9 @@ FactoryGirl.define do
 
     factory :cart_with_approval_group do
       after :create do |cart|
-        approval_group = FactoryGirl.create(:approval_group_with_approver_and_requester_approvals)
-
+        approval_group = FactoryGirl.create(:approval_group_with_approvals)
         cart.approval_group = approval_group
+        cart.add_requester('requester1@some-dot-gov.gov')
         cart.save!
       end
     end
@@ -29,7 +29,7 @@ FactoryGirl.define do
     factory :cart_with_requester do
       after :create do |cart|
         requester = FactoryGirl.create(:user, email_address: 'requester1@some-dot-gov.gov', first_name: 'Panthro', last_name: 'Requester')
-        cart.proposal.approvals << FactoryGirl.create(:approval, role: 'requester', user_id: requester.id)
+        cart.set_requester(requester)
       end
     end
 
@@ -49,13 +49,16 @@ FactoryGirl.define do
 
     factory :cart_with_observers do
       after :create do |cart|
-        #TODO: change approval_group to use a factory that adds observers
-        approval_group = FactoryGirl.create(:approval_group_with_approvers_observers_and_requester)
+        for i in 1..2
+          cart.add_approver("approver#{i}@some-dot-gov.gov")
+        end
 
-        cart.approval_group = approval_group
-        cart.save!
+        for i in 1..3
+          cart.add_observer("observer#{i}@some-dot-gov.gov")
+        end
+
+        cart.add_requester('requester1@some-dot-gov.gov')
       end
     end
-
   end
 end

--- a/spec/factories/carts.rb
+++ b/spec/factories/carts.rb
@@ -19,7 +19,7 @@ FactoryGirl.define do
 
     factory :cart_with_approval_group do
       after :create do |cart|
-        approval_group = FactoryGirl.create(:approval_group_with_approvals)
+        approval_group = FactoryGirl.create(:approval_group_with_approver_and_requester_approvals)
         cart.approval_group = approval_group
         cart.add_requester('requester1@some-dot-gov.gov')
         cart.save!

--- a/spec/features/18f_proposal_spec.rb
+++ b/spec/features/18f_proposal_spec.rb
@@ -117,8 +117,7 @@ describe "GSA 18f Purchase Request Form" do
     end
 
     it "cannot be edited by someone other than the requester" do
-      req = gsa18f.approvals.where(role: 'requester').first
-      req.update_attribute(:user, FactoryGirl.create(:user))
+      gsa18f.set_requester(FactoryGirl.create(:user))
 
       visit "/gsa18f/proposals/#{gsa18f.id}/edit"
       expect(current_path).to eq("/gsa18f/proposals/new")
@@ -145,15 +144,15 @@ describe "GSA 18f Purchase Request Form" do
       fill_in 'gsa18f_proposal_additional_info', with: 'none'
       select Gsa18f::ProposalForm::URGENCY[0], :from => 'gsa18f_proposal_urgency'
       select Gsa18f::ProposalForm::OFFICES[0], :from => 'gsa18f_proposal_office'
-      
+
       click_on 'Submit for approval'
 
       expect(page).to have_content("Proposal submitted")
       expect(current_path).to eq("/carts/#{Cart.last.id}")
       expect(page).to have_content('Restart this Cart?')
-      
+
       click_on('Restart this Cart?')
-      
+
       expect(current_path).to eq("/gsa18f/proposals/#{Cart.last.id}/edit")
 
       click_on 'Submit for approval'
@@ -199,9 +198,7 @@ describe "GSA 18f Purchase Request Form" do
     end
 
     it "does not show a restart link for non requester" do
-      req = gsa18f.approvals.where(role: 'requester').first
-      req.update_attribute(:user, FactoryGirl.create(:user))
-
+      gsa18f.set_requester(FactoryGirl.create(:user))
       visit "/carts/#{gsa18f.id}"
       expect(page).not_to have_content('Restart this Cart?')
     end

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -142,8 +142,7 @@ describe "National Capital Region proposals" do
     end
 
     it "cannot be edited by someone other than the requester" do
-      req = ncr_cart.approvals.where(role: 'requester').first
-      req.update_attribute(:user, FactoryGirl.create(:user))
+      ncr_cart.set_requester(FactoryGirl.create(:user))
 
       visit "/ncr/work_orders/#{work_order.id}/edit"
       expect(current_path).to eq("/ncr/work_orders/new")
@@ -179,9 +178,7 @@ describe "National Capital Region proposals" do
     end
 
     it "does not show a restart link for non requester" do
-      req = ncr_cart.approvals.where(role: 'requester').first
-      req.update_attribute(:user, FactoryGirl.create(:user))
-
+      ncr_cart.set_requester(FactoryGirl.create(:user))
       visit "/carts/#{ncr_cart.id}"
       expect(page).not_to have_content('Restart this Cart?')
     end

--- a/spec/mailers/communicart_mailer_spec.rb
+++ b/spec/mailers/communicart_mailer_spec.rb
@@ -164,9 +164,10 @@ describe CommunicartMailer do
       expect(cart_with_observers).to receive(:requester).and_return(requester).at_least(:once)
     end
 
+    # TODO rename to :cart
     let(:cart_with_observers) { FactoryGirl.create(:cart_with_observers, external_id: 1965) }
     let(:observer) { cart_with_observers.observers.first }
-    let(:mail) { CommunicartMailer.cart_observer_email(observer.user_email_address, cart_with_observers) }
+    let(:mail) { CommunicartMailer.cart_observer_email(observer.email_address, cart_with_observers) }
 
     it 'renders the subject' do
       expect(mail.subject).to eq('Communicart Approval Request from Liono Thunder: Please review Cart #1965')

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -35,7 +35,7 @@ describe Cart do
       end
 
       cart.process_approvals_from_approval_group
-      expect(cart.approvals.order('user_id ASC').map(&:position)).to eq(cart.user_roles.order('user_id ASC').map(&:position))
+      expect(cart.approvals.order('user_id ASC').map(&:position)).to eq(cart.user_roles.approvers.order('user_id ASC').map(&:position))
     end
   end
 

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -40,10 +40,12 @@ describe Cart do
   end
 
   describe '#process_approvals_without_approval_group' do
-    let(:user1) { FactoryGirl.create(:user, email_address: 'user1@some-dot-gov.gov') }
-
     it 'excludes blank email addresses' do
-      expect(User).to receive(:find_or_create_by).and_return(user1).exactly(2).times
+      expect(User).to receive(:find_or_create_by).with(email_address: 'requester1@some-dot-gov.gov').and_call_original
+      expect(User).to receive(:find_or_create_by).with(email_address: 'email1@some-dot-gov.gov').and_call_original
+      # was leaving off the '.gov' a typo? -AF
+      expect(User).to receive(:find_or_create_by).with(email_address: 'email2@some-dot-gov').and_call_original
+
       params = { 'toAddress' => ["email1@some-dot-gov.gov", "email2@some-dot-gov", ""] }
       cart.process_approvals_without_approval_group params
     end

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -2,7 +2,7 @@ describe Ncr::WorkOrder do
   describe 'fields_for_display' do
     it "shows BA61 fields" do
       wo = Ncr::WorkOrder.new(
-        amount: 1000, expense_type: "BA61", vendor: "Some Vend", 
+        amount: 1000, expense_type: "BA61", vendor: "Some Vend",
         not_to_exceed: false, emergency: true, rwa_number: "RWWAAA #",
         building_number: Ncr::BUILDING_NUMBERS[0],
         office: Ncr::OFFICES[0])
@@ -20,7 +20,7 @@ describe Ncr::WorkOrder do
     end
     it "shows BA80 fields" do
       wo = Ncr::WorkOrder.new(
-        amount: 1000, expense_type: "BA80", vendor: "Some Vend", 
+        amount: 1000, expense_type: "BA80", vendor: "Some Vend",
         not_to_exceed: false, emergency: true, rwa_number: "RWWAAA #",
         building_number: Ncr::BUILDING_NUMBERS[0], code: "Some WO#",
         office: Ncr::OFFICES[0])
@@ -45,8 +45,8 @@ describe Ncr::WorkOrder do
       cart.proposal.client_data = form
       cart.proposal.save
       form.add_approvals('bob@example.com')
-      expect(cart.approvals.observing.length).to eq(0)
-      expect(cart.approvals.approvable.length).to eq(3)
+      expect(cart.observations.length).to eq(0)
+      expect(cart.approvals.length).to eq(3)
       cart.reload
       expect(cart.approved?).to eq(false)
     end
@@ -56,8 +56,8 @@ describe Ncr::WorkOrder do
       cart.proposal.client_data = form
       cart.proposal.save
       form.add_approvals('bob@example.com')
-      expect(cart.approvals.observing.length).to eq(3)
-      expect(cart.approvals.approvable.length).to eq(0)
+      expect(cart.observations.length).to eq(3)
+      expect(cart.approvals.length).to eq(0)
       cart.clear_association_cache
       expect(cart.approved?).to eq(true)
     end

--- a/spec/requests/cart_creation_without_approval_group_spec.rb
+++ b/spec/requests/cart_creation_without_approval_group_spec.rb
@@ -49,8 +49,10 @@ describe 'Creating a cart without an approval group' do
 
   it 'creates approvals' do
     post 'send_cart', @json_params_1
-    expect(Approval.all.map(&:role)).to match_array ['approver','approver','requester']
-    expect(Approval.count).to eq 3
+    expect(Approval.all.map(&:user_email_address)).to eq(%w(
+      some-approver-1@some-dot-gov.gov
+      some-approver-2@some-dot-gov.gov
+    ))
   end
 
   it 'delivers emails to requester and approver email addresses indicated in the toAddress field' do

--- a/spec/requests/communicarts_spec.rb
+++ b/spec/requests/communicarts_spec.rb
@@ -4,7 +4,7 @@ describe 'CommunicartsController' do
       params = CommunicartMailer.default_params.merge({from:'reply@communicart-stub.com'})
       expect(Dispatcher).to receive(:deliver_new_cart_emails)
 
-      approval_group = FactoryGirl.create(:approval_group_with_approver_and_requester_approvals, name: 'MyApprovalGroup')
+      approval_group = FactoryGirl.create(:approval_group_with_approvals, name: 'MyApprovalGroup')
       expect(ApprovalGroup).to receive(:find_by).and_return(approval_group)
     end
 

--- a/spec/requests/communicarts_spec.rb
+++ b/spec/requests/communicarts_spec.rb
@@ -1,10 +1,9 @@
 describe 'CommunicartsController' do
   describe "POST /communicarts/send_cart" do
     before do
-      params = CommunicartMailer.default_params.merge({from:'reply@communicart-stub.com'})
       expect(Dispatcher).to receive(:deliver_new_cart_emails)
 
-      approval_group = FactoryGirl.create(:approval_group_with_approvals, name: 'MyApprovalGroup')
+      approval_group = FactoryGirl.create(:approval_group_with_approver_and_requester_approvals, name: 'MyApprovalGroup')
       expect(ApprovalGroup).to receive(:find_by).and_return(approval_group)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,7 @@ RSpec.configure do |config|
   end
 
   config.raise_errors_for_deprecations!
+  config.backtrace_exclusion_patterns << %r{/gems/}
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.

--- a/spec/steps/approval_steps.rb
+++ b/spec/steps/approval_steps.rb
@@ -18,7 +18,7 @@ module ApprovalSteps
 
   step "the cart has an approval for :email in position :position" do |email, position|
     approver = User.find_or_create_by(email_address: email)
-    @approval = FactoryGirl.create(:approval, role: 'approver', user_id: approver.id, position: position)
+    @approval = FactoryGirl.create(:approval, user_id: approver.id, position: position)
     @cart.proposal.approvals << @approval
   end
 

--- a/spec/support/requests.rb
+++ b/spec/support/requests.rb
@@ -1,3 +1,4 @@
+# TODO move to spec/requests/communicarts_spec.rb
 def cart_initialize_params
   {
     cartName: "Q1 Test Cart",


### PR DESCRIPTION
`Approval`s no longer have a `role` – there is an equivalent `Observation` model, and a `requester_id` on the `Proposal` directly. These were the minimum required changes...I'll do some other cleanup in a follow-up PR.