### PR TITLE
Remove total_price from proposal interface

### DIFF
--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -159,14 +159,6 @@ class Cart < ActiveRecord::Base
     "Cart ##{self.external_id || self.id}"
   end
 
-  def total_price
-    if self.client == 'gsa18f'
-      self.getProp('cost_per_unit').to_f * self.getProp('quantity').to_f
-    else
-      0.0
-    end
-  end
-
   # may be replaced with paper-trail or similar at some point
   def version
     self.updated_at.to_i

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -17,8 +17,8 @@ class Proposal < ActiveRecord::Base
 
   # The following list also servers as an interface spec for client_datas
   # Note: clients should also implement :version
-  delegate :fields_for_display, :client, :public_identifier, :total_price,
-           :name, to: :client_data_legacy
+  delegate :fields_for_display, :client, :public_identifier, :name,
+           to: :client_data_legacy
 
   validates :flow, presence: true, inclusion: {in: ApprovalGroup::FLOWS}
   # TODO validates :requester_id, presence: true

--- a/app/views/default/_proposal_list.html.erb
+++ b/app/views/default/_proposal_list.html.erb
@@ -1,0 +1,28 @@
+<%#-- "proposals" is the critical local variable for using this partial --%>
+<%#-- "role" (either 'requester' or 'approver') modifies the list slightly --%>
+<%#-- "closed" (bool) determines whether we're showing closed proposals or not. --%>
+<%#-- "limit" is the maximum number of proposals to show. --%>
+<table class="proposal-list">
+  <tr class="header">
+    <th class="sixth" scope="col"><h5>ID</h5></th>
+    <th class="first" scope="col"><h5>Request</h5></th>
+    <th class="sixth" scope="col"><h5>Status</h5></th>
+    <th class="sixth" scope="col"><h5>Submitted</h5></th>
+  </tr>
+  <%- if defined? limit %>
+    <%- proposals_list = proposals.limit(limit) %>
+  <%- else %>
+    <%- proposals_list = proposals %>
+  <%- end %>
+  <%- proposals_list.each do |proposal| %>
+    <tr>
+      <td class="sixth"><a href="<%= proposal_url(proposal) %>"><%= proposal.public_identifier %></a></td>
+      <td class="first"><a href="<%= proposal_url(proposal) %>"><%= proposal.name %></a></td>
+      <td class="sixth">
+        <%= render partial: 'proposals/review_status',
+            locals: {proposal: proposal} %>
+      </td>
+      <td class="sixth"><%= date_with_tooltip(proposal.created_at) %></td>
+    </tr>
+  <%- end %>
+</table>

--- a/app/views/default/_proposal_mail.html.erb
+++ b/app/views/default/_proposal_mail.html.erb
@@ -26,29 +26,5 @@
     </tr>
 
     <%= render partial: "shared/email_status" %>
-    <tr>
-      <td class="w-container results-list" colspan="2">
-        <table width="100%">
-          <tr class='header'>
-            <td class="first" width="50%" scope="col">
-              <h5>Product</h5>
-            </td>
-            <td width="25%" scope="col">
-              <h5>Price</h5>
-            </td>
-
-            <td width="25%" scope="col">
-              <h5>Vendor</h5>
-            </td>
-
-          </tr>
-          <tr>
-            <td class='cart-total' colspan='3'>
-              <span class="total-label">Total: <strong><%= number_to_currency(proposal.total_price) %></strong></span>
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>
   </table>
 </div>

--- a/app/views/gsa18f/_proposal_list.html.erb
+++ b/app/views/gsa18f/_proposal_list.html.erb
@@ -19,20 +19,13 @@
     <tr>
       <td class="sixth"><a href="<%= proposal_url(proposal) %>"><%= proposal.public_identifier %></a></td>
       <td class="first"><a href="<%= proposal_url(proposal) %>"><%= proposal.name %></a></td>
-      <td class="sixth"><%= number_to_currency(proposal.total_price) %></td>
+      <td class="sixth"><%= number_to_currency(proposal.client_data.total_price) %></td>
       <td class="sixth">
-        <% approvers = proposal.currently_awaiting_approvers %>
-        <% if proposal.pending? && approvers.include?(current_user) %>
-          <%# This isn't used anywhere %>
-          <p><strong>Please review</strong></p>
-        <% elsif proposal.pending? %>
-          <p><em>Waiting for review from:
-            <%= approvers.map(&:full_name).join(', ') %></em></p>
-        <% else %>
-          <%= proposal.status.titlecase %>
-        <% end %>
+        <%= render partial: 'proposals/review_status',
+            locals: {proposal: proposal} %>
       </td>
       <td class="sixth"><%= date_with_tooltip(proposal.created_at) %></td>
     </tr>
   <%- end %>
 </table>
+

