### PR TITLE
[Delivers #92876748] delegate notification emails shouldn't use URL to automatically login

### DIFF
--- a/app/helpers/communicart_mailer_helper.rb
+++ b/app/helpers/communicart_mailer_helper.rb
@@ -20,15 +20,15 @@ module CommunicartMailerHelper
   end
 
   def approval_action_url(approval, action = 'approve')
-    opts = {
-      cart_id: approval.cart_id,
-      version: approval.proposal.version,
-      approver_action: action
-    }
     if auto_login?(approval.user)
-      opts[:cch] = approval.api_token.access_token
+      approval_response_url(
+        approver_action: action,
+        cart_id: approval.cart_id,
+        cch: approval.api_token.access_token,
+        version: approval.proposal.version
+      )
+    else
+      cart_url(approval.cart_id)
     end
-
-    approval_response_url(opts)
   end
 end

--- a/spec/helpers/communicart_mailer_helper_spec.rb
+++ b/spec/helpers/communicart_mailer_helper_spec.rb
@@ -14,18 +14,13 @@ describe CommunicartMailerHelper do
       )
     end
 
-    it "doesn't include a token if the approver has delegates" do
+    it "links to the cart if the approver has delegates" do
       approver = FactoryGirl.create(:user, :with_delegate)
       approval = FactoryGirl.create(:approval, :with_cart, user: approver)
       approval.create_api_token!
 
       url = helper.approval_action_url(approval)
-      uri = Addressable::URI.parse(url)
-      expect(uri.query_values).to eq(
-        'approver_action' => 'approve',
-        'cart_id' => approval.cart_id.to_s,
-        'version' => approval.proposal.version.to_s
-      )
+      expect(url).to eq("http://test.host/carts/#{approval.cart_id}")
     end
 
     it "throws an error if there's no token" do


### PR DESCRIPTION
Just use the simple cart URL.