### PR TITLE
[Delivers #92876870] fix display of approver after a delegate approves

### DIFF
--- a/app/controllers/communicarts_controller.rb
+++ b/app/controllers/communicarts_controller.rb
@@ -17,15 +17,14 @@ class CommunicartsController < ApplicationController
   def approval_response
     proposal = self.cart.proposal
     approval = proposal.approval_for(current_user)
+    if approval.user.delegates_to?(current_user)
+      # assign them to the approval
+      approval.update_attributes!(user: current_user)
+    end
 
     case params[:approver_action]
       when 'approve'
-        if approval.user.delegates_to?(current_user)
-          # assign them to the approval
-          approval.update_attributes!(user: current_user)
-        end
         approval.approve!
-
         flash[:success] = "You have approved Cart #{proposal.public_identifier}."
       when 'reject'
         approval.reject!

--- a/app/controllers/communicarts_controller.rb
+++ b/app/controllers/communicarts_controller.rb
@@ -20,11 +20,11 @@ class CommunicartsController < ApplicationController
 
     case params[:approver_action]
       when 'approve'
-        approval.approve!
-        unless approval.user == current_user
-          # delegate - assign them to the approval
-          approval.update_attributes!(user_id: current_user.id)
+        if approval.user.delegates_to?(current_user)
+          # assign them to the approval
+          approval.update_attributes!(user: current_user)
         end
+        approval.approve!
 
         flash[:success] = "You have approved Cart #{proposal.public_identifier}."
       when 'reject'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,10 @@ class User < ActiveRecord::Base
     self.outgoing_delegates.create!(assignee: other)
   end
 
+  def delegates_to?(other)
+    self.outgoing_delegates.exists?(assignee_id: other.id)
+  end
+
   def self.from_oauth_hash(auth_hash)
     user_data = auth_hash.extra.raw_info.to_hash
     self.find_or_create_by(email_address: user_data['email'])


### PR DESCRIPTION
Fixes two issues:

* The subsequent notification email was showing the delegator as having approved, not the delegate.
* The delegate wasn't being assigned in the case of rejection.