### PR TITLE
Use a (delegated) proposal field for cart name

### DIFF
--- a/app/controllers/communicarts_controller.rb
+++ b/app/controllers/communicarts_controller.rb
@@ -20,23 +20,23 @@ class CommunicartsController < ApplicationController
 
   def approval_response
     cart = Cart.find(params[:cart_id]).decorate
-    client_data = cart.proposal.client_data_legacy
+    proposal = cart.proposal
     approval = cart.approvals.find_by(user_id: user_id)
     
     @token ||= ApiToken.find_by(approval_id: approval.id)
     
     if !approval.pending?
-      flash[:error] = "You have already logged a response for Cart #{client_data.public_identifier}"
+      flash[:error] = "You have already logged a response for Cart #{proposal.public_identifier}"
     elsif !approval.approvable?
       flash[:error] = "Sorry. You are not allowed to approve your own request."
     else
       case params[:approver_action]
       when 'approve'
         approval.approve!
-        flash[:success] = "You have approved Cart #{client_data.public_identifier}."
+        flash[:success] = "You have approved Cart #{proposal.public_identifier}."
       when 'reject'
         approval.reject!
-        flash[:success] = "You have rejected Cart #{client_data.public_identifier}."
+        flash[:success] = "You have rejected Cart #{proposal.public_identifier}."
       end
     end
 

--- a/app/decorators/cart_decorator.rb
+++ b/app/decorators/cart_decorator.rb
@@ -48,7 +48,7 @@ class CartDecorator < Draper::Decorator
   end
 
   def completed_status_message
-    "All #{number_approved} of #{total_approvers} approvals have been received. Please move forward with the purchase  of Cart ##{object.proposal.client_data_legacy.public_identifier}."
+    "All #{number_approved} of #{total_approvers} approvals have been received. Please move forward with the purchase  of Cart ##{object.proposal.public_identifier}."
   end
 
   def progress_status_message
@@ -57,7 +57,7 @@ class CartDecorator < Draper::Decorator
 
   # @TODO: remove in favor of client_partial or similar
   def cart_template_name
-    origin_name = self.proposal.client_data_legacy.client
+    origin_name = self.proposal.client
     if Cart::ORIGINS.include? origin_name
       "#{origin_name}_cart"
     else

--- a/app/mailers/communicart_mailer.rb
+++ b/app/mailers/communicart_mailer.rb
@@ -40,7 +40,7 @@ class CommunicartMailer < ActionMailer::Base
 
     mail(
          to: to_address,
-         subject: "User #{approval.user.email_address} has #{approval.status} cart ##{cart.proposal.client_data_legacy.public_identifier}",
+         subject: "User #{approval.user.email_address} has #{approval.status} cart ##{cart.proposal.public_identifier}",
          from: user_email(approval.user)
          )
   end

--- a/app/mailers/communicart_mailer.rb
+++ b/app/mailers/communicart_mailer.rb
@@ -50,7 +50,7 @@ class CommunicartMailer < ActionMailer::Base
 
     mail(
          to: to_email,
-         subject: "A comment has been added to '#{comment.commentable.name}'",
+         subject: "A comment has been added to '#{comment.commentable.proposal.name}'",
          from: user_email(comment.user)
          )
   end
@@ -60,8 +60,8 @@ class CommunicartMailer < ActionMailer::Base
 
   def set_attachments(cart)
     if cart.all_approvals_received?
-      attachments['Communicart' + cart.name + '.comments.csv'] = Exporter::Comments.new(cart).to_csv
-      attachments['Communicart' + cart.name + '.approvals.csv'] = Exporter::Approvals.new(cart).to_csv
+      attachments['Communicart' + cart.proposal.public_identifier.to_s + '.comments.csv'] = Exporter::Comments.new(cart).to_csv
+      attachments['Communicart' + cart.proposal.public_identifier.to_s + '.approvals.csv'] = Exporter::Approvals.new(cart).to_csv
     end
   end
 
