### PR TITLE
[Delivers #93381468] Add an endpoint for feedback, along with its form

### DIFF
--- a/app/assets/javascripts/filter.js.coffee
+++ b/app/assets/javascripts/filter.js.coffee
@@ -18,9 +18,10 @@ class Filter
 
   filter: ($el) ->
     value = $el.val()
-    checked = $el.is(":checked")
+    if !$el.is(":checked")
+      value = "!" + value
     @$("[data-filter-key=#{ @key }]").each (idx, el) ->
-      hidden = el.getAttribute("data-filter-value") != value || !checked
+      hidden = el.getAttribute("data-filter-value") != value
       el.setAttribute("aria-hidden", hidden.toString())
 
   hideAll: () ->

--- a/app/assets/stylesheets/webapp/ncr.scss
+++ b/app/assets/stylesheets/webapp/ncr.scss
@@ -1,4 +1,4 @@
-.controller-ncr-work_orders {
+.controller-ncr-work_orders, .controller-feedback {
   .content.container {
     max-width: 400px;
   }

--- a/app/assets/stylesheets/webapp/webviews.scss
+++ b/app/assets/stylesheets/webapp/webviews.scss
@@ -404,6 +404,11 @@ body.webapp {
   }
 }
 
+#footer {
+  margin-top: 4em;
+  text-align: center;
+}
+
 @media (max-width: $break-small) {
   tr.cart_item_information p {
     font-size: 67%;

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,5 +1,7 @@
 class FeedbackController < ApplicationController
-  # note that index is rendered implicitly as it's just a template
+  def index
+    @skip_footer = true
+  end
 
   def create
     fields = [:bug, :context, :expected, :actually, :comments, :satisfaction, :referral]

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -2,18 +2,11 @@ class FeedbackController < ApplicationController
   # note that index is rendered implicitly as it's just a template
 
   def create
-    message = []
-    [:bug, :context, :expected, :actually, :comments, :satisfaction, :referral].each do |key|
-      if !params[key].blank?
-        message << "#{key}: #{params[key]}"
-      end
-    end
-    message = message.join("\n")
-    if !message.blank?
-      if current_user
-        message += "\nuser: #{current_user.email_address}"
-      end
-      CommunicartMailer.feedback(message).deliver
+    fields = [:bug, :context, :expected, :actually, :comments, :satisfaction, :referral]
+    fields = fields.select {|key| !params[key].blank?}
+    form_values = fields.map {|key| [key, params[key]]}
+    unless form_values.empty?
+      CommunicartMailer.feedback(current_user, form_values).deliver
     end
   end
 end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -10,5 +10,6 @@ class FeedbackController < ApplicationController
     unless form_values.empty?
       CommunicartMailer.feedback(current_user, form_values).deliver
     end
+    # @todo - redirect somewhere to avoid back/refresh button issues
   end
 end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,0 +1,19 @@
+class FeedbackController < ApplicationController
+  # note that index is rendered implicitly as it's just a template
+
+  def create
+    message = []
+    [:bug, :context, :expected, :actually, :comments, :satisfaction, :referral].each do |key|
+      if !params[key].blank?
+        message << "#{key}: #{params[key]}"
+      end
+    end
+    message = message.join("\n")
+    if !message.blank?
+      if current_user
+        message += "\nuser: #{current_user.email_address}"
+      end
+      CommunicartMailer.feedback(message).deliver
+    end
+  end
+end

--- a/app/mailers/communicart_mailer.rb
+++ b/app/mailers/communicart_mailer.rb
@@ -66,12 +66,15 @@ class CommunicartMailer < ActionMailer::Base
     end
   end
 
-  def feedback(message)
+  def feedback(sending_user, form_values)
+    form_strings = form_values.map { |pair| "#{pair[0]}: #{pair[1]}" }
+    message = form_strings.join("\n")
     mail(
       to: CommunicartMailer.support_email,
       subject: 'Feedback submission',
       from: default_sender_email,
-      body: message
+      body: message,
+      cc: sending_user.try(:email_address)
     )
   end
 

--- a/app/mailers/communicart_mailer.rb
+++ b/app/mailers/communicart_mailer.rb
@@ -66,6 +66,18 @@ class CommunicartMailer < ActionMailer::Base
     end
   end
 
+  def feedback(message)
+    mail(
+      to: CommunicartMailer.support_email,
+      subject: 'Feedback submission',
+      from: default_sender_email,
+      body: message
+    )
+  end
+
+  def self.support_email
+    ENV['SUPPORT_EMAIL'] || 'capdevs@gsa.gov'   # not sensitive, so hard coding
+  end
 
   private
 

--- a/app/views/feedback/create.html.haml
+++ b/app/views/feedback/create.html.haml
@@ -1,0 +1,8 @@
+- content_for :title, "Feedback Submitted"
+.container.content
+  %h3 Feedback Submitted
+  %p
+    Thank you for feedback submission.
+    - if current_user
+      We will reach out to you if we need additional details.
+  %p Please remember to close this window.

--- a/app/views/feedback/index.html.haml
+++ b/app/views/feedback/index.html.haml
@@ -1,0 +1,46 @@
+- content_for :title, "Feedback"
+.container.content
+  %h3 Feedback
+  = form_tag do
+    %p
+      Thank you for helping us improve Communicart! All of the following
+      fields are optional, but the more information you provide, the better we
+      will be able to address it.
+    %p
+      Your feedback will be sent to our developers and project managers via
+      e-mail. Do not include any sensitive or private information.
+
+    %hr
+
+    .form-group
+      = label_tag :bug do
+        = check_box_tag(:bug, "yes", false, "data-filter-control" => 'is-bug')
+        I found a bug
+
+    %div{'data-filter-key' => 'is-bug', 'data-filter-value' => 'yes'}
+      %p We're very sorry to hear that. Please tell us a bit more so we can fix it.
+      .form-group
+        = label_tag :context, "What you were doing when you found the bug?"
+        = text_area_tag :context, nil, class: 'form-control'
+
+      .form-group
+        = label_tag :expected, "What did you expect to happen?"
+        = text_area_tag :expected, nil, class: 'form-control'
+
+      .form-group
+        = label_tag :actually, "What actually happened?"
+        = text_area_tag :actually, nil, class: 'form-control'
+
+    .form-group
+      = label_tag :comments, "General comments"
+      = text_area_tag :comments, nil, class: 'form-control'
+
+    %p Please rate your overall satisfaction with this tool
+    .form-group
+      = label_tag :satisfaction, "Satisfaction Rating (1 low, 5 high)"
+      = select_tag :satisfaction, options_for_select([""] + (1..5).map(&:to_s)), class: 'form-control'
+
+    = hidden_field_tag(:referral, request.referrer)
+
+    .form-group
+      = submit_tag("Submit", class: 'form-control')

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -95,3 +95,6 @@
         %li
           Design:
           %a{href: "http://html5up.net"} HTML5 UP
+      %p
+        Find a bug, have a recommendation, or want to provide other feedback? We'd love to
+        %a{href: feedback_path} hear from you!

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -97,4 +97,4 @@
           %a{href: "http://html5up.net"} HTML5 UP
       %p
         Find a bug, have a recommendation, or want to provide other feedback? We'd love to
-        %a{href: feedback_path} hear from you!
+        %a{href: feedback_path, target: "_blank"} hear from you!

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,5 +23,11 @@
 
 <%= yield %>
 
+<%- unless @skip_footer %>
+  <div id="footer" class="inset">
+    <p>Find a bug, have a recommendation, or want to provide other feedback? We'd love to <a href="<%= feedback_path %>">hear from you!</a></p>
+  </div>
+<%- end %>
+
 </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
 
 <%- unless @skip_footer %>
   <div id="footer" class="inset">
-    <p>Find a bug, have a recommendation, or want to provide other feedback? We'd love to <a href="<%= feedback_path %>">hear from you!</a></p>
+    <p>Find a bug, have a recommendation, or want to provide other feedback? We'd love to <a target="_blank" href="<%= feedback_path %>">hear from you!</a></p>
   </div>
 <%- end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ C2::Application.routes.draw do
   match "/auth/:provider/callback" => "home#oauth_callback", via: [:get]
   get '/error' => 'home#error'
   post "/logout" => "home#logout"
+  get '/feedback' => 'feedback#index'
+  post '/feedback' => 'feedback#create'
 
   namespace :api do
     scope :v1 do

--- a/public/404.html
+++ b/public/404.html
@@ -53,6 +53,6 @@
     <h1>The page you were looking for doesn't exist.</h1>
     <p>You may have mistyped the address or the page may have moved.</p>
   </div>
-  <p>If you are the application owner check the logs for more information.</p>
+  <p>If you weren't expecting this, <a href="/feedback" target="_blank">let us know</a>.</p>
 </body>
 </html>

--- a/public/422.html
+++ b/public/422.html
@@ -53,6 +53,6 @@
     <h1>The change you wanted was rejected.</h1>
     <p>Maybe you tried to change something you didn't have access to.</p>
   </div>
-  <p>If you are the application owner check the logs for more information.</p>
+  <p>If you weren't expecting this, <a href="/feedback" target="_blank">let us know</a>.</p>
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -52,6 +52,12 @@
   <div class="dialog">
     <h1>We're sorry, but something went wrong.</h1>
   </div>
-  <p>If you are the application owner check the logs for more information.</p>
+  <!-- What were you doing when you found the bug?
+
+       What did you expect to happen?
+  -->
+  <p>Please <a target="_blank"
+    href="mailto:capdevs@gsa.gov?subject=I+got+a+500&body=What+were+you+doing+when+you+found+the+bug%3F%0A%0AWhat+did+you+expect+to+happen%3F">email</a> us
+  so that we can fix the problem. </p>
 </body>
 </html>

--- a/spec/controllers/feedback_controller_spec.rb
+++ b/spec/controllers/feedback_controller_spec.rb
@@ -15,6 +15,7 @@ describe FeedbackController do
         ["bug: Yes", "context: Some context here", "expected: it to work",
          "actually: it did not", "comments: Comments here", "satisfaction: 4",
          "referral: /somewhere/else"].join("\n"))
+      expect(deliveries[0].cc).to eq([])
     end
 
     it "doesn't include extra fields" do
@@ -31,7 +32,8 @@ describe FeedbackController do
       user = FactoryGirl.create(:user, email_address: "actor@example.com")
       login_as(user)
       post :create, {bug: "Yes"}
-      expect(deliveries[0].body.to_s).to eq("bug: Yes\nuser: actor@example.com")
+      expect(deliveries[0].body.to_s).to eq("bug: Yes")
+      expect(deliveries[0].cc).to eq(["actor@example.com"])
     end
   end
 end

--- a/spec/controllers/feedback_controller_spec.rb
+++ b/spec/controllers/feedback_controller_spec.rb
@@ -1,0 +1,37 @@
+describe FeedbackController do
+  describe '#create' do
+    it 'sends an email when feedback is submitted' do
+      post :create, {
+        bug: 'Yes',
+        context: 'Some context here',
+        expected: 'it to work', 
+        actually: 'it did not',
+        comments: 'Comments here',
+        satisfaction: '4',
+        referral: '/somewhere/else'
+      }
+      expect(deliveries.count).to be(1)
+      expect(deliveries[0].body.to_s).to eq(
+        ["bug: Yes", "context: Some context here", "expected: it to work",
+         "actually: it did not", "comments: Comments here", "satisfaction: 4",
+         "referral: /somewhere/else"].join("\n"))
+    end
+
+    it "doesn't include extra fields" do
+      post :create, {bug: 'Yes', bogus: 'Field'}
+      expect(deliveries[0].body.to_s).to eq("bug: Yes")
+    end
+
+    it "doesn't include blank fields" do
+      post :create, {comments: "    ", actually: 'ACT'}
+      expect(deliveries[0].body.to_s).to eq("actually: ACT")
+    end
+
+    it "includes user if signed in" do
+      user = FactoryGirl.create(:user, email_address: "actor@example.com")
+      login_as(user)
+      post :create, {bug: "Yes"}
+      expect(deliveries[0].body.to_s).to eq("bug: Yes\nuser: actor@example.com")
+    end
+  end
+end

--- a/spec/features/return_to_spec.rb
+++ b/spec/features/return_to_spec.rb
@@ -22,15 +22,15 @@ describe "the return_to url option" do
   end
 
   it 'send back to main if not a validat sig (name)' do
-    different_name = return_to.merge(name: 'other')
+    different_name = return_to.merge(name: 'other-key-here')
     visit query_proposals_path(return_to: different_name)
     expect(page).to have_content('Back to main portal')
     expect(page).not_to have_content(return_to[:name])
-    expect(page).not_to have_content('other')
+    expect(page).not_to have_content('other-key-here')
   end
 
   it 'send back to main if not a validat sig (name)' do
-    different_path = return_to.merge(path: 'other')
+    different_path = return_to.merge(path: 'other-key-here')
     visit query_proposals_path(return_to: different_path)
     expect(page).to have_content('Back to main portal')
     expect(page).not_to have_content(return_to[:name])


### PR DESCRIPTION
Also tweaks the logic around js filters to allow for logic when an option is _not_ selected. There are currently no links to this form.

## initial form
![screen shot 2015-06-11 at 5 39 57 pm](https://cloud.githubusercontent.com/assets/326918/8119459/9ab41bae-1063-11e5-8aea-f795c0ad305a.png)

## is a bug
![screen shot 2015-06-11 at 5 40 08 pm](https://cloud.githubusercontent.com/assets/326918/8119461/9ab7d3fc-1063-11e5-9b08-bf66507b4334.png)

## submitted (not logged in)
![screen shot 2015-06-11 at 5 40 29 pm](https://cloud.githubusercontent.com/assets/326918/8119458/9ab3c6d6-1063-11e5-8fe8-4db8eb23474c.png)

## submitted (logged in)
![screen shot 2015-06-11 at 5 41 00 pm](https://cloud.githubusercontent.com/assets/326918/8119460/9ab4ab00-1063-11e5-9417-c4ef3961a3a7.png)

## email
![screen shot 2015-06-11 at 5 41 37 pm](https://cloud.githubusercontent.com/assets/326918/8119457/9ab34030-1063-11e5-921e-a33c008b7393.png)