### PR TITLE
[Delivers #91070178] Comment Authorization and connection to Proposal

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,7 @@
 class CommentsController < ApplicationController
   before_filter :authenticate_user!
+  before_filter ->{authorize self.proposal, :can_show!}
+  rescue_from Pundit::NotAuthorizedError, with: :auth_errors
 
   def index
     @proposal = self.proposal
@@ -27,4 +29,7 @@ class CommentsController < ApplicationController
     params.require(:comment).permit(:comment_text)
   end
 
+  def auth_errors(exception)
+    redirect_to carts_path, :alert => "You are not allowed to see that cart"
+  end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,35 +2,25 @@ class CommentsController < ApplicationController
   before_filter :authenticate_user!
 
   def index
-    @commentable = find_commentable
-    @comments = @commentable.comments
+    @proposal = self.proposal
+    @comments = @proposal.comments
   end
 
   def create
-    commentable = find_commentable
-    comment = commentable.comments.build(comment_params)
+    comment = self.proposal.comments.build(comment_params)
     comment.user = current_user
     if comment.save
-      flash[:success] = "You successfully added a comment for #{commentable.class.name} #{commentable.id}"
+      flash[:success] = "You successfully added a comment"
     else
       flash[:error] = comment.errors.full_messages
     end
 
-    if commentable.respond_to?(:cart)
-      redirect_to commentable.cart
-    else
-      redirect_to commentable
-    end
+    redirect_to proposal.cart
   end
 
-private
-  def find_commentable
-    params.each do |name, val|
-      if name =~ /^(.+)_id$/
-        return $1.classify.constantize.find(val)
-      end
-    end
-    nil
+  protected
+  def proposal
+    @cached_proposal ||= Cart.find(params[:cart_id]).proposal
   end
 
   def comment_params

--- a/app/mailers/communicart_mailer.rb
+++ b/app/mailers/communicart_mailer.rb
@@ -51,7 +51,7 @@ class CommunicartMailer < ActionMailer::Base
 
     mail(
          to: to_email,
-         subject: "A comment has been added to '#{comment.commentable.proposal.name}'",
+         subject: "A comment has been added to '#{comment.proposal.name}'",
          from: user_email(comment.user)
          )
   end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -7,7 +7,6 @@ class Cart < ActiveRecord::Base
   has_one :approval_group
   has_many :user_roles, through: :approval_group
   has_many :api_tokens, through: :approvals
-  has_many :comments, as: :commentable
   has_many :properties, as: :hasproperties
 
   #TODO: validates_uniqueness_of :name
@@ -69,7 +68,7 @@ class Cart < ActiveRecord::Base
   end
 
   def import_initial_comments(comments)
-    self.comments.create!(user_id: self.proposal.requester_id, comment_text: comments.strip)
+    self.proposal.comments.create!(user_id: self.proposal.requester_id, comment_text: comments.strip)
   end
 
   def create_approvals(emails)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,6 +1,6 @@
 class Comment < ActiveRecord::Base
   include ObservableModel
-  belongs_to :commentable, polymorphic: true
+  belongs_to :proposal
   belongs_to :user
   delegate :full_name, :email_address, :to => :user, :prefix => true
 

--- a/app/models/concerns/proposal_delegate.rb
+++ b/app/models/concerns/proposal_delegate.rb
@@ -7,6 +7,7 @@ module ProposalDelegate
     has_many :approvers, through: :approvals, source: :user
     has_many :observations, through: :proposal
     has_many :observers, through: :observations, source: :user
+    has_many :comments, through: :proposal
     has_one :requester, through: :proposal
 
     accepts_nested_attributes_for :proposal

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -6,6 +6,7 @@ class Proposal < ActiveRecord::Base
   has_one :cart
   has_many :approvals
   has_many :approvers, through: :approvals, source: :user
+  has_many :comments
   has_many :observations
   has_many :observers, through: :observations, source: :user
   belongs_to :client_data, polymorphic: true

--- a/app/views/comments/index.html.haml
+++ b/app/views/comments/index.html.haml
@@ -1,6 +1,6 @@
 %h1
-  = "Comments for #{@commentable.class.name}"
-  = @commentable.id
+  = "Comments"
+  = @proposal.id
 
 %h4 Comments
 - @comments.each do |c|
@@ -8,4 +8,4 @@
   %br
 
 %br
-= link_to "Back to cart", "/carts/#{@commentable.id}"
+= link_to "Back to cart", "/carts/#{@proposal.cart.id}"

--- a/app/views/communicart_mailer/comment_added_email.html.erb
+++ b/app/views/communicart_mailer/comment_added_email.html.erb
@@ -1,18 +1,18 @@
 <body class="communicart-notification">
   <table class="w-container main-container" width='800'>
-    <% cart = @comment.commentable %>
+    <% proposal = @comment.proposal %>
     <tr><td class="w-container html-email-message">
       <p>
         Action need on Request 
-        #<%= cart.proposal.public_identifier %>
-        (<%= cart.proposal.name %>):
+        #<%= proposal.public_identifier %>
+        (<%= proposal.name %>):
       </p>
     </td></tr>
     <tr><td class="w-container html-email-message">
       <%= @comment.comment_text %>
     </td></tr>
     <tr><td class="w-container html-email-message">
-      <%= link_to "View / Update Request", cart_url(cart, anchor: 'cart-comments'), class: 'form-button' %>
+      <%= link_to "View / Update Request", cart_url(proposal.cart, anchor: 'cart-comments'), class: 'form-button' %>
     </td></tr>
   </table>
 </body>

--- a/app/views/communicart_mailer/comment_added_email.text.erb
+++ b/app/views/communicart_mailer/comment_added_email.text.erb
@@ -1,6 +1,6 @@
-<% cart = @comment.commentable %>
-Action need on Request #<%= cart.proposal.public_identifier %> (<%= cart.proposal.name %>):
+<% proposal = @comment.proposal %>
+Action need on Request #<%= proposal.public_identifier %> (<%= proposal.name %>):
 
 <%= @comment.comment_text %>
 
-View / Update Request: <%= cart_url(cart, anchor: 'cart-comments') %>
+View / Update Request: <%= cart_url(proposal.cart, anchor: 'cart-comments') %>

--- a/config/initializers/observers.rb
+++ b/config/initializers/observers.rb
@@ -1,5 +1,3 @@
 ActiveSupport::Notifications.subscribe('Comment.create') {|_, _, _, _, comment|
-  if comment.commentable_type == 'Cart'
-    Dispatcher.on_cart_comment_created(comment)
-  end
+  Dispatcher.on_comment_created(comment)
 }

--- a/db/migrate/20150410142248_make_comments_only_reference_proposals.rb
+++ b/db/migrate/20150410142248_make_comments_only_reference_proposals.rb
@@ -1,0 +1,28 @@
+class MakeCommentsOnlyReferenceProposals < ActiveRecord::Migration
+  def change
+    add_reference :comments, :proposal, index: true
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE comments
+          SET proposal_id = carts.proposal_id
+          FROM carts
+          WHERE carts.id = commentable_id
+            AND commentable_type = 'Cart';
+        SQL
+      end
+      dir.down do
+        execute <<-SQL
+          UPDATE comments
+          SET commentable_type = 'Cart',
+              commentable_id = carts.id
+          FROM carts
+          WHERE comments.proposal_id = carts.proposal_id;
+        SQL
+      end
+    end
+
+    remove_reference :comments, :commentable, polymorphic: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150401170800) do
+ActiveRecord::Schema.define(version: 20150410142248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,10 +59,11 @@ ActiveRecord::Schema.define(version: 20150401170800) do
     t.text     "comment_text"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "commentable_id"
-    t.string   "commentable_type"
     t.integer  "user_id"
+    t.integer  "proposal_id"
   end
+
+  add_index "comments", ["proposal_id"], name: "index_comments_on_proposal_id", using: :btree
 
   create_table "ncr_work_orders", force: true do |t|
     t.decimal  "amount"

--- a/lib/mail_preview.rb
+++ b/lib/mail_preview.rb
@@ -40,7 +40,7 @@ class MailPreview < MailView
   end
 
   def comment
-    Comment.where(commentable_type: 'Cart').last
+    Comment.last
   end
 
 

--- a/lib/populator.rb
+++ b/lib/populator.rb
@@ -55,7 +55,7 @@ module Populator
       num_comments.times do |i|
         commented_at = rand(requested_at..Time.now)
 
-        cart.comments.create!(
+        cart.proposal.comments.create!(
           comment_text: Faker::Hacker.say_something_smart,
           created_at: commented_at,
           updated_at: commented_at,

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,0 +1,41 @@
+describe CommentsController do
+  describe 'permission checking' do
+    let (:proposal) { FactoryGirl.create(:proposal, :with_approvers,
+                                         :with_observers, :with_requester,
+                                         :with_cart) }
+    let (:params) { {cart_id: proposal.cart.id, 
+                     comment: {comment_text: 'Some comment'}} }
+                     
+    it "allows the requester to comment" do
+      login_as(proposal.requester)
+      post :create, params
+      expect(flash[:success]).to be_present
+      expect(flash[:error]).not_to be_present
+      expect(response).to redirect_to(proposal.cart)
+    end
+
+    it "allows an approver to comment" do
+      login_as(proposal.approvers[0])
+      post :create, params
+      expect(flash[:success]).to be_present
+      expect(flash[:alert]).not_to be_present
+      expect(response).to redirect_to(proposal.cart)
+    end
+
+    it "allows an observer to comment" do
+      login_as(proposal.observers[0])
+      post :create, params
+      expect(flash[:success]).to be_present
+      expect(flash[:alert]).not_to be_present
+      expect(response).to redirect_to(proposal.cart)
+    end
+
+    it "does not allow others to comment" do
+      login_as(FactoryGirl.create(:user))
+      post :create, params
+      expect(flash[:success]).not_to be_present
+      expect(flash[:alert]).to be_present
+      expect(response).to redirect_to(carts_path)
+    end
+  end
+end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -4,5 +4,6 @@ FactoryGirl.define do
   factory :comment do
     comment_text "MyText"
     user
+    proposal
   end
 end

--- a/spec/mailers/communicart_mailer_spec.rb
+++ b/spec/mailers/communicart_mailer_spec.rb
@@ -46,7 +46,7 @@ describe CommunicartMailer do
       end
 
       it 'renders comments when present' do
-        cart.comments << FactoryGirl.create(:comment)
+        cart.proposal.comments << FactoryGirl.create(:comment)
         expect(mail.body.encoded).to include('Comments')
       end
     end
@@ -103,7 +103,7 @@ describe CommunicartMailer do
 
     context 'comments' do
       it 'renders comments when present' do
-        cart.comments << FactoryGirl.create(:comment, comment_text: 'My added comment')
+        cart.proposal.comments << FactoryGirl.create(:comment, comment_text: 'My added comment')
         expect(mail.body.encoded).to include('Comments')
       end
 
@@ -129,7 +129,7 @@ describe CommunicartMailer do
 
   describe 'comment_added_email' do
     let(:cart) { FactoryGirl.create(:cart) }
-    let(:comment) { FactoryGirl.create(:comment, commentable: cart) }
+    let(:comment) { FactoryGirl.create(:comment, proposal: cart.proposal) }
     let(:email) { "commenter@some-dot-gov.gov" }
     let(:mail) { CommunicartMailer.comment_added_email(comment, email) }
 

--- a/spec/requests/user_ownership_of_comments.rb
+++ b/spec/requests/user_ownership_of_comments.rb
@@ -67,8 +67,8 @@ describe 'Testing User Ownership of Comments' do
      user2 = cart.approvers.where(email_address: "approver2@some-dot-gov.gov").first
      new_comment = Comment.new(user_id: user.id,comment_text: "spud")
      snd_comment = Comment.new(user_id: user2.id,comment_text: "second")
-     cart.comments << new_comment
-     cart.comments << snd_comment
+     cart.proposal.comments << new_comment
+     cart.proposal.comments << snd_comment
 
     # We can add approval comments to both carts and distinguish them.
     expect(cart.comments[0].user_id).not_to eq cart.comments[1].user_id


### PR DESCRIPTION
Builds on #294: https://github.com/18F/C2/compare/cart-auth...comment-auth?expand=1

* Adds a proposal field for comments, migrates existing comments to use that field, and removes the existing polymorphic field.
* Removes all references to said polymorphic field
* Adds authorization when creating comments
* Specs to test that authorization