### PR TITLE
[Delivers #95898302] Include attachments in proposal emails

### DIFF
--- a/app/assets/stylesheets/common/communicarts.scss
+++ b/app/assets/stylesheets/common/communicarts.scss
@@ -11,7 +11,7 @@ table {
     margin-top: 15px;
   }
 
-  &.reply-section, &.comments-section {
+  &.reply-section, &.submodel-section {
     width: 800px;
     background-color: #fff;
 
@@ -22,7 +22,7 @@ table {
         width: 155px;
       }
 
-      &.comment-detail {
+      &.submodel-detail {
         border-top: 1px solid #ccc;
       }
     }

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,6 +1,6 @@
 class AttachmentsController < ApplicationController
   before_filter :authenticate_user!
-  before_filter ->{authorize self.proposal, :can_show!}, only: [:create]
+  before_filter ->{authorize self.proposal, :can_show!}, only: [:create, :show]
   before_filter ->{authorize self.attachment}, only: [:destroy]
   rescue_from Pundit::NotAuthorizedError, with: :auth_errors
 
@@ -20,6 +20,10 @@ class AttachmentsController < ApplicationController
     self.attachment.destroy
     flash[:success] = "Deleted attachment"
     redirect_to proposal_path(self.attachment.proposal_id)
+  end
+
+  def show
+    redirect_to self.attachment.url
   end
 
   protected

--- a/app/views/communicart_mailer/_attachments.html.haml
+++ b/app/views/communicart_mailer/_attachments.html.haml
@@ -1,0 +1,17 @@
+- if attachments.any?
+  %table.submodel-section
+    %tr
+      %td.w-container{colspan: '2'}
+        %strong Attachments
+    - attachments.each do |attachment|
+      %tr
+        %td.submodel-detail.first{valign: 'top'}
+          %p
+            = l(attachment.created_at.to_date)
+        %td.submodel-detail{valign: 'top'}
+          %p
+            %strong
+              = attachment.user.full_name
+            %br
+            %a{href: proposal_attachment_url(proposal, attachment)}
+              = attachment.file_file_name

--- a/app/views/communicart_mailer/_comments.html.erb
+++ b/app/views/communicart_mailer/_comments.html.erb
@@ -1,5 +1,5 @@
 <% if comments.any? %>
-  <table class='comments-section'>
+  <table class='submodel-section'>
     <tr>
       <td colspan='2' class='w-container'>
         <strong>Comments</strong>

--- a/app/views/communicart_mailer/approval_reply_received_email.html.erb
+++ b/app/views/communicart_mailer/approval_reply_received_email.html.erb
@@ -18,6 +18,7 @@
       <tr>
         <td>
           <%= render partial: 'comments', locals: { comments: @proposal.comments } %>
+          <%= render partial: 'attachments', locals: { proposal: @proposal, attachments: @proposal.attachments } %>
           <%= client_partial(@proposal.client, 'proposal_mail',
                              locals: {proposal: @proposal, title: "Purchase Request"}) %>
           <%= render partial: 'email_reply', locals: { approval: @approval, show_approval_actions: false } %>

--- a/app/views/communicart_mailer/proposal_notification_email.html.erb
+++ b/app/views/communicart_mailer/proposal_notification_email.html.erb
@@ -12,6 +12,7 @@
 
 <div style="width:800px">
   <%= render partial: 'comments', locals: { comments: @proposal.comments } %>
+  <%= render partial: 'attachments', locals: { proposal: @proposal, attachments: @proposal.attachments } %>
 
   <%= client_partial(@proposal.client, 'proposal_mail',
                      locals: {proposal: @proposal, title: "Purchase Request"}) %>

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -158,7 +158,7 @@
         <div class="line-item">
           <div class="row">
             <p class="col-sm-5 col-xs-12">
-              <a href="<%= attachment.url %>"><%= attachment.file_file_name %></a>
+              <a href="<%= proposal_attachment_path(@proposal, attachment) %>"><%= attachment.file_file_name %></a>
             </p>
             <p class="col-sm-3 col-xs-6">
               <strong><%= attachment.user.full_name %></strong>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ C2::Application.routes.draw do
     end
 
     resources :comments, only: [:index, :create]
-    resources :attachments, only: [:create, :destroy]
+    resources :attachments, only: [:create, :destroy, :show]
   end
 
   namespace :ncr do

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -56,15 +56,32 @@ describe AttachmentsController do
   end
 
   describe '#show' do
-    let (:proposal) { FactoryGirl.create(:proposal, :with_approvers) }
+    let (:proposal) { FactoryGirl.create(:proposal, :with_approvers, :with_observers) }
     let (:attachment) { FactoryGirl.create(:attachment, proposal: proposal, user: proposal.requester) }
-    before do
-      login_as(proposal.requester)
-    end
 
-    it "redirects to the url" do
+    it "allows the requester to view attachment" do
+      login_as(proposal.requester)
       get :show, proposal_id: proposal.id, id: attachment.id
       expect(response).to redirect_to(attachment.url)
+    end
+
+    it "allows the approver to view attachment" do
+      login_as(proposal.approvers[0])
+      get :show, proposal_id: proposal.id, id: attachment.id
+      expect(response).to redirect_to(attachment.url)
+    end
+
+    it "allows the observer to view attachment" do
+      login_as(proposal.observers[0])
+      get :show, proposal_id: proposal.id, id: attachment.id
+      expect(response).to redirect_to(attachment.url)
+    end
+
+    it "does not allow others to view attachment" do
+      login_as(FactoryGirl.create(:user))
+      get :show, proposal_id: proposal.id, id: attachment.id
+      expect(flash[:alert]).to be_present
+      expect(response).to redirect_to(proposals_path)
     end
   end
 end

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -54,4 +54,17 @@ describe AttachmentsController do
       expect(proposal.attachments.count).to eq(0)
     end
   end
+
+  describe '#show' do
+    let (:proposal) { FactoryGirl.create(:proposal, :with_approvers) }
+    let (:attachment) { FactoryGirl.create(:attachment, proposal: proposal, user: proposal.requester) }
+    before do
+      login_as(proposal.requester)
+    end
+
+    it "redirects to the url" do
+      get :show, proposal_id: proposal.id, id: attachment.id
+      expect(response).to redirect_to(attachment.url)
+    end
+  end
 end

--- a/spec/features/attachment_spec.rb
+++ b/spec/features/attachment_spec.rb
@@ -36,33 +36,4 @@ describe "Add attachments" do
     visit proposal_path(proposal)
     expect(page).not_to have_button("Delete")
   end
-
-  context "aws" do
-    before do
-      Paperclip::Attachment.default_options.merge!(
-        bucket: 'my-bucket',
-        s3_credentials: {
-          access_key_id: 'akey',
-          secret_access_key: 'skey'
-        },
-        s3_permissions: :private,
-        storage: :s3,
-      )
-    end
-    after do
-      Paperclip::Attachment.default_options[:storage] = :filesystem
-    end
-
-    # This test may be flaky... -AF 5/20/15
-    it "uses an expiring url with aws" do
-      visit proposal_path(proposal)
-      url = find("#files a")[:href]
-      # TODO parse with Addressable
-      expect(url).to include('my-bucket')
-      expect(url).to include('akey')
-      expect(url).to include('Expires')
-      expect(url).to include('Signature')
-      expect(url).not_to include('skey')
-    end
-  end
 end

--- a/spec/mailers/communicart_mailer_spec.rb
+++ b/spec/mailers/communicart_mailer_spec.rb
@@ -65,6 +65,18 @@ describe CommunicartMailer do
       end
     end
 
+    context 'attachments' do
+      it 'does not render attachments when empty' do
+        expect(proposal.attachments.count).to eq 0
+        expect(body).not_to include('Attachments')
+      end
+
+      it 'renders attachments when present' do
+        FactoryGirl.create(:attachment, proposal: proposal)
+        expect(body).to include('Attachments')
+      end
+    end
+
     context 'custom templates' do
       it 'renders a default template when an origin is not indicated' do
         expect(body).to include('Purchase Request')

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1,0 +1,33 @@
+describe Attachment do
+  let (:proposal) { FactoryGirl.create(:proposal, :with_approvers) }
+  let (:attachment) { FactoryGirl.create(:attachment, proposal: proposal, user: proposal.requester) }
+
+  context "aws" do
+    before do
+      Paperclip::Attachment.default_options.merge!(
+        bucket: 'my-bucket',
+        s3_credentials: {
+          access_key_id: 'akey',
+          secret_access_key: 'skey'
+        },
+        s3_permissions: :private,
+        storage: :s3,
+      )
+    end
+    after do
+      Paperclip::Attachment.default_options[:storage] = :filesystem
+    end
+
+    describe "#url" do
+      it "uses an expiring url with aws" do
+        url = Addressable::URI.parse(attachment.url)
+        query = url.query_values
+        expect(url.host).to eq('my-bucket.s3.amazonaws.com')
+        expect(query).to have_key('AWSAccessKeyId')
+        expect(query['AWSAccessKeyId']).to eq('akey')
+        expect(query).to have_key('Expires')
+        expect(query).to have_key('Signature')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds an endpoint for viewing attachments. This will redirect after performing the appropriate authorization.

Then, in emails, include the attachments as links. Note: the links do _not_ automatically log the user in.

Looks like
![screen shot 2015-06-03 at 12 50 44 pm](https://cloud.githubusercontent.com/assets/326918/7967449/c6efdc28-09ef-11e5-8af0-49ac486acb2b.png)