@@ -78,7 +78,7 @@ class CommunicartMailer < ActionMailer::Base
   end
 
   def subject(cart)
-    "Communicart Approval Request from #{cart.requester.full_name}: Please review Cart ##{cart.proposal.client_data_legacy.public_identifier}"
+    "Communicart Approval Request from #{cart.requester.full_name}: Please review Cart ##{cart.proposal.public_identifier}"
   end
 
   def send_cart_email(from_email, to_email, cart)

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -99,6 +99,10 @@ module Ncr
       self.amount || 0.0
     end
 
+    def name
+      self.proposal.cart.name
+    end
+
     protected
     def budget_approver
       ENV['NCR_BUDGET_APPROVER_EMAIL'] || 'communicart.budget.approver@gmail.com'

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -7,6 +7,9 @@ class Proposal < ActiveRecord::Base
   has_many :approvals
   has_many :approval_users, through: :approvals, source: :user
   belongs_to :client_data, polymorphic: true
+  # The following list also servers as an interface spec for client_datas
+  delegate :fields_for_display, :client, :public_identifier, :total_price,
+           :name, to: :client_data_legacy
 
   validates :flow, presence: true, inclusion: {in: ApprovalGroup::FLOWS}
 

--- a/app/views/carts/_cart.html.erb
+++ b/app/views/carts/_cart.html.erb
@@ -14,7 +14,7 @@
           Requested by:
           <strong><%= cart.requester.full_name %></strong>
         </p>
