### PR TITLE
[Delivers #94113926] have public_identifier reference the proposal ID rather than the client model's

### DIFF
--- a/app/models/gsa18f/procurement.rb
+++ b/app/models/gsa18f/procurement.rb
@@ -5,7 +5,7 @@ module Gsa18f
   end
 
   DATA = YAML.load_file("#{Rails.root}/config/data/18f.yaml")
-  
+
 
   class Procurement < ActiveRecord::Base
     URGENCY = DATA['URGENCY']
@@ -17,7 +17,7 @@ module Gsa18f
     has_one :proposal, as: :client_data
     # TODO remove the dependence
     has_one :cart, through: :proposal
-    
+
     validates :cost_per_unit, numericality: {
       greater_than_or_equal_to: 0,
       less_than_or_equal_to: 3000
@@ -36,7 +36,7 @@ module Gsa18f
       Dispatcher.deliver_new_proposal_emails(proposal)
       cart
     end
-    
+
     def update_cart(cart)
       cart.proposal.approvals.destroy_all
       self.add_approvals
@@ -52,11 +52,11 @@ module Gsa18f
     # split these into different models
     def self.relevant_fields(recurring)
       fields = [:office, :justification, :link_to_product, :quantity,
-        :date_requested, :urgency, :additional_info, :cost_per_unit, 
+        :date_requested, :urgency, :additional_info, :cost_per_unit,
         :product_name_and_description, :recurring]
       if recurring
         fields += [:recurring_interval, :recurring_length]
-      end 
+      end
       fields
     end
 
@@ -76,7 +76,7 @@ module Gsa18f
 
     # @todo - this is pretty ugly
     def public_identifier
-      "##{self.id}"
+      "##{self.proposal.id}"
     end
 
     def total_price

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -102,7 +102,7 @@ module Ncr
     end
 
     def public_identifier
-      "FY" + self.fiscal_year.to_s.rjust(2, "0") + "-#{self.id}"
+      "FY" + self.fiscal_year.to_s.rjust(2, "0") + "-#{self.proposal.id}"
     end
 
     def total_price

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -105,12 +105,14 @@ describe Ncr::WorkOrder do
     it 'includes the fiscal year' do
       work_order = FactoryGirl.create(:ncr_work_order, :with_proposal,
                                       created_at: Date.new(2007, 1, 15))
+      proposal_id = work_order.proposal.id
+
       expect(work_order.public_identifier).to eq(
-        "FY07-#{work_order.id}")
+        "FY07-#{proposal_id}")
 
       work_order.update_attribute(:created_at, Date.new(2007, 10, 1))
       expect(work_order.public_identifier).to eq(
-        "FY08-#{work_order.id}")
+        "FY08-#{proposal_id}")
     end
   end
 


### PR DESCRIPTION
I didn't update for the `Cart#public_identifier` for backwards-compatibility reasons...not sure if it matters one way or another.