### PR TITLE
[Delivers #93639720] Validate RWA Number format

### DIFF
--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -29,6 +29,10 @@ module Ncr
     validates :expense_type, inclusion: {in: EXPENSE_TYPES}, presence: true
     validates :vendor, presence: true
     validates :building_number, presence: true
+    validates :rwa_number, format: {
+      with: /[a-zA-Z][0-9]{7}/,
+      message: "one letter followed by 7 numbers"
+    }, allow_blank: true
     # TODO validates :proposal, presence: true
 
     def set_defaults

--- a/spec/factories/ncr/work_orders.rb
+++ b/spec/factories/ncr/work_orders.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
     not_to_exceed false
     building_number Ncr::BUILDING_NUMBERS[0]
     emergency false
-    rwa_number "RWWAAA #"
+    rwa_number "R1234567"
     office Ncr::OFFICES[0]
     project_title "NCR Name"
 

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -78,7 +78,7 @@ describe "National Capital Region proposals" do
       visit '/ncr/work_orders/new'
       fill_in 'Project title', with: "buying stuff"
       choose 'BA80'
-      fill_in 'RWA Number', with: 'NumNum'
+      fill_in 'RWA Number', with: 'B9876543'
       fill_in 'Vendor', with: 'ACME'
       fill_in 'Amount', with: 123.45
       fill_in "Approving Official's Email Address", with: 'approver@example.com'
@@ -232,7 +232,7 @@ describe "National Capital Region proposals" do
         choose 'BA61'
         check "This request was an emergency and I received a verbal Notice to Proceed (NTP)"
         choose 'BA80'
-        fill_in 'RWA Number', with: "a 'number'"
+        fill_in 'RWA Number', with: 'R9876543'
         expect {
           click_on 'Submit for approval'
         }.to change { Proposal.count }.from(0).to(1)

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -150,4 +150,29 @@ describe Ncr::WorkOrder do
       expect(deliveries.last.to).to eq(['bob@example.com'])
     end
   end
+
+  describe 'rwa validations' do
+    let (:work_order) { FactoryGirl.create(:ncr_work_order) }
+    it 'works with one letter followed by 7 numbers' do
+      work_order.rwa_number = 'A1234567'
+      expect(work_order).to be_valid
+    end
+
+    it 'must be 8 chars' do
+      work_order.rwa_number = 'A123456'
+      expect(work_order).not_to be_valid
+    end
+
+    it 'must have a letter at the beginning' do
+      work_order.rwa_number = '12345678'
+      expect(work_order).not_to be_valid
+    end
+
+    it 'is not required' do
+      work_order.rwa_number = nil
+      expect(work_order).to be_valid
+      work_order.rwa_number = ''
+      expect(work_order).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
Per the spec. Only thing I'm not too clear on is how rails handles empty values -- should I just be using `allow_nil` (and not testing the empty string)?