-        <%= client_partial(proposal.client_data_legacy.client, 'external_id',
+        <%= client_partial(proposal.client, 'external_id',
                            locals: {cart: cart}) %>
       </div>
     </div>
@@ -120,6 +120,6 @@
   <%= render partial: 'approval_actions', locals: { current_user: @current_user, cart: cart} %>
 <% end %>
 <% if display_restart?(cart) %>
-  <%= client_partial(proposal.client_data_legacy.client,
+  <%= client_partial(proposal.client,
                      'restart_link', locals: {proposal: proposal, cart: cart}) %>
 <% end %>

--- a/app/views/carts/_cart.html.erb
+++ b/app/views/carts/_cart.html.erb
@@ -3,7 +3,7 @@
 
     <div class="col-md-12 col-xs-12">
       <h1 class="communicart_header">
-        <%= cart.name %>
+        <%= cart.proposal.name %>
       </h1>
 
       <div class="communicart_description">

--- a/app/views/carts/_cart_list.html.erb
+++ b/app/views/carts/_cart_list.html.erb
@@ -19,7 +19,7 @@
     <%- proposal = cart.proposal %>
     <tr>
       <td class="sixth"><a href="/carts/<%= cart.id %>"><%= cart.id %></a></td>
-      <td class="first"><a href="/carts/<%= cart.id %>"><%= cart.name %></a></td>
+      <td class="first"><a href="/carts/<%= cart.id %>"><%= cart.proposal.name %></a></td>
       <td class="sixth"><%= number_to_currency(proposal.client_data_legacy.total_price) %></td>
       <td class="sixth">
         <p><%= display_status(cart, current_user) %></p>

--- a/app/views/carts/_cart_list.html.erb
+++ b/app/views/carts/_cart_list.html.erb
@@ -20,7 +20,7 @@
     <tr>
       <td class="sixth"><a href="/carts/<%= cart.id %>"><%= cart.id %></a></td>
       <td class="first"><a href="/carts/<%= cart.id %>"><%= cart.proposal.name %></a></td>
-      <td class="sixth"><%= number_to_currency(proposal.client_data_legacy.total_price) %></td>
+      <td class="sixth"><%= number_to_currency(proposal.total_price) %></td>
       <td class="sixth">
         <p><%= display_status(cart, current_user) %></p>
       </td>

--- a/app/views/communicart_mailer/_cart_mail.html.erb
+++ b/app/views/communicart_mailer/_cart_mail.html.erb
@@ -17,7 +17,7 @@
           <p>
             GSA Advantage:
             GSA Advantage:
-            <strong>[Some description] - Cart #<%= cart.proposal.client_data_legacy.public_identifier %></strong>
+            <strong>[Some description] - Cart #<%= cart.proposal.public_identifier %></strong>
           </p>
         </div>
       </td>
@@ -45,7 +45,7 @@
           </tr>
           <tr>
             <td class='cart-total' colspan='3'>
-              <span class="total-label">Total: <strong><%= number_to_currency(proposal.client_data_legacy.total_price) %></strong></span>
+              <span class="total-label">Total: <strong><%= number_to_currency(proposal.total_price) %></strong></span>
             </td>
           </tr>
         </table>

--- a/app/views/communicart_mailer/_gsa18f_cart.html.erb
+++ b/app/views/communicart_mailer/_gsa18f_cart.html.erb
@@ -2,7 +2,7 @@
   <table class="w-container main-container" width='800'>
     <tr>
       <td>
-        <h1 class="communicart_header"><%= title %>: <%= cart.name %></h1>
+        <h1 class="communicart_header"><%= title %>: <%= cart.proposal.name %></h1>
         <div class="communicart_description">
           <p>
             Requested by:

--- a/app/views/communicart_mailer/_navigator_cart.html.erb
+++ b/app/views/communicart_mailer/_navigator_cart.html.erb
@@ -38,7 +38,7 @@
           <tr class="cart_item_information">
             <!-- Product -->
             <td class="first" valign="top">
-              <%= cart.try(:name) || "" %>
+              <%= cart.proposal.try(:name) || "" %>
             </td>
             <td class="first" valign="top">
               <%= (cart.properties.detect{|p| p.property == 'contractingVehicle'}.try(:value) || "") %>

--- a/app/views/communicart_mailer/_ncr_cart.html.erb
+++ b/app/views/communicart_mailer/_ncr_cart.html.erb
@@ -2,7 +2,7 @@
   <table class="w-container main-container" width='800'>
     <tr>
       <td>
-        <h1 class="communicart_header"><%= title %>: <%= cart.name %></h1>
+        <h1 class="communicart_header"><%= title %>: <%= cart.proposal.name %></h1>
         <div class="communicart_description">
           <p>
             Requested by:

--- a/app/views/communicart_mailer/approval_reply_received_email.html.erb
+++ b/app/views/communicart_mailer/approval_reply_received_email.html.erb
@@ -4,7 +4,7 @@
       <td class="w-container html-email-message">
         <p>
           Hello,<br/>
-          The approver, <%= @approval.user_email_address %>, <%= @approval.status %>  Cart #<%= @cart.proposal.client_data_legacy.public_identifier %>.<br/>
+          The approver, <%= @approval.user_email_address %>, <%= @approval.status %>  Cart #<%= @cart.proposal.public_identifier %>.<br/>
           Please see below for more details.
         </p>
 

--- a/app/views/communicart_mailer/approval_reply_received_email.text.erb
+++ b/app/views/communicart_mailer/approval_reply_received_email.text.erb
@@ -1,7 +1,7 @@
 
 Current status: <%=  @cart.generate_status_message %>
 
-At time <%= @approval.created_at %>, approver <%= @approval.user_email_address %> <%= @approval.status %>  Cart Number <%= @cart.proposal.client_data_legacy.public_identifier %>. <%= @approval.approved? ?
+At time <%= @approval.created_at %>, approver <%= @approval.user_email_address %> <%= @approval.status %>  Cart Number <%= @cart.proposal.public_identifier %>. <%= @approval.approved? ?
 "This approval has been logged for future information" :
 "You may wish to contact the approver for more explanation."
  %>

--- a/app/views/communicart_mailer/comment_added_email.html.erb
+++ b/app/views/communicart_mailer/comment_added_email.html.erb
@@ -4,7 +4,7 @@
     <tr><td class="w-container html-email-message">
       <p>
         Action need on Request 
-        #<%= cart.proposal.client_data_legacy.public_identifier %>
+        #<%= cart.proposal.public_identifier %>
         (<%= cart.proposal.name %>):
       </p>
     </td></tr>

--- a/app/views/communicart_mailer/comment_added_email.html.erb
+++ b/app/views/communicart_mailer/comment_added_email.html.erb
@@ -5,7 +5,7 @@
       <td class="w-container html-email-message">
         <p>
           Hello,<br/>
-          A comment has been created for <strong><%= @comment.commentable.name %>:</strong>
+          A comment has been created for <strong><%= @comment.commentable.proposal.name %>:</strong>
         </p>
         <p>
           <%= @comment.comment_text %>

--- a/app/views/communicart_mailer/comment_added_email.text.erb
+++ b/app/views/communicart_mailer/comment_added_email.text.erb
@@ -1,3 +1,3 @@
 Hello,
-A comment has been created for <%= @comment.commentable.name %>:
+A comment has been created for <%= @comment.commentable.proposal.name %>:
 <%= @comment.comment_text %>

--- a/app/views/shared/_proposal_properties.html.erb
+++ b/app/views/shared/_proposal_properties.html.erb
@@ -4,7 +4,7 @@
       <h5>FY15 Credit Card Purchase Request</h5>
     </td>
   </tr>
-  <%- proposal.client_data_legacy.fields_for_display.each do |name, value| %>
+  <%- proposal.fields_for_display.each do |name, value| %>
     <tr class="cart_item_information">
       <td class="results-list" align="left" scope="row">
         <strong><%= name %>

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -55,7 +55,7 @@ class Dispatcher
       ParallelDispatcher.new
     when 'linear'
       # @todo: dynamic dispatch for selection
-      if cart.proposal.client_data_legacy.client == "ncr"
+      if cart.proposal.client == "ncr"
         NcrDispatcher.new
       else
         LinearDispatcher.new

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -31,7 +31,7 @@ describe "National Capital Region proposals" do
       expect(page).to have_content("Proposal submitted")
       expect(current_path).to eq("/carts/#{cart.id}")
 
-      expect(cart.name).to eq("buying stuff")
+      expect(cart.proposal.name).to eq("buying stuff")
       expect(cart.flow).to eq('linear')
       client_data = cart.proposal.client_data
       expect(client_data.client).to eq('ncr')

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -73,7 +73,7 @@ describe Ncr::WorkOrder do
       form = FactoryGirl.create(:ncr_work_order, expense_type: 'BA80')
       cart = form.init_and_save_cart('aaa@example.com', 'Desc1', requester)
 
-      expect(cart.name).to eq('Desc1')
+      expect(form.proposal.name).to eq('Desc1')
       expect(cart.requester).to eq(requester)
       expect(approver_emails(cart)).to eq(%w(
         aaa@example.com
@@ -85,7 +85,7 @@ describe Ncr::WorkOrder do
       form = FactoryGirl.build(:ncr_work_order, expense_type: 'BA61')
       cart = form.init_and_save_cart('bbb@example.com', 'Desc2', requester)
 
-      expect(cart.name).to eq('Desc2')
+      expect(form.proposal.name).to eq('Desc2')
       expect(cart.requester).to eq(requester)
       expect(approver_emails(cart)).to eq(%w(
         bbb@example.com

--- a/spec/requests/cart_creation_without_approval_group_spec.rb
+++ b/spec/requests/cart_creation_without_approval_group_spec.rb
@@ -68,7 +68,7 @@ describe 'Creating a cart without an approval group' do
   context 'cart' do
     it 'sets the appropriate cart values' do
       post 'send_cart', @json_params_1
-      expect(Cart.first.name).to eq "A Cart With No Approvals"
+      expect(Cart.first.proposal.name).to eq "A Cart With No Approvals"
     end
 
     it 'adds cart properties' do


### PR DESCRIPTION
Also replaces the explicit `client_data_legacy` calls with similar delegated methods

Does not change functionality at all, but should allow a `name` field to be added with ease.