### PR TITLE
[Delivers #95888854] Allow Work Orders to be edited post approval

### DIFF
--- a/app/controllers/ncr/work_orders_controller.rb
+++ b/app/controllers/ncr/work_orders_controller.rb
@@ -14,6 +14,9 @@ module Ncr
     end
 
     def edit
+      if self.proposal.approved?
+        flash[:warning] = "You are about to modify a fully approved request. Changes will be logged and sent to approvers but this request will not require re-approval."
+      end
       @approver_email = self.proposal.approvers.first.email_address
       super
     end

--- a/app/controllers/use_case_controller.rb
+++ b/app/controllers/use_case_controller.rb
@@ -43,7 +43,7 @@ class UseCaseController < ApplicationController
 
     if self.errors.empty?
       @model_instance.save
-      flash[:success] = "Proposal resubmitted!"
+      flash[:success] = "Successfully modified!"
       redirect_to proposal_path(@model_instance.proposal)
     else
       flash[:error] = self.errors

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -192,14 +192,4 @@ class Proposal < ActiveRecord::Base
       next_approval.make_actionable!
     end
   end
-
-  def changed_fields comment_text
-    if comment_text.present?
-      self.comments.create(
-        comment_text: comment_text, 
-        update_comment: true, 
-        user_id: self.requester_id
-      )
-    end
-  end
 end

--- a/app/policies/ncr/work_order_policy.rb
+++ b/app/policies/ncr/work_order_policy.rb
@@ -1,0 +1,12 @@
+module Ncr
+  class WorkOrderPolicy < ProposalPolicy
+    def initialize(user, record)
+      super(user, record.proposal)
+      @work_order = record
+    end
+
+    def can_edit!
+      author!
+    end
+  end
+end

--- a/app/policies/ncr/work_order_policy.rb
+++ b/app/policies/ncr/work_order_policy.rb
@@ -8,5 +8,6 @@ module Ncr
     def can_edit!
       author!
     end
+    alias_method :can_update!, :can_edit!
   end
 end

--- a/spec/controllers/ncr/work_orders_controller_spec.rb
+++ b/spec/controllers/ncr/work_orders_controller_spec.rb
@@ -51,7 +51,25 @@ describe Ncr::WorkOrdersController do
     end
   end
 
-  describe 'editing' do
+  describe '#edit' do
+    let (:work_order) { FactoryGirl.create(:ncr_work_order, :with_approvers) }
+    before do
+      login_as(work_order.proposal.requester)
+    end
+
+    it 'does not display a message when the proposal is not fully approved' do
+      get :edit, {id: work_order.id}
+      expect(flash[:warning]).not_to be_present
+    end
+
+    it 'displays a warning message when editing a fully-approved proposal' do
+      work_order.approve!
+      get :edit, {id: work_order.id}
+      expect(flash[:warning]).to be_present
+    end
+  end
+
+  describe '#update' do
     let (:work_order) { FactoryGirl.create(:ncr_work_order, :with_approvers) }
     before do
       login_as(work_order.proposal.requester)

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -170,7 +170,7 @@ describe "National Capital Region proposals" do
       click_on 'Submit for approval'
       expect(current_path).to eq("/proposals/#{ncr_proposal.id}")
       expect(page).to have_content("New ACME")
-      expect(page).to have_content("resubmitted")
+      expect(page).to have_content("modified")
       # Verify it is actually saved
       work_order.reload
       expect(work_order.vendor).to eq("New ACME")

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -216,12 +216,11 @@ describe "National Capital Region proposals" do
       expect(current_path).to eq("/ncr/work_orders/#{work_order.id}/edit")
     end
 
-    it "cannot be edited if approved" do
+    it "can be edited if approved" do
       ncr_proposal.update_attributes(status: 'approved')  # avoid workflow
 
       visit "/ncr/work_orders/#{work_order.id}/edit"
-      expect(current_path).to eq("/ncr/work_orders/new")
-      expect(page).to have_content('already approved')
+      expect(current_path).to eq("/ncr/work_orders/#{work_order.id}/edit")
     end
 
     it "cannot be edited by someone other than the requester" do
@@ -246,11 +245,11 @@ describe "National Capital Region proposals" do
       expect(page).to have_content('Modify Request')
     end
 
-    it "does not show a edit link for an approved cart" do
+    it "shows a edit link for an approved cart" do
       ncr_proposal.update_attribute(:status, 'approved') # avoid state machine
 
       visit "/proposals/#{ncr_proposal.id}"
-      expect(page).not_to have_content('Modify Request')
+      expect(page).to have_content('Modify Request')
     end
 
     it "does not show a edit link for another client" do

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -130,5 +130,16 @@ describe Ncr::WorkOrder do
       comment_text += "_Modified post-approval_"
       expect(comment.comment_text).to eq(comment_text)
     end
+
+    it 'does not add a change comment when nothing has changed' do
+      work_order.touch
+      expect(Comment.count).to be 0
+    end
+
+    it 'does not add a comment when nothing has changed and it is approved' do
+      work_order.approve!
+      work_order.touch
+      expect(Comment.count).to be 0
+    end
   end
 end

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -105,4 +105,30 @@ describe Ncr::WorkOrder do
       expect(work_order).to be_valid
     end
   end
+
+  describe '#record_changes' do
+    let (:work_order) { FactoryGirl.create(:ncr_work_order) }
+
+    it 'adds a change comment' do
+      work_order.update(vendor: 'VenVenVen', amount: 123.45)
+      expect(work_order.proposal.comments.count).to be 1
+      comment = Comment.last
+      expect(comment.update_comment).to be(true)
+      comment_text = "- *Vendor* was changed to VenVenVen\n"
+      comment_text += "- *Amount* was changed to $123.45"
+      expect(comment.comment_text).to eq(comment_text)
+    end
+
+    it 'includes extra information if modified post approval' do
+      work_order.approve!
+      work_order.update(vendor: 'VenVenVen', amount: 123.45)
+      expect(work_order.proposal.comments.count).to be 1
+      comment = Comment.last
+      expect(comment.update_comment).to be(true)
+      comment_text = "- *Vendor* was changed to VenVenVen\n"
+      comment_text += "- *Amount* was changed to $123.45\n"
+      comment_text += "_Modified post-approval_"
+      expect(comment.comment_text).to eq(comment_text)
+    end
+  end
 end


### PR DESCRIPTION
This allows approved work orders to be edited, adds a notice when editing such a work order, and tags edit comments as occurring post approval.

To do that:
* Added a mechanism for Work Orders (or other client-specific models) to override proposal's policies. In this case, this allowed Work Orders to be edited post approval while other client-specific models cannot be
* Adds a line to the "edited" comment noting that this edit took place after the proposal was approved
* Moved "edited" comment logic into Ncr::WorkOrder, as it's quite coupled at the moment

Looks like:
__Edit form__
![screen shot 2015-06-09 at 12 30 17 pm](https://cloud.githubusercontent.com/assets/326918/8064495/0cf299a0-0ea9-11e5-8b0d-123463da7ccf.png)

__Email header__
![screen shot 2015-06-09 at 1 03 23 pm](https://cloud.githubusercontent.com/assets/326918/8064494/0cef8e4a-0ea9-11e5-87f8-3c15719b63b6.png)

__Web interface__
![screen shot 2015-06-09 at 1 02 55 pm](https://cloud.githubusercontent.com/assets/326918/8064496/0cf3cdd4-0ea9-11e5-830a-3009de5bbda0.png)
