### PR TITLE
remove deployment task from CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,12 +1,4 @@
 dependencies:
   pre:
     - cp .env.example .env
-deployment:
-  production:
-    branch: production
-    commands:
-      - ./deploy.sh $CIRCLE_SHA1 production
-  demo:
-    branch: master
-    commands:
-      - ./deploy.sh $CIRCLE_SHA1 demo
+


### PR DESCRIPTION
Follow-up to https://github.com/18F/C2/pull/280 – was causing the build on `master` (but not other branches) to fail.

https://circleci.com/gh/18F/C2/727

We might [set up continuous deployment](https://docs.cf.18f.us/apps/continuous-deployment/) down the road, but we can discuss that separately.