### PR TITLE
prompt delegate to log in when approving

### DIFF
--- a/app/controllers/communicarts_controller.rb
+++ b/app/controllers/communicarts_controller.rb
@@ -57,10 +57,16 @@ class CommunicartsController < ApplicationController
   end
 
   def auth_errors(exception)
-    flash[:error] = exception.message
     if exception.record == :api_token
-      render 'authentication_error', status: 403
+      session[:return_to] = request.fullpath
+      if signed_in?
+        flash[:error] = exception.message
+        render 'authentication_error', status: 403
+      else
+        redirect_to root_path, alert: "Please sign in to complete this action."
+      end
     else
+      flash[:error] = exception.message
       redirect_to cart_path(self.cart)
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -42,4 +42,8 @@ module ApplicationHelper
     controller_name == 'home' ||
     current_page?(carts_path)
   end
+
+  def auth_path
+    '/auth/myusa'
+  end
 end

--- a/app/helpers/communicart_mailer_helper.rb
+++ b/app/helpers/communicart_mailer_helper.rb
@@ -20,15 +20,16 @@ module CommunicartMailerHelper
   end
 
   def approval_action_url(approval, action = 'approve')
+    opts = {
+      approver_action: action,
+      cart_id: approval.cart_id,
+      version: approval.proposal.version
+
+    }
     if auto_login?(approval.user)
-      approval_response_url(
-        approver_action: action,
-        cart_id: approval.cart_id,
-        cch: approval.api_token.access_token,
-        version: approval.proposal.version
-      )
-    else
-      cart_url(approval.cart_id)
+      opts[:cch] = approval.api_token.access_token
     end
+
+    approval_response_url(opts)
   end
 end

--- a/app/views/layouts/_communicart_header.html.erb
+++ b/app/views/layouts/_communicart_header.html.erb
@@ -9,7 +9,7 @@
       <%- unless signed_in? %>
 
         <li>
-          <%= link_to 'Sign in with MyUSA', "/auth/myusa" %>
+          <%= link_to 'Sign in with MyUSA', auth_path %>
         </li>
       <%- else %>
         <li>

--- a/spec/acceptance/token_expiration.feature
+++ b/spec/acceptance/token_expiration.feature
@@ -11,4 +11,4 @@ Feature: Approving a cart from the web application expires the token
     Then I should see alert text 'You have approved Cart 1357531.'
     When I click 'Logout'
     And I go to the approval_response page with token
-    Then I should see alert text 'Something went wrong with the token (already used)'
+    Then I should see alert text 'Please sign in to complete this action.'

--- a/spec/controllers/communicarts_controller_spec.rb
+++ b/spec/controllers/communicarts_controller_spec.rb
@@ -120,7 +120,7 @@ describe CommunicartsController do
       end
 
       it 'successfully validates the user_id and cart_id with the token twice' do
-        
+
         expect do
           put 'approval_response', approval_params_with_token
           put 'approval_response', approval_params_with_token
@@ -130,22 +130,27 @@ describe CommunicartsController do
 
 
     context 'Request token' do
-      it 'fails when the token does not exist' do
+      def expect_redirect_to_login
+        expect(response).to redirect_to('/')
+        # TODO expect(response.body).to include("You need to sign in")
+      end
+
+      it 'redirects to sign in when the token does not exist' do
         approval_params_with_token[:cch] = nil
         put 'approval_response', approval_params_with_token
-        expect(response.status).to be(403)
+        expect_redirect_to_login
       end
 
-      it 'fails when the token has expired' do
+      it 'redirects to sign in when the token has expired' do
         token.update_attributes(expires_at: 8.days.ago)
         put 'approval_response', approval_params_with_token
-        expect(response.status).to be(403)
+        expect_redirect_to_login
       end
 
-      it 'fails when the token has already been used once' do
+      it 'redirects to sign in when the token has already been used once' do
         token.update_attributes(used_at: 1.hour.ago)
         put 'approval_response', approval_params_with_token
-        expect(response.status).to be(403)
+        expect_redirect_to_login
       end
 
       it 'marks a token as used' do

--- a/spec/helpers/communicart_mailer_helper_spec.rb
+++ b/spec/helpers/communicart_mailer_helper_spec.rb
@@ -20,7 +20,15 @@ describe CommunicartMailerHelper do
       approval.create_api_token!
 
       url = helper.approval_action_url(approval)
-      expect(url).to eq("http://test.host/carts/#{approval.cart_id}")
+
+      uri = Addressable::URI.parse(url)
+      expect(uri.path).to eq('/approval_response')
+      cart = approval.cart
+      expect(uri.query_values).to eq(
+        'approver_action' => 'approve',
+        'cart_id' => cart.id.to_s,
+        'version' => cart.version.to_s
+      )
     end
 
     it "throws an error if there's no token" do

--- a/spec/mailers/communicart_mailer_spec.rb
+++ b/spec/mailers/communicart_mailer_spec.rb
@@ -48,6 +48,7 @@ describe CommunicartMailer do
     end
 
     it "uses the approval URL" do
+      expect(approval_uri.path).to eq('/approval_response')
       expect(approval_uri.query_values).to eq(
         'approver_action' => 'approve',
         'cart_id' => cart.id.to_s,


### PR DESCRIPTION
A little janky, and not convinced about the approach, but it should work for now. The new flow, when logged out:

1. Delegate sees notification email
1. They click "Approve" from the email
1. If signed in:
    * Yes: Approved.
    * No:
        1. They are redirected to the homepage, with a flash message saying they should log in
        1. They click "Sign in with MyUSA"
        1. After completing the OAuth flow, Approved.

Could use some manual testing as well if someone has a moment to try it.