### PR TITLE
[Delivers #92448720] add notion of approval delegates

### DIFF
--- a/app/controllers/communicarts_controller.rb
+++ b/app/controllers/communicarts_controller.rb
@@ -16,11 +16,16 @@ class CommunicartsController < ApplicationController
 
   def approval_response
     proposal = self.cart.proposal
-    approval = cart.approvals.find_by(user_id: current_user.id)
+    approval = proposal.approval_for(current_user)
 
     case params[:approver_action]
       when 'approve'
         approval.approve!
+        unless approval.user == current_user
+          # delegate - assign them to the approval
+          approval.update_attributes!(user_id: current_user.id)
+        end
+
         flash[:success] = "You have approved Cart #{proposal.public_identifier}."
       when 'reject'
         approval.reject!

--- a/app/helpers/communicart_mailer_helper.rb
+++ b/app/helpers/communicart_mailer_helper.rb
@@ -14,12 +14,21 @@ module CommunicartMailerHelper
     end
   end
 
+  # If the user has delegates, returns `false` so that the email can be safely forwarded.
+  def auto_login?(user)
+    user.outgoing_delegates.empty?
+  end
+
   def approval_action_url(approval, action = 'approve')
-    approval_response_url(
+    opts = {
       cart_id: approval.cart_id,
-      cch: approval.api_token.access_token,
       version: approval.proposal.version,
       approver_action: action
-    )
+    }
+    if auto_login?(approval.user)
+      opts[:cch] = approval.api_token.access_token
+    end
+
+    approval_response_url(opts)
   end
 end

--- a/app/models/approval_delegate.rb
+++ b/app/models/approval_delegate.rb
@@ -1,0 +1,7 @@
+class ApprovalDelegate < ActiveRecord::Base
+  belongs_to :assignee, class_name: 'User', foreign_key: 'assignee_id'
+  belongs_to :assigner, class_name: 'User', foreign_key: 'assigner_id'
+
+  validates :assignee_id, presence: true
+  validates :assigner_id, presence: true
+end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -49,7 +49,7 @@ class Proposal < ActiveRecord::Base
     # TODO convert to SQL
     self.approvals.find do |approval|
       approver = approval.user
-      approver == user || approver.outgoing_delegates.exists?(assignee_id: user)
+      approver == user || approver.outgoing_delegates.exists?(assignee_id: user.id)
     end
   end
 
@@ -59,10 +59,15 @@ class Proposal < ActiveRecord::Base
     self.client_data || self.cart
   end
 
+  # TODO convert to an association
+  def delegates
+    self.approval_delegates.map(&:assignee)
+  end
+
   # Returns a list of all users involved with the Proposal.
   def users
     # TODO use SQL
-    results = self.approvers + self.observers + [self.requester]
+    results = self.approvers + self.observers + self.delegates + [self.requester]
     results.compact
   end
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -45,6 +45,14 @@ class Proposal < ActiveRecord::Base
     self.approval_delegates.exists?(assignee_id: user.id)
   end
 
+  def approval_for(user)
+    # TODO convert to SQL
+    self.approvals.find do |approval|
+      approver = approval.user
+      approver == user || approver.outgoing_delegates.exists?(assignee_id: user)
+    end
+  end
+
   # Use this until all clients are migrated to models (and we no longer have a
   # dependence on "Cart"
   def client_data_legacy

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -6,6 +6,7 @@ class Proposal < ActiveRecord::Base
   has_one :cart
   has_many :approvals
   has_many :approvers, through: :approvals, source: :user
+  has_many :approval_delegates, through: :approvers, source: :outgoing_delegates
   has_many :comments
   has_many :observations
   has_many :observers, through: :observations, source: :user
@@ -40,6 +41,9 @@ class Proposal < ActiveRecord::Base
     self.flow == 'linear'
   end
 
+  def delegate?(user)
+    self.approval_delegates.exists?(assignee_id: user.id)
+  end
 
   # Use this until all clients are migrated to models (and we no longer have a
   # dependence on "Cart"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,10 +30,6 @@ class User < ActiveRecord::Base
     Cart.joins(:proposal).where(proposals: {requester_id: self.id})
   end
 
-  def approver_of?(cart)
-    cart.approvers.include? self
-  end
-
   def last_requested_cart
     self.requested_carts.order('created_at DESC').first
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,10 @@ class User < ActiveRecord::Base
     self.requested_carts.order('created_at DESC').first
   end
 
+  def add_delegate(other)
+    self.outgoing_delegates.create!(assignee: other)
+  end
+
   def self.from_oauth_hash(auth_hash)
     user_data = auth_hash.extra.raw_info.to_hash
     self.find_or_create_by(email_address: user_data['email'])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,10 +5,14 @@ class User < ActiveRecord::Base
 
   has_many :user_roles
   has_many :approval_groups, through: :user_roles
+
   has_many :approvals
   has_many :observations
   has_many :properties, as: :hasproperties
   has_many :comments
+
+  has_many :outgoing_delegates, class_name: 'ApprovalDelegate', foreign_key: 'assigner_id'
+  has_many :incoming_delegates, class_name: 'ApprovalDelegate', foreign_key: 'assignee_id'
 
   def full_name
     if first_name && last_name

--- a/db/migrate/20150415025447_create_approval_delegates.rb
+++ b/db/migrate/20150415025447_create_approval_delegates.rb
@@ -1,0 +1,9 @@
+class CreateApprovalDelegates < ActiveRecord::Migration
+  def change
+    create_table :approval_delegates do |t|
+      t.references :assigner
+      t.references :assignee
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150410142248) do
+ActiveRecord::Schema.define(version: 20150415025447) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,13 @@ ActiveRecord::Schema.define(version: 20150410142248) do
     t.datetime "updated_at"
     t.datetime "used_at"
     t.integer  "approval_id"
