### PR TITLE
add WorkOrder#description attribute to API docs

### DIFF
--- a/app/serializers/approval_serializer.rb
+++ b/app/serializers/approval_serializer.rb
@@ -1,4 +1,6 @@
 class ApprovalSerializer < ActiveModel::Serializer
+  # make sure to keep docs/api.md up-to-date
+
   attributes(
     :id,
     :status

--- a/app/serializers/ncr/work_order_serializer.rb
+++ b/app/serializers/ncr/work_order_serializer.rb
@@ -1,5 +1,7 @@
 module Ncr
   class WorkOrderSerializer < ActiveModel::Serializer
+    # make sure to keep docs/api.md up-to-date
+
     attributes(
       :amount,
       :building_number,

--- a/app/serializers/proposal_serializer.rb
+++ b/app/serializers/proposal_serializer.rb
@@ -1,4 +1,6 @@
 class ProposalSerializer < ActiveModel::Serializer
+  # make sure to keep docs/api.md up-to-date
+
   attributes(
     :created_at,
     :flow,

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,4 +1,6 @@
 class UserSerializer < ActiveModel::Serializer
+  # make sure to keep docs/api.md up-to-date
+
   attributes(
     :created_at,
     :id,

--- a/doc/api.md
+++ b/doc/api.md
@@ -24,10 +24,11 @@ Attribute | Type | Note
 `amount` | string (decimal) | The cost of the work order
 `building_number` | string | ([full list](../config/data/ncr.yaml))
 `code` | `null` for BA61, string for BA80 | Identifier for the type of work
+`description` | string |
 `emergency` | boolean | Whether the work order was pre-approved or not (can only be `true` for BA61)
 `expense_type` | string | `BA61` or `BA80`
 `id` | integer |
-`name` | string | Shown as "description" in the form
+`name` | string |
 `not_to_exceed` | boolean | If the `amount` is exact, or an upper limit
 `office` | string | The group within the service center who submitted the work order ([full list](../config/data/ncr.yaml))
 `proposal` | [Proposal](#proposal) |
@@ -83,6 +84,7 @@ Returns an array of [Work Orders](#ncr-work-order), in descending order of creat
     "amount": "1000.00",
     "building_number": "DC0017ZZ ,WHITE HOUSE-WEST WING1600 PA AVE. NW",
     "code": "ABC",
+    "description": "Existing paint is starting to crack.",
     "emergency": false,
     "expense_type": "BA80",
     "id": 16,

--- a/spec/requests/api/ncr/work_orders_spec.rb
+++ b/spec/requests/api/ncr/work_orders_spec.rb
@@ -141,6 +141,8 @@ describe 'NCR Work Orders API' do
       }.to raise_error(ActionController::RoutingError)
     end
 
+    it "matches the format in the API documentation"
+
     describe "CORS" do
       let(:origin) { 'http://corsexample.com/' }
       let(:headers) {


### PR DESCRIPTION
Follow-up to https://github.com/18F/C2/pull/269.