### PR TITLE
updated verbage for emails and proposal view

### DIFF
--- a/app/mailers/communicart_mailer.rb
+++ b/app/mailers/communicart_mailer.rb
@@ -42,7 +42,7 @@ class CommunicartMailer < ActionMailer::Base
 
     mail(
          to: to_address,
-         subject: "User #{approval.user.email_address} has #{approval.status} #{@proposal.public_identifier}",
+         subject: "User #{approval.user.email_address} has #{approval.status} request #{@proposal.public_identifier}",
          from: user_email(approval.user)
          )
   end
@@ -52,7 +52,7 @@ class CommunicartMailer < ActionMailer::Base
 
     mail(
          to: to_email,
-         subject: "A comment has been added to #{comment.proposal.public_identifier}",
+         subject: "A comment has been added to request #{comment.proposal.public_identifier}",
          from: user_email(comment.user)
          )
   end
@@ -84,7 +84,7 @@ class CommunicartMailer < ActionMailer::Base
 
     mail(
       to: to_email,
-      subject: "Communicart Approval Request from #{proposal.requester.full_name}: Please review #{proposal.public_identifier}",
+      subject: "Communicart Approval Request from #{proposal.requester.full_name}: Please review request #{proposal.public_identifier}",
       from: from_email
     )
   end

--- a/app/models/gsa18f/procurement.rb
+++ b/app/models/gsa18f/procurement.rb
@@ -76,7 +76,7 @@ module Gsa18f
 
     # @todo - this is pretty ugly
     def public_identifier
-      self.cart.id
+      "##{self.cart.id}"
     end
 
     def total_price

--- a/app/models/gsa18f/procurement.rb
+++ b/app/models/gsa18f/procurement.rb
@@ -76,7 +76,7 @@ module Gsa18f
 
     # @todo - this is pretty ugly
     def public_identifier
-      "##{self.cart.id}"
+      "##{self.id}"
     end
 
     def total_price

--- a/app/views/communicart_mailer/approval_reply_received_email.html.erb
+++ b/app/views/communicart_mailer/approval_reply_received_email.html.erb
@@ -4,7 +4,7 @@
       <td class="w-container html-email-message">
         <p>
           Hello,<br/>
-          The approver, <%= @approval.user_email_address %>, <%= @approval.status %>  Cart #<%= @proposal.public_identifier %>.<br/>
+          The approver, <%= @approval.user_email_address %>, <%= @approval.status %>  request <%= @proposal.public_identifier %>.<br/>
           Please see below for more details.
         </p>
 

--- a/spec/mailers/communicart_mailer_spec.rb
+++ b/spec/mailers/communicart_mailer_spec.rb
@@ -42,7 +42,7 @@ describe CommunicartMailer do
 
     it 'renders the subject' do
       requester.update_attributes(first_name: 'Liono', last_name: 'Requester')
-      expect(mail.subject).to eq('Communicart Approval Request from Liono Requester: Please review Cart #13579')
+      expect(mail.subject).to eq('Communicart Approval Request from Liono Requester: Please review request Cart #13579')
     end
 
     it 'renders the receiver email' do
@@ -115,7 +115,7 @@ describe CommunicartMailer do
     end
 
     it 'renders the subject' do
-      expect(mail.subject).to eq('User approver1@some-dot-gov.gov has approved Cart #13579')
+      expect(mail.subject).to eq('User approver1@some-dot-gov.gov has approved request Cart #13579')
     end
 
     it 'renders the receiver email' do
@@ -161,7 +161,7 @@ describe CommunicartMailer do
     let(:mail) { CommunicartMailer.comment_added_email(comment, email) }
 
     it 'renders the subject' do
-      expect(mail.subject).to eq("A comment has been added to Cart #13579")
+      expect(mail.subject).to eq("A comment has been added to request Cart #13579")
     end
 
     it 'renders the receiver email' do
@@ -180,7 +180,7 @@ describe CommunicartMailer do
     let(:mail) { CommunicartMailer.proposal_observer_email(observer.email_address, proposal) }
 
     it 'renders the subject' do
-      expect(mail.subject).to eq("Communicart Approval Request from #{proposal.requester.full_name}: Please review Cart #13579")
+      expect(mail.subject).to eq("Communicart Approval Request from #{proposal.requester.full_name}: Please review request Cart #13579")
     end
 
     it 'renders the receiver email' do


### PR DESCRIPTION
Here is the updated language
### 18f
![letteropenerweb](https://cloud.githubusercontent.com/assets/5296248/7480462/b1802566-f336-11e4-943b-0efc6c0f545e.png)

![letteropenerweb](https://cloud.githubusercontent.com/assets/5296248/7480485/cea1f28c-f336-11e4-8055-7009faf46785.png)

![letteropenerweb](https://cloud.githubusercontent.com/assets/5296248/7480500/eef0c914-f336-11e4-932e-16ee0bc3e05a.png)

![letteropenerweb](https://cloud.githubusercontent.com/assets/5296248/7480514/02ea11b4-f337-11e4-9e1e-8d946b8d81ea.png)
This used to say "Cart"

### NCR

![letteropenerweb](https://cloud.githubusercontent.com/assets/5296248/7480532/240ba0ba-f337-11e4-8411-5bacc2302e26.png)

![letteropenerweb](https://cloud.githubusercontent.com/assets/5296248/7480550/3d21f4b4-f337-11e4-935f-e93ed0e7767a.png)