+  end
+
+  create_table "approval_delegates", force: true do |t|
+    t.integer  "assigner_id"
+    t.integer  "assignee_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "approval_groups", force: true do |t|

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -29,9 +29,25 @@ They can then log in one of two ways:
 
 The system doesn't have any notion of user-level "roles", other than on a Proposal-by-Proposal basis. They can be one of:
 
-* Approver
-* Observer
-* Requester
+#### Approver
+
+A User who can approve a Proposal directly.
+
+#### Delegate
+
+A User who can approve Proposals on behalf of an approver. They can be added via the console with
+
+```ruby
+approver.add_delegate(other_user)
+```
+
+#### Observer
+
+A User who gets notifications for and can comment on a Proposal.
+
+#### Requester
+
+The User who initiated a Proposal.
 
 ## Data types
 

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -40,6 +40,7 @@ describe CommentsController do
       expect {
         post :create, params
       }.to change{ proposal.comments.count }.from(0).to(1)
+      expect(Comment.last.user).to eq(delegate)
     end
 
     it "does not allow others to comment" do

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -33,7 +33,7 @@ describe CommentsController do
     it "allows a delegate to comment" do
       approver = proposal.approvals.first.user
       delegate = FactoryGirl.create(:user)
-      approver.outgoing_delegates.create!(assignee: delegate)
+      approver.add_delegate(delegate)
 
       login_as(delegate)
 

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -3,9 +3,9 @@ describe CommentsController do
     let (:proposal) { FactoryGirl.create(:proposal, :with_approvers,
                                          :with_observers, :with_requester,
                                          :with_cart) }
