### PR TITLE
[Delivers #94019990] Be more careful when approving via GET

### DIFF
--- a/app/assets/stylesheets/common/communicarts.scss
+++ b/app/assets/stylesheets/common/communicarts.scss
@@ -281,7 +281,7 @@ p {
   display: inline-block;
   margin-top: 15px;
   padding: 15px 25px;
-  border-bottom: 2px solid #095ba7;
+  border: 2px solid #095ba7;
   border-radius: 5px;
   background-color: #0d66bf;
   color: black;

--- a/app/controllers/concerns/token_auth.rb
+++ b/app/controllers/concerns/token_auth.rb
@@ -17,6 +17,13 @@ module TokenAuth
     rescue_from Pundit::NotAuthorizedError, with: :auth_errors
   end
 
+  # As a security precaution, certain actions must be POSTed to.
+  def needs_token_on_get
+    if request.get?
+      authorize(:api_token, :valid!, params)
+    end
+  end
+
   def validate_access
     if !signed_in?
       authorize(:api_token, :valid!, params)
@@ -40,7 +47,7 @@ module TokenAuth
     when :api_token
       if signed_in?
         flash[:error] = exception.message
-        render 'authentication_error', status: 403
+        render 'communicarts/authentication_error', status: 403
       else
         redirect_to root_path(return_to: self.make_return_to("Previous", request.fullpath)), alert: "Please sign in to complete this action."
       end

--- a/app/controllers/concerns/token_auth.rb
+++ b/app/controllers/concerns/token_auth.rb
@@ -27,6 +27,7 @@ module TokenAuth
   def validate_access
     if !signed_in?
       authorize(:api_token, :valid!, params)
+      authorize(:api_token, :not_delegate!, params)
       # validated above
       sign_in(ApiToken.find_by(access_token: params[:cch]).user)
     end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -3,6 +3,7 @@ class ProposalsController < ApplicationController
 
   before_filter :authenticate_user!, except: :approve
   before_filter ->{authorize self.proposal}, only: :show
+  before_filter :needs_token_on_get, only: :approve
   before_filter :validate_access, only: :approve
   helper_method :display_status
   add_template_helper ProposalsHelper
@@ -21,6 +22,7 @@ class ProposalsController < ApplicationController
   def archive
     @proposals = self.proposals.closed
   end
+
 
   def approve
     approval = self.proposal.approval_for(current_user)

--- a/app/helpers/communicart_mailer_helper.rb
+++ b/app/helpers/communicart_mailer_helper.rb
@@ -14,18 +14,9 @@ module CommunicartMailerHelper
     end
   end
 
-  # If the user has delegates, returns `false` so that the email can be safely forwarded.
-  def auto_login?(user)
-    user.outgoing_delegates.empty?
-  end
-
   def generate_approve_url(approval)
     proposal = approval.proposal
-    opts = { version: proposal.version }
-    if auto_login?(approval.user)
-      opts[:cch] = approval.api_token.access_token
-    end
-
+    opts = { version: proposal.version, cch: approval.api_token.access_token }
     approve_proposal_url(proposal, opts)
   end
 end

--- a/app/policies/api_token_policy.rb
+++ b/app/policies/api_token_policy.rb
@@ -26,6 +26,11 @@ class ApiTokenPolicy
                      "Something went wrong with the token (already used)")
   end
 
+  def not_delegate!
+    exists! && check(@api_token.user.outgoing_delegates.empty?,
+                     "You must first sign in")
+  end
+
   def cart?
     !!@params[:cart_id]
   end

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -185,8 +185,9 @@
 
 <% if policy(@proposal).can_approve_or_reject? %>
   <div class="centered">
-    <p>
-      <%= link_to "Approve", approve_proposal_path(@proposal, version: @proposal.version), class: 'form-button' %>
-    </p>
+    <%= form_tag(approve_proposal_path(@proposal, method: "POST")) do %>
+      <%= hidden_field_tag(:version, @proposal.version) %>
+      <%= submit_tag("Approve", class: 'form-button') %>
+    <% end %>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,8 @@ C2::Application.routes.draw do
 
   resources :proposals, only: [:index, :show] do
     member do
-      get 'approve'
+      get 'approve'   # this route has special protection to prevent the confused deputy problem
+                      # if you are adding a new controller which performs an action, use post instead
       post 'approve'
     end
 

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -1,4 +1,5 @@
 describe ProposalsController do
+  include ReturnToHelper
   let(:user) { FactoryGirl.create(:user) }
 
   describe '#index' do
@@ -106,6 +107,17 @@ describe ProposalsController do
       post :approve, id: proposal.id, cch: token.access_token
 
       expect(controller.send(:current_user)).to eq(approval.user)
+    end
+
+    it "won't sign the user in via the token if delegated" do
+      proposal = FactoryGirl.create(:proposal, :with_approver, :with_cart)
+      approval = proposal.approvals.first
+      token = approval.create_api_token!
+      approval.user.add_delegate(FactoryGirl.create(:user))
+
+      post :approve, id: proposal.id, cch: token.access_token
+
+      expect(response).to redirect_to(root_path(return_to: self.make_return_to("Previous", request.fullpath)))
     end
 
     it "won't allow a missing token when using GET" do

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -107,5 +107,23 @@ describe ProposalsController do
 
       expect(controller.send(:current_user)).to eq(approval.user)
     end
+
+    it "won't allow a missing token when using GET" do
+      proposal = FactoryGirl.create(:proposal, :with_approver, :with_cart)
+      login_as(proposal.approvers.first)
+      get :approve, id: proposal.id
+
+      expect(response).to have_http_status(403)
+    end
+
+    it "will allow action if the token is valid" do
+      proposal = FactoryGirl.create(:proposal, :with_approver, :with_cart)
+      approval = proposal.approvals.first
+      token = approval.create_api_token!
+
+      get :approve, id: proposal.id, cch: token.access_token
+      approval.reload
+      expect(approval.approved?).to be(true)
+    end
   end
 end

--- a/spec/helpers/communicart_mailer_helper_spec.rb
+++ b/spec/helpers/communicart_mailer_helper_spec.rb
@@ -16,22 +16,6 @@ describe CommunicartMailerHelper do
       )
     end
 
