### PR TITLE
[Delivers #93379244] Add ability to remove attachment (if the original uploader)

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,6 +1,7 @@
 class AttachmentsController < ApplicationController
   before_filter :authenticate_user!
-  before_filter ->{authorize self.proposal, :can_show!}
+  before_filter ->{authorize self.proposal, :can_show!}, only: [:create]
+  before_filter ->{authorize self.attachment}, only: [:destroy]
   rescue_from Pundit::NotAuthorizedError, with: :auth_errors
 
   def create
@@ -15,9 +16,19 @@ class AttachmentsController < ApplicationController
     redirect_to proposal
   end
 
+  def destroy
+    self.attachment.destroy
+    flash[:success] = "Deleted attachment"
+    redirect_to proposal_path(self.attachment.proposal_id)
+  end
+
   protected
   def proposal
     @cached_proposal ||= Proposal.find(params[:proposal_id])
+  end
+
+  def attachment
+    @cached_attachment ||= Attachment.find(params[:id])
   end
 
   def attachments_params

--- a/app/policies/attachment_policy.rb
+++ b/app/policies/attachment_policy.rb
@@ -1,0 +1,8 @@
+class AttachmentPolicy
+  include ExceptionPolicy
+
+  def can_destroy!
+    check(@user.id == @record.user_id,
+          "Only the original author can delete an attachment")
+  end
+end

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -154,14 +154,21 @@
       <% @proposal.attachments.each do |attachment| %>
         <div class="line-item">
           <div class="row">
-            <p class="col-sm-6 col-xs-12">
+            <p class="col-sm-5 col-xs-12">
               <a href="<%= attachment.url %>"><%= attachment.file_file_name %></a>
             </p>
             <p class="col-sm-3 col-xs-6">
               <strong><%= attachment.user.full_name %></strong>
             </p>
-            <p class="col-sm-3 col-xs-6 date righted">
+            <p class="col-sm-3 col-xs-5 date righted">
               <%= date_with_tooltip(attachment.created_at) %>
+            </p>
+            <p class="col-sm-1 col-xs-1 righted">
+              <%- if policy(attachment).can_destroy? %>
+                <%= link_to "Delete",
+                    proposal_attachment_path(@proposal, attachment),
+                    method: :delete, data: {confirm: "Are you sure?"} %>
+              <%- end %>
             </p>
           </div>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,11 +30,7 @@ C2::Application.routes.draw do
     end
 
     resources :comments, only: [:index, :create]
-  end
-
-  # todo: integrate once proposal urls are complete
-  resources :proposals, only: [] do
-    resources :attachments, only: [:create]
+    resources :attachments, only: [:create, :destroy]
   end
 
   namespace :ncr do

--- a/spec/features/attachment_spec.rb
+++ b/spec/features/attachment_spec.rb
@@ -1,8 +1,10 @@
 describe "Add attachments" do
   let (:proposal) {
-    FactoryGirl.create(:proposal, :with_requester, :with_cart)
+    FactoryGirl.create(:proposal, :with_requester, :with_cart, :with_approvers)
   }
-  let! (:attachment) { FactoryGirl.create(:attachment, proposal: proposal) }
+  let! (:attachment) {
+    FactoryGirl.create(:attachment, proposal: proposal,
+                       user: proposal.requester) }
 
   before do
     login_as(proposal.requester)
@@ -11,6 +13,21 @@ describe "Add attachments" do
   it "is visible on a proposal" do
     visit proposal_path(proposal)
     expect(page).to have_content(attachment.file_file_name)
+  end
+
+  it "uploader can delete" do
+    visit proposal_path(proposal)
+    expect(page).to have_content("Delete")
+    click_on("Delete")
+    expect(current_path).to eq("/proposals/#{proposal.id}")
+    expect(page).to have_content("Deleted attachment")
+    expect(Attachment.count).to be(0)
+  end
+
+  it "does not have a delete link for another" do
+    login_as(proposal.approvers.first)
+    visit proposal_path(proposal)
+    expect(page).not_to have_content("Delete")
   end
 
   context "aws" do

--- a/spec/policies/attachment_policy_spec.rb
+++ b/spec/policies/attachment_policy_spec.rb
@@ -1,0 +1,21 @@
+describe AttachmentPolicy do
+  subject { described_class }
+  let(:proposal) {
+    FactoryGirl.create(:proposal, :with_requester, :with_approvers,
+                       :with_observers)
+  }
+  let(:attachment) { FactoryGirl.create(:attachment, proposal: proposal) } 
+
+  permissions :can_destroy? do
+    it "allows the original uploader to delete" do
+      expect(subject).to permit(attachment.user, attachment)
+    end
+
+    it "does not allow anyone else to delete" do
+      expect(subject).not_to permit(FactoryGirl.create(:user), attachment)
+      expect(subject).not_to permit(proposal.requester, attachment)
+      expect(subject).not_to permit(proposal.approvers.first, attachment)
+      expect(subject).not_to permit(proposal.observers.first, attachment)
+    end
+  end
+end


### PR DESCRIPTION
Only the original uploader has permission to delete. Others don't see the "delete" link. Interface looks like:

![screen shot 2015-04-29 at 10 15 25 am](https://cloud.githubusercontent.com/assets/326918/7392889/bb76eb0a-ee58-11e4-8605-0fbccf7ce549.png)
![screen shot 2015-04-29 at 10 15 33 am](https://cloud.githubusercontent.com/assets/326918/7392891/be770c5e-ee58-11e4-8cff-be8f3d23bbe4.png)
![screen shot 2015-04-29 at 10 15 41 am](https://cloud.githubusercontent.com/assets/326918/7392892/c0bcd07a-ee58-11e4-9d32-dea25571c2cb.png)
