### PR TITLE
[Delivers #93440210] Friendly error message when attachment not present

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -21,7 +21,7 @@ class AttachmentsController < ApplicationController
   end
 
   def attachments_params
-    params.require(:attachment).permit(:file)
+    params.permit(attachment: [:file])[:attachment]
   end
 
   def auth_errors(exception)

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -44,4 +44,16 @@ describe AttachmentsController do
       expect(proposal.attachments.count).to eq(0)
     end
   end
+
+  describe 'error handling' do
+    it "gives an error when a file was not selected" do
+      proposal = FactoryGirl.create(:proposal, :with_requester)
+      login_as(proposal.requester)
+      post :create, { proposal_id: proposal.id }
+      expect(flash[:success]).not_to be_present
+      expect(flash[:error]).to be_present
+      expect(response).to redirect_to(proposal_path(proposal))
+      expect(proposal.attachments.count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
Looks like:
![screen shot 2015-04-28 at 10 53 17 am](https://cloud.githubusercontent.com/assets/326918/7372456/d231e558-ed94-11e4-99b8-bfb1cf98ed97.png)
