### PR TITLE
[Delivers #93639592] Disable submit when nothing is present

### DIFF
--- a/app/assets/javascripts/forms.js.coffee
+++ b/app/assets/javascripts/forms.js.coffee
@@ -59,18 +59,9 @@ class Selectizer
       @loadRemoteOptions()
 
 
-
 $ ->
   $('.js-selectize').each (i, el) ->
     selectizer = new Selectizer(el)
     selectizer.enable()
     selectizer.loadOptionsIfRemote()
     selectizer.add_label()
-
-  #Disable/Enable button if textbox is empty
-  $('#add_a_comment').prop 'disabled', true
-  $('#comment_comment_text').keyup ->
-    disable = false
-    if $(this).val() == ''
-      disable = true
-    $('#add_a_comment').prop 'disabled', disable

--- a/app/assets/javascripts/required_for_submit.js.coffee
+++ b/app/assets/javascripts/required_for_submit.js.coffee
@@ -1,0 +1,16 @@
+class RequiredForSubmit
+  constructor: ($root, $submit) ->
+    @$submit = $submit
+    @$controller = $root.find("##{ $submit.attr('data-disable-if-empty') }")
+    @$controller.keyup => @checkDisable()
+    @$controller.change => @checkDisable()
+    @checkDisable()
+
+  checkDisable: ->
+    @$submit.prop 'disabled', (@$controller.val() == '')
+
+$ ->
+  # @todo - better scope
+  $scope = $(document)
+  $scope.find("[data-disable-if-empty]").each (idx, el) ->
+    new RequiredForSubmit($scope, $(el))

--- a/app/assets/stylesheets/common/communicarts.scss
+++ b/app/assets/stylesheets/common/communicarts.scss
@@ -158,7 +158,7 @@ h1 {
 
     &.pending {
       min-width: 155px;
-      background-image: image-url('icon-pending.gif');
+      background-image: image-url('icon-pending.png');
       background-repeat: no-repeat;
       background-position: center -0.2em;
       padding-top: 20px;

--- a/app/assets/stylesheets/webapp/webviews.scss
+++ b/app/assets/stylesheets/webapp/webviews.scss
@@ -232,6 +232,11 @@ tr.cart_item_information p {
     border: 0;
     padding: 15px;
 
+    &[disabled] {
+      color: $medgray;
+      background-color: $lightgray;
+    }
+
     @media(max-width: $break-small) {
       padding: 10px;
     }

--- a/app/assets/stylesheets/webapp/webviews.scss
+++ b/app/assets/stylesheets/webapp/webviews.scss
@@ -364,7 +364,7 @@ body.webapp {
 
     &.pending {
       min-width: 155px;
-      background-image: image-url('icon-pending.gif');
+      background-image: image-url('icon-pending.png');
       background-repeat: no-repeat;
       background-position: center -0.2em;
       padding-top: 20px;

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -102,7 +102,7 @@
             </p>
           </div>
           <p class='col-xs-5 col-sm-6 text-area-button'>
-            <%= submit_tag "Send a Comment", id: :add_a_comment %>
+          <%= submit_tag "Send a Comment", id: :add_a_comment, data: {'disable-if-empty' => 'comment_comment_text'} %>
           </p>
         </div>
       <%- end %>
@@ -148,7 +148,7 @@
             <p>Attach a file (e.g. receipts, contract documents, etc.)</p>
           </div>
           <p class='col-xs-5 col-sm-6 text-area-button'>
-            <%= submit_tag "Attach a File", id: :add_a_file %>
+          <%= submit_tag "Attach a File", id: :add_a_file, data: {'disable-if-empty' => 'attachment_file'} %>
           </p>
         </div>
       <%- end %>

--- a/spec/features/attachment_spec.rb
+++ b/spec/features/attachment_spec.rb
@@ -15,6 +15,13 @@ describe "Add attachments" do
     expect(page).to have_content(attachment.file_file_name)
   end
 
+  it "disables attachments if none is selected", js: true do
+    visit proposal_path(proposal)
+    expect(find("#add_a_file").disabled?).to be(true)
+    page.attach_file('attachment[file]', "#{Rails.root}/app/assets/images/bg_approved_status.gif")
+    expect(find("#add_a_file").disabled?).to be(false)
+  end
+
   it "uploader can delete" do
     visit proposal_path(proposal)
     expect(page).to have_content("Delete")

--- a/spec/features/comment_spec.rb
+++ b/spec/features/comment_spec.rb
@@ -24,6 +24,13 @@ describe "commenting" do
       expect(page).to have_content("can't be blank")
     end
 
+    it "disables attachments if none is selected", js: true do
+      visit proposal_path(cart.proposal)
+      expect(find("#add_a_comment").disabled?).to be(true)
+      fill_in 'comment[comment_text]', with: 'foo'
+      expect(find("#add_a_comment").disabled?).to be(false)
+    end
+
     it "sends an email" do
       fill_in 'comment[comment_text]', with: 'foo'
       click_on 'Send a Comment'


### PR DESCRIPTION
This extends #344 by
* changing the style of disabled buttons so that it's obvious they're disabled
* abstracting the disable-checking code into a declarative style
* using that style to re-use the code for file submission
* adding tests

Also fixes a reference to a non-existent image. Looks like:

![screen shot 2015-05-14 at 12 27 55 pm](https://cloud.githubusercontent.com/assets/326918/7636342/b6d0ce08-fa34-11e4-96c4-30540eb179ef.png)

![screen shot 2015-05-14 at 12 28 38 pm](https://cloud.githubusercontent.com/assets/326918/7636353/c595529c-fa34-11e4-8936-ef5a77e4e753.png)
