### PR TITLE
[Delivers #96626124] eager load the associated models for the WorkOrder API

### DIFF
--- a/app/controllers/api/ncr/work_orders_controller.rb
+++ b/app/controllers/api/ncr/work_orders_controller.rb
@@ -3,7 +3,9 @@ module Api
     class WorkOrdersController < BaseController
       def index
         # TODO use a scope for ordering
-        orders = ::Ncr::WorkOrder.joins(:proposal).order('proposals.created_at DESC')
+        orders = ::Ncr::WorkOrder.
+          includes(proposal: [:requester, approvals: [:user]]).
+          order('proposals.created_at DESC')
 
         if params[:limit]
           orders = orders.limit(params[:limit].to_i)

--- a/app/controllers/api/ncr/work_orders_controller.rb
+++ b/app/controllers/api/ncr/work_orders_controller.rb
@@ -4,6 +4,7 @@ module Api
       def index
         # TODO use a scope for ordering
         orders = ::Ncr::WorkOrder.
+          joins(:proposal).
           includes(proposal: [:requester, approvals: [:user]]).
           order('proposals.created_at DESC')
 


### PR DESCRIPTION
Was noticing a *ton* of SQL queries in the log when loading the NCR form...turns out it was doing a separate database call for every association :grin: This brings it down to a single query. On my local machine, loading http://localhost:3000/api/v1/ncr/work_orders.json with 841 WorkOrders:

**Before**

```
Completed 200 OK in 6391ms (Views: 5853.2ms | ActiveRecord: 535.2ms)
```

**After**

```
Completed 200 OK in 1274ms (Views: 1258.1ms | ActiveRecord: 13.5ms)
```