--- a/app/views/ncr/_proposal_list.html.erb
+++ b/app/views/ncr/_proposal_list.html.erb
@@ -1,0 +1,31 @@
+<%#-- "proposals" is the critical local variable for using this partial --%>
+<%#-- "role" (either 'requester' or 'approver') modifies the list slightly --%>
+<%#-- "closed" (bool) determines whether we're showing closed proposals or not. --%>
+<%#-- "limit" is the maximum number of proposals to show. --%>
+<table class="proposal-list">
+  <tr class="header">
+    <th class="sixth" scope="col"><h5>ID</h5></th>
+    <th class="first" scope="col"><h5>Request</h5></th>
+    <th class="sixth" scope="col"><h5>Total Price</h5></th>
+    <th class="sixth" scope="col"><h5>Status</h5></th>
+    <th class="sixth" scope="col"><h5>Submitted</h5></th>
+  </tr>
+  <%- if defined? limit %>
+    <%- proposals_list = proposals.limit(limit) %>
+  <%- else %>
+    <%- proposals_list = proposals %>
+  <%- end %>
+  <%- proposals_list.each do |proposal| %>
+    <tr>
+      <td class="sixth"><a href="<%= proposal_url(proposal) %>"><%= proposal.public_identifier %></a></td>
+      <td class="first"><a href="<%= proposal_url(proposal) %>"><%= proposal.name %></a></td>
+      <td class="sixth"><%= number_to_currency(proposal.client_data.total_price) %></td>
+      <td class="sixth">
+        <%= render partial: 'proposals/review_status',
+            locals: {proposal: proposal} %>
+      </td>
+      <td class="sixth"><%= date_with_tooltip(proposal.created_at) %></td>
+    </tr>
+  <%- end %>
+</table>
+

--- a/app/views/proposals/_review_status.html.erb
+++ b/app/views/proposals/_review_status.html.erb
@@ -1,0 +1,12 @@
+<%#-- This snippet describes who needs to review a proposal.
+      It needs access to both "proposal" and "current_user" --%>
+"proposal" is the critical local variable
+<% approvers = proposal.currently_awaiting_approvers %>
+<% if proposal.pending? && approvers.include?(current_user) %>
+  <p><strong>Please review</strong></p>
+<% elsif proposal.pending? %>
+  <p><em>Waiting for review from:
+    <%= approvers.map(&:full_name).join(', ') %></em></p>
+<% else %>
+  <%= proposal.status.titlecase %>
+<% end %>

--- a/app/views/proposals/archive.html.erb
+++ b/app/views/proposals/archive.html.erb
@@ -5,7 +5,7 @@
 </div>
 <div class="row">
   <div class="col-sm-12">
-    <%= render partial: "proposal_list",
+    <%= client_partial current_user.client_slug, "proposal_list", 
                locals: {proposals: @proposals, role: @role,
                         closed: true} %>
   </div>

--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -3,7 +3,8 @@
     <div class="col-md-12">
       <h3>Pending Purchase Requests</h3>
       <%- if @proposals.pending.any? %>
-        <%= render partial: "proposal_list", locals: { proposals: @proposals.pending, role: @role, closed: false} %>
+        <%= client_partial current_user.client_slug, "proposal_list",
+            locals: { proposals: @proposals.pending, role: @role, closed: false} %>
       <%- else %>
         <p class="empty-list-label">No pending purchase requests</p>
       <%- end %>
@@ -20,8 +21,9 @@
   <%- if @proposals.closed.any? %>
     <div class="row">
       <div class="col-sm-12">
-        <%= render partial: "proposal_list", locals: { 
-          proposals: @proposals.closed, limit: @CLOSED_PROPOSAL_LIMIT} %>
+        <%= client_partial current_user.client_slug, "proposal_list",
+            locals: {proposals: @proposals.closed,
+                     limit: @CLOSED_PROPOSAL_LIMIT} %>
       </div>
     </div>
 

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -134,19 +134,4 @@ describe Cart do
       expect(cart.api_tokens.unexpired.length).to eq(2)
     end
   end
-
-  describe '#total_price' do
-    context 'the client origin is 18f' do
-      it 'gets price from two fields' do
-        cart.setProp('origin', 'gsa18f')
-        cart.setProp('cost_per_unit', '18.50')
-        cart.setProp('quantity', '20')
-        expect(cart.total_price).to eq(18.50*20)
-      end
-    end
-
-    it 'returns 0 otherwise' do
-      expect(cart.total_price).to eq(0.0)
-    end
-  end
 end

--- a/spec/models/gsa18f/procurement_spec.rb
+++ b/spec/models/gsa18f/procurement_spec.rb
@@ -14,4 +14,12 @@ describe Gsa18f::Procurement do
       ))
     end
   end
+
+  describe '#total_price' do
+    it 'gets price from two fields' do
+      procurement = FactoryGirl.build(
+        :gsa18f_procurement, cost_per_unit: 18.50, quantity: 20)
+      expect(procurement.total_price).to eq(18.50*20)
+    end
+  end
 end


### PR DESCRIPTION
Removes the field from the Proposal model, which requires removing it from the default proposal listing template.

Went ahead and also removed a chunk in proposal_mail which isn't used by any existing client that also referenced this field.