-    let (:params) { {cart_id: proposal.cart.id, 
+    let (:params) { {cart_id: proposal.cart.id,
                      comment: {comment_text: 'Some comment'}} }
-                     
+
     it "allows the requester to comment" do
       login_as(proposal.requester)
       post :create, params
@@ -28,6 +28,18 @@ describe CommentsController do
       expect(flash[:success]).to be_present
       expect(flash[:alert]).not_to be_present
       expect(response).to redirect_to(proposal.cart)
+    end
+
+    it "allows a delegate to comment" do
+      approver = proposal.approvals.first.user
+      delegate = FactoryGirl.create(:user)
+      approver.outgoing_delegates.create!(assignee: delegate)
+
+      login_as(delegate)
+
+      expect {
+        post :create, params
+      }.to change{ proposal.comments.count }.from(0).to(1)
     end
 
     it "does not allow others to comment" do

--- a/spec/factories/approvals.rb
+++ b/spec/factories/approvals.rb
@@ -7,5 +7,9 @@ FactoryGirl.define do
     trait :with_cart do
       association :proposal, :with_cart
     end
+
+    trait :with_user do
+      user
+    end
   end
 end

--- a/spec/factories/approvals.rb
+++ b/spec/factories/approvals.rb
@@ -4,10 +4,6 @@ FactoryGirl.define do
     user_id 1
     status 'pending'
 
-    factory :approval_with_user do
-      user
-    end
-
     trait :with_cart do
       association :proposal, :with_cart
     end

--- a/spec/factories/carts.rb
+++ b/spec/factories/carts.rb
@@ -17,6 +17,13 @@ FactoryGirl.define do
     end
 
 
+    trait :with_requester do
+      after :create do |cart|
+        cart.add_requester('requester@some-dot-gov.gov')
+      end
+    end
+
+
     factory :cart_with_approval_group do
       after :create do |cart|
         approval_group = FactoryGirl.create(:approval_group_with_approvers_and_requester)
@@ -26,18 +33,12 @@ FactoryGirl.define do
       end
     end
 
-    factory :cart_with_requester do
-      after :create do |cart|
-        requester = FactoryGirl.create(:user, email_address: 'requester1@some-dot-gov.gov', first_name: 'Panthro', last_name: 'Requester')
-        cart.set_requester(requester)
-      end
-    end
-
     factory :cart_with_approvals do
+      with_requester
+
       after :create do |cart|
         cart.add_approver('approver1@some-dot-gov.gov')
         cart.add_approver('approver2@some-dot-gov.gov')
-        cart.add_requester('requester@some-dot-gov.gov')
       end
 
       factory :cart_with_all_approvals_approved do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
     trait :with_delegate do
       after(:create) do |user|
         delegate = FactoryGirl.create(:user)
-        user.outgoing_delegates.create!(assignee: delegate)
+        user.add_delegate(delegate)
       end
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,5 +3,12 @@ FactoryGirl.define do
     sequence(:email_address) {|n| "liono#{n}@some-cartoon-show.com" }
     first_name "Liono"
     last_name "Thunder"
+
+    trait :with_delegate do
+      after(:create) do |user|
+        delegate = FactoryGirl.create(:user)
+        user.outgoing_delegates.create!(assignee: delegate)
+      end
+    end
   end
 end

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -5,7 +5,7 @@ describe "National Capital Region proposals" do
     expect(page).to have_content("You need to sign in")
   end
 
-  context "when signed in" do
+  context "when signed in as the requester" do
     let(:requester) { FactoryGirl.create(:user) }
 
     before do

--- a/spec/helpers/communicart_mailer_helper_spec.rb
+++ b/spec/helpers/communicart_mailer_helper_spec.rb
@@ -1,9 +1,8 @@
 describe CommunicartMailerHelper do
   describe '#approval_action_url' do
     it "returns a URL" do
-      approval = FactoryGirl.build(:approval, :with_cart)
-      token = FactoryGirl.build(:api_token)
-      expect(approval).to receive(:api_token).and_return(token)
+      approval = FactoryGirl.create(:approval, :with_cart, :with_user)
+      token = approval.create_api_token!
 
       url = helper.approval_action_url(approval)
       uri = Addressable::URI.parse(url)
@@ -11,6 +10,20 @@ describe CommunicartMailerHelper do
         'approver_action' => 'approve',
         'cart_id' => approval.cart_id.to_s,
         'cch' => token.access_token,
+        'version' => approval.proposal.version.to_s
+      )
+    end
+
+    it "doesn't include a token if the approver has delegates" do
+      approver = FactoryGirl.create(:user, :with_delegate)
+      approval = FactoryGirl.create(:approval, :with_cart, user: approver)
+      approval.create_api_token!
+
+      url = helper.approval_action_url(approval)
+      uri = Addressable::URI.parse(url)
+      expect(uri.query_values).to eq(
+        'approver_action' => 'approve',
+        'cart_id' => approval.cart_id.to_s,
         'version' => approval.proposal.version.to_s
       )
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,17 +29,4 @@ describe User do
       expect(user.full_name).to eq 'george.jetson@spacelysprockets.com'
     end
   end
-
-  describe '#approver_of?' do
-    let(:cart) { FactoryGirl.create(:cart) }
-
-    it 'returns true when user is an approver' do
-      cart.add_approver user.email_address
-      expect(user.approver_of? cart).to eq true
-    end
-
-    it 'returns false when user is not an approver' do
-      expect(user.approver_of? cart).to eq false
-    end
-  end
 end

--- a/spec/policies/proposal_policy_spec.rb
+++ b/spec/policies/proposal_policy_spec.rb
@@ -7,7 +7,8 @@ describe ProposalPolicy do
 
       approval = proposal.approvals.first
       delegate = FactoryGirl.create(:user)
-      approval.user.outgoing_delegates.create!(assignee: delegate)
+      approver = approval.user
+      approver.add_delegate(delegate)
 
       expect(subject).to permit(delegate, proposal)
     end

--- a/spec/policies/proposal_policy_spec.rb
+++ b/spec/policies/proposal_policy_spec.rb
@@ -2,6 +2,16 @@ describe ProposalPolicy do
   subject { described_class }
 
   permissions :can_approve_or_reject? do
+    it "allows pending delegates" do
+      proposal = FactoryGirl.create(:proposal, :with_approvers)
+
+      approval = proposal.approvals.first
+      delegate = FactoryGirl.create(:user)
+      approval.user.outgoing_delegates.create!(assignee: delegate)
+
+      expect(subject).to permit(delegate, proposal)
+    end
+
     context "parallel cart" do
       let(:proposal) {FactoryGirl.create(:proposal, :with_cart, :with_approvers,
                                          flow: 'parallel')}

--- a/spec/requests/carts_spec.rb
+++ b/spec/requests/carts_spec.rb
@@ -1,0 +1,16 @@
+describe 'carts' do
+  describe 'GET /carts/:id' do
+    it "can be viewed by a delegate" do
+      cart = FactoryGirl.create(:cart, :with_requester)
+      approver = FactoryGirl.create(:user, :with_delegate)
+      cart.proposal.approvals.create!(user: approver)
+
+      delegate = approver.outgoing_delegates.first.assignee
+      login_as(delegate)
+
+      get "/carts/#{cart.id}"
+
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/spec/requests/communicarts_spec.rb
+++ b/spec/requests/communicarts_spec.rb
@@ -33,7 +33,7 @@ describe 'CommunicartsController' do
 
         # TODO move to factory trait
         delegate = FactoryGirl.create(:user)
-        approver.outgoing_delegates.create!(assignee_id: delegate.id)
+        approver.add_delegate(delegate)
 
         login_as(delegate)
         params = {

--- a/spec/requests/communicarts_spec.rb
+++ b/spec/requests/communicarts_spec.rb
@@ -23,4 +23,32 @@ describe 'CommunicartsController' do
       expect(response.status).to eq 201
     end
   end
+
+  describe 'PUT /approval_response' do
+    context "without a token" do
+      it "accepts responses from a signed-in delegate" do
+        cart = FactoryGirl.create(:cart_with_approvals)
+        approval = cart.approvals.first
+        approver = approval.user
+
+        # TODO move to factory trait
+        delegate = FactoryGirl.create(:user)
+        approver.outgoing_delegates.create!(assignee_id: delegate.id)
+
+        login_as(delegate)
+        params = {
+          cart_id: cart.id.to_s,
+          approver_action: 'approve'
+        }
+
+        put '/approval_response', params
+
+        approval.reload
+        expect(approval.status).to eq('approved')
+        expect(approval.user).to eq(delegate)
+      end
+
+      it "redirects them to log in when not signed in"
+    end
+  end
 end

--- a/spec/steps/user_steps.rb
+++ b/spec/steps/user_steps.rb
@@ -56,15 +56,15 @@ module UserSteps
   end
 
   step 'a cart :external_id' do |external_id|
-    @cart = FactoryGirl.create(:cart_with_requester, external_id: external_id)
+    @cart = FactoryGirl.create(:cart, :with_requester, external_id: external_id)
   end
 
   step 'a :cart_type cart :external_id' do |cart_type, external_id|
-    @cart = FactoryGirl.create(:cart_with_requester, external_id: external_id, flow: cart_type)
+    @cart = FactoryGirl.create(:cart, :with_requester, external_id: external_id, flow: cart_type)
   end
 
   step 'a cart :external_id with approver :approver_email' do |external_id, approver_email|
-    @cart = FactoryGirl.create(:cart_with_requester, external_id: external_id)
+    @cart = FactoryGirl.create(:cart, :with_requester, external_id: external_id)
     @cart.add_approver(approver_email)
     @approval = @cart.approvals.first
   end


### PR DESCRIPTION
A User can have zero or more ApprovalDelegates, which are other users who can approve requests instead of them. Not loving the names I used for new models/columns/associations...very open to suggestions for alternatives. Open questions:

* If an approver has delegates, should they still be allowed to approve?

TODOs:

* [x] Document how to add delegates
* [x] Ensure that the delegate can view the proposals
* [x] Ensure that the delegate can comment on the proposals
* [x] Don't auto-login from notification emails that have delegates