### PR TITLE
ensure that delegates can only be assigned to an approver once

### DIFF
--- a/app/models/approval_delegate.rb
+++ b/app/models/approval_delegate.rb
@@ -2,6 +2,6 @@ class ApprovalDelegate < ActiveRecord::Base
   belongs_to :assignee, class_name: 'User', foreign_key: 'assignee_id'
   belongs_to :assigner, class_name: 'User', foreign_key: 'assigner_id'
 
-  validates :assignee_id, presence: true
+  validates :assignee_id, presence: true, uniqueness: {scope: :assigner_id}
   validates :assigner_id, presence: true
 end


### PR DESCRIPTION
Just noticed that we have some duplicates in our database. Cleaned them up, but this will prevent new ones.