### PR TITLE
[Finished #93639564] Display the time for comments

### DIFF
--- a/app/helpers/value_helper.rb
+++ b/app/helpers/value_helper.rb
@@ -1,6 +1,7 @@
 module ValueHelper
   def date_with_tooltip(time)
-    content_tag('span', l(time.to_date), title: l(time))
+    adjusted_time = time.in_time_zone("Eastern Time (US & Canada)").strftime("%b %-d, %Y at %l:%M%P")
+    content_tag('span', adjusted_time, title: adjusted_time)
   end
 
   def decimal?(val)


### PR DESCRIPTION
Displaying time for comments. Decided to display in ET since our first group is in that timezone. Also displaying the month, day, year in a more readable format since we have the space.

![screen shot 2015-05-07 at 5 05 10 pm](https://cloud.githubusercontent.com/assets/11333/7526877/9927f876-f4db-11e4-8a7c-75eca0f12d9f.png)
