### PR TITLE
[Delivers #93997522] Don't rely on rails magic to POST/DELETE

### DIFF
--- a/app/assets/stylesheets/common/button_to.scss
+++ b/app/assets/stylesheets/common/button_to.scss
@@ -1,0 +1,22 @@
+/* Whenever we use button_to, we're using it like a link. Style accordingly: a lot of resets.*/
+
+form.button_to {
+  display: inline;
+  div {
+    display: inline;
+  }
+  input[type="submit"] {
+    background: transparent;
+    border: 0;
+    padding: 0;
+    box-shadow: none;
+    transition: none;
+    text-transform: none;
+    font-weight: inherit;
+
+    &:hover, &:active,  {
+      background: transparent;
+    }
+  }
+}
+

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -10,6 +10,7 @@
  *
  *= require_self
  *= require common/header
+ *= require common/button_to
  */
 
 @import "bootstrap-sprockets";

--- a/app/assets/stylesheets/webapp/webviews.scss
+++ b/app/assets/stylesheets/webapp/webviews.scss
@@ -306,11 +306,11 @@ body.webapp {
     color: black;
   }
 
-  a {
+  a, .button_to input {
     text-decoration: underline;
     color: #0C75E1;
   }
-  p {
+  p, .button_to input {
     font-size: 14px;
   }
 }

--- a/app/views/layouts/_header_nav.html.erb
+++ b/app/views/layouts/_header_nav.html.erb
@@ -5,7 +5,7 @@
       <%= image_tag 'icon-user.png', alt: ' ' %>
     </li>
     <li>
-      <%= link_to 'Logout', "/logout", class: 'login-link' %>
+      <%= button_to 'Logout', "/logout", method: 'post', class: 'login-link' %>
       <%= image_tag 'icon-logout.png', alt: 'Logout' %>
     </li>
   <%- else %>

--- a/app/views/layouts/_header_nav.html.erb
+++ b/app/views/layouts/_header_nav.html.erb
@@ -5,7 +5,7 @@
       <%= image_tag 'icon-user.png', alt: ' ' %>
     </li>
     <li>
-      <%= button_to 'Logout', "/logout", method: 'post', class: 'login-link' %>
+      <%= button_to 'Logout', "/logout", method: :post, class: 'login-link' %>
       <%= image_tag 'icon-logout.png', alt: 'Logout' %>
     </li>
   <%- else %>

--- a/app/views/layouts/_header_nav.html.erb
+++ b/app/views/layouts/_header_nav.html.erb
@@ -5,7 +5,7 @@
       <%= image_tag 'icon-user.png', alt: ' ' %>
     </li>
     <li>
-      <%= link_to 'Logout', "/logout", method: :post, class: 'login-link' %>
+      <%= link_to 'Logout', "/logout", class: 'login-link' %>
       <%= image_tag 'icon-logout.png', alt: 'Logout' %>
     </li>
   <%- else %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -164,13 +164,11 @@
             <p class="col-sm-3 col-xs-5 date righted">
               <%= date_with_tooltip(attachment.created_at) %>
             </p>
-            <p class="col-sm-1 col-xs-1 righted">
-              <%- if policy(attachment).can_destroy? %>
-                <%= link_to "Delete",
-                    proposal_attachment_path(@proposal, attachment),
-                    method: :delete, data: {confirm: "Are you sure?"} %>
-              <%- end %>
-            </p>
+            <%- if policy(attachment).can_destroy? %>
+              <%= button_to "Delete", proposal_attachment_path(@proposal, attachment), method: :delete, data: {confirm: "Are you sure?"}, class: "col-sm-1 col-xs-1 righted" %>
+            <%- else %>
+              <p class="col-sm-1 col-xs-1 righted"></p>
+            <%- end %>
           </div>
         </div>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ C2::Application.routes.draw do
   root :to => 'home#index'
   match "/auth/:provider/callback" => "home#oauth_callback", via: [:get]
   get '/error' => 'home#error'
-  post "/logout" => "home#logout"
+  get "/logout" => "home#logout"
 
   namespace :api do
     scope :v1 do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ C2::Application.routes.draw do
   root :to => 'home#index'
   match "/auth/:provider/callback" => "home#oauth_callback", via: [:get]
   get '/error' => 'home#error'
-  get "/logout" => "home#logout"
+  post "/logout" => "home#logout"
 
   namespace :api do
     scope :v1 do

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,3 +1,11 @@
 describe HomeController do
-
+  describe '#logout' do
+    it "it signs a user out" do
+      login_as(FactoryGirl.create(:user))
+      expect(session[:user]).not_to be_nil
+      get :logout
+      expect(response).to redirect_to(root_path)
+      expect(session[:user]).to be_nil
+    end
+  end
 end

--- a/spec/features/attachment_spec.rb
+++ b/spec/features/attachment_spec.rb
@@ -17,7 +17,7 @@ describe "Add attachments" do
 
   it "uploader can delete" do
     visit proposal_path(proposal)
-    expect(page).to have_content("Delete")
+    expect(page).to have_button("Delete")
     click_on("Delete")
     expect(current_path).to eq("/proposals/#{proposal.id}")
     expect(page).to have_content("Deleted attachment")
@@ -27,7 +27,7 @@ describe "Add attachments" do
   it "does not have a delete link for another" do
     login_as(proposal.approvers.first)
     visit proposal_path(proposal)
-    expect(page).not_to have_content("Delete")
+    expect(page).not_to have_button("Delete")
   end
 
   context "aws" do

--- a/spec/features/logout_spec.rb
+++ b/spec/features/logout_spec.rb
@@ -1,0 +1,28 @@
+# This is both a feature and a controller spec and the controller spec doesn't test the route
+describe "Logging out" do
+  context 'a user is signed in' do
+    before do
+      login_as(FactoryGirl.create(:user))
+    end
+
+    it 'allows logout via the header link' do
+      visit '/'
+      expect(page).not_to have_content('Sign in')
+      expect(page).to have_content('Logout')
+      click_on 'Logout'
+      expect(current_path).to eq('/')
+      expect(page).to have_content('Sign in')
+      expect(page).not_to have_content('Logout')
+    end
+
+    it 'allows logout via a url' do
+      visit '/'
+      expect(page).not_to have_content('Sign in')
+      expect(page).to have_content('Logout')
+      visit '/logout'   # hard page refresh
+      expect(current_path).to eq('/')
+      expect(page).to have_content('Sign in')
+      expect(page).not_to have_content('Logout')
+    end
+  end
+end

--- a/spec/features/logout_spec.rb
+++ b/spec/features/logout_spec.rb
@@ -5,24 +5,14 @@ describe "Logging out" do
       login_as(FactoryGirl.create(:user))
     end
 
-    it 'allows logout via the header link' do
+    it 'allows logout via the header button' do
       visit '/'
       expect(page).not_to have_content('Sign in')
-      expect(page).to have_content('Logout')
+      expect(page).to have_button('Logout')
       click_on 'Logout'
       expect(current_path).to eq('/')
       expect(page).to have_content('Sign in')
-      expect(page).not_to have_content('Logout')
-    end
-
-    it 'allows logout via a url' do
-      visit '/'
-      expect(page).not_to have_content('Sign in')
-      expect(page).to have_content('Logout')
-      visit '/logout'   # hard page refresh
-      expect(current_path).to eq('/')
-      expect(page).to have_content('Sign in')
-      expect(page).not_to have_content('Logout')
+      expect(page).not_to have_button('Logout')
     end
   end
 end

--- a/vendor/assets/stylesheets/photon/style.css
+++ b/vendor/assets/stylesheets/photon/style.css
@@ -1,4 +1,6 @@
-/* modifications: changed Google Font URL to HTTPS */
+/* modifications: changed Google Font URL to HTTPS 
+ *                removed header button box-shadow, hover/active states
+ **/
 
 @import url(font-awesome.min.css);
 @import url("https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300italic,400,400italic");
@@ -1061,25 +1063,9 @@
 		#header input[type="button"],
 		#header button,
 		#header .button {
-			box-shadow: inset 0 0 0 1px #ffffff;
 			color: #ffffff !important;
 		}
 
-			#header input[type="submit"]:hover,
-			#header input[type="reset"]:hover,
-			#header input[type="button"]:hover,
-			#header button:hover,
-			#header .button:hover {
-				background-color: rgba(255, 255, 255, 0.125);
-			}
-
-			#header input[type="submit"]:active,
-			#header input[type="reset"]:active,
-			#header input[type="button"]:active,
-			#header button:active,
-			#header .button:active {
-				background-color: rgba(255, 255, 255, 0.25);
-			}
 
 			#header input[type="submit"].special,
 			#header input[type="reset"].special,


### PR DESCRIPTION
Logging a user out used to require Javascript to convert a link into a POST request. When the home page was replaced, that magic disappeared, so logging out became broken.

Instead of fixing the Javascript, allow everyone visiting `/logout` to be logged out.