-    it "leaves out the token if the approver has delegates" do
-      approver = FactoryGirl.create(:user, :with_delegate)
-      approval = FactoryGirl.create(:approval, :with_proposal, user: approver)
-      approval.create_api_token!
-      proposal = approval.proposal
-
-      expect(proposal).to receive(:version).and_return(123)
-
-      url = helper.generate_approve_url(approval)
-      uri = Addressable::URI.parse(url)
-      expect(uri.path).to eq("/proposals/#{proposal.id}/approve")
-      expect(uri.query_values).to eq(
-        'version' => '123'
-      )
-    end
-
     it "throws an error if there's no token" do
       approval = FactoryGirl.build(:approval)
       expect(approval.api_token).to eq(nil)

--- a/spec/policies/api_token_policy_spec.rb
+++ b/spec/policies/api_token_policy_spec.rb
@@ -38,4 +38,15 @@ describe ApiTokenPolicy do
       expect(subject).not_to permit(approval_params_with_token, :api_token)
     end
   end
+
+  permissions :not_delegate? do
+    it "allows non-delegates to use" do
+      expect(subject).to permit(approval_params_with_token, :api_token)
+    end
+
+    it "does not allow delegates to use" do
+      token.user.add_delegate(FactoryGirl.create(:user))
+      expect(subject).not_to permit(approval_params_with_token, :api_token)
+    end
+  end
 end

--- a/spec/steps/user_steps.rb
+++ b/spec/steps/user_steps.rb
@@ -1,5 +1,10 @@
 module UserSteps
 
+  # include body text and button text
+  def page_text
+    page.find('body').text + ' ' + page.all("input[type=submit]").map(&:value).join(" ")
+  end
+
   step 'a valid user' do
     @user = User.find_or_create_by(email_address: 'test.user@some-dot-gov.gov')
     @user.update_attributes(first_name: "George", last_name: "Jetson")
@@ -23,11 +28,11 @@ module UserSteps
   end
 
   step "I should see :text" do |text|
-    expect(page.find('body')).to have_content(text)
+    expect(page_text).to include(text)
   end
 
   step "I should not see :text" do |text|
-    expect(page.find('body')).to_not have_content(text)
+    expect(page_text).not_to include(text)
   end
 
   step 'I should see a header :text' do |text|


### PR DESCRIPTION
Using a GET-able URL when performing an action is problematic due to the confused deputy problem. Imagine a malicious requester crafted an email with an `img` with the src pointing to the approval url. If an approver loaded this "image", their browser would be acting on their behalf to approve the request.

This limits the surface area of this attack a bit by generally forcing a POST to occur. The exception is that the "approve" button in an email cannot be a POST and work correctly in most mail readers. Since this had to be a GET, we single out this exception by adding a special check that a token is present.

Continues to look like:
![screen shot 2015-05-13 at 9 01 57 pm](https://cloud.githubusercontent.com/assets/326918/7624294/87592d76-f9b4-11e4-888c-8dd9e52f9fc8.png)
