### PR TITLE
[Delivers #94399790] Account for proposal lists including mixes of proposals

### DIFF
--- a/app/views/gsa18f/_proposal_list.html.erb
+++ b/app/views/gsa18f/_proposal_list.html.erb
@@ -19,7 +19,7 @@
     <tr>
       <td class="sixth"><a href="<%= proposal_url(proposal) %>"><%= proposal.public_identifier %></a></td>
       <td class="first"><a href="<%= proposal_url(proposal) %>"><%= proposal.name %></a></td>
-      <td class="sixth"><%= number_to_currency(proposal.client_data.total_price) %></td>
+      <td class="sixth"><%= number_to_currency(proposal.client_data.try(:total_price)) %></td>
       <td class="sixth">
         <%= render partial: 'proposals/review_status',
             locals: {proposal: proposal} %>

--- a/app/views/ncr/_proposal_list.html.erb
+++ b/app/views/ncr/_proposal_list.html.erb
@@ -19,7 +19,7 @@
     <tr>
       <td class="sixth"><a href="<%= proposal_url(proposal) %>"><%= proposal.public_identifier %></a></td>
       <td class="first"><a href="<%= proposal_url(proposal) %>"><%= proposal.name %></a></td>
-      <td class="sixth"><%= number_to_currency(proposal.client_data.total_price) %></td>
+      <td class="sixth"><%= number_to_currency(proposal.client_data.try(:total_price)) %></td>
       <td class="sixth">
         <%= render partial: 'proposals/review_status',
             locals: {proposal: proposal} %>

--- a/spec/features/proposal_listing_spec.rb
+++ b/spec/features/proposal_listing_spec.rb
@@ -1,0 +1,40 @@
+describe "Listing Page" do
+  let!(:user){ FactoryGirl.create(:user) }
+  let!(:default){ FactoryGirl.create(:proposal, :with_cart, requester: user) }
+  let!(:ncr){ 
+    ncr = FactoryGirl.create(:ncr_work_order, :with_proposal)
+    ncr.proposal.update_attribute(:requester, user)
+    ncr
+  }
+  let!(:gsa18f){
+    gsa18f = FactoryGirl.create(:gsa18f_procurement, :with_proposal)
+    gsa18f.proposal.update_attribute(:requester, user)
+    gsa18f
+  }
+  before do
+    login_as(user)
+  end
+
+  it "should not explode if client is not set" do
+    visit '/proposals'
+    expect(page).to have_content(default.public_identifier)
+    expect(page).to have_content(ncr.public_identifier)
+    expect(page).to have_content(gsa18f.public_identifier)
+  end
+
+  it "should not explode if client is ncr" do
+    user.update_attribute(:client_slug, 'ncr')
+    visit '/proposals'
+    expect(page).to have_content(default.public_identifier)
+    expect(page).to have_content(ncr.public_identifier)
+    expect(page).to have_content(gsa18f.public_identifier)
+  end
+
+  it "should not explode if client is gsa18f" do
+    user.update_attribute(:client_slug, 'gsa18f')
+    visit '/proposals'
+    expect(page).to have_content(default.public_identifier)
+    expect(page).to have_content(ncr.public_identifier)
+    expect(page).to have_content(gsa18f.public_identifier)
+  end
+end


### PR DESCRIPTION
While this wouldn't affect normal users so much, devs often have proposals of various types in their proposal list. Don't let that lead to an error.