### PR TITLE
[Delivers #96691408] make #name present for all Proposals

### DIFF
--- a/app/models/gsa18f/procurement.rb
+++ b/app/models/gsa18f/procurement.rb
@@ -58,11 +58,6 @@ module Gsa18f
       "gsa18f"
     end
 
-    # @todo - this is pretty ugly
-    def public_identifier
-      "##{self.proposal.id}"
-    end
-
     def total_price
       (self.cost_per_unit * self.quantity) || 0.0
     end

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -30,6 +30,7 @@ module Ncr
       less_than_or_equal_to: 3000
     }
     validates :expense_type, inclusion: {in: EXPENSE_TYPES}, presence: true
+    validates :project_title, presence: true
     validates :vendor, presence: true
     validates :building_number, presence: true
     validates :rwa_number, format: {

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -39,8 +39,7 @@ class Proposal < ActiveRecord::Base
   # :public_identifier
   # :version
   # Note: clients should also implement :version
-  delegate :client, :name,
-           to: :client_data_legacy, allow_nil: true
+  delegate :client, to: :client_data_legacy, allow_nil: true
 
   validates :flow, presence: true, inclusion: {in: ApprovalGroup::FLOWS}
   # TODO validates :requester_id, presence: true
@@ -148,8 +147,17 @@ class Proposal < ActiveRecord::Base
     end
   end
 
+
+  ## delegated methods ##
+
   def public_identifier
     self.delegate_with_default(:public_identifier) { "##{self.id}" }
+  end
+
+  def name
+    self.delegate_with_default(:name) {
+      "Request #{self.public_identifier}"
+    }
   end
 
   def fields_for_display
@@ -165,6 +173,8 @@ class Proposal < ActiveRecord::Base
       self.client_data_legacy.try(:version)
     ].compact.max
   end
+
+  #######################
 
 
   #### state machine methods ####

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -136,14 +136,18 @@ class Proposal < ActiveRecord::Base
   # TODO refactor to class method in a module
   def delegate_with_default(method)
     data = self.client_data_legacy
+
+    result = nil
     if data && data.respond_to?(method)
-      data.public_send(method)
+      result = data.public_send(method)
+    end
+
+    if result.present?
+      result
+    elsif block_given?
+      yield
     else
-      if block_given?
-        yield
-      else
-        nil
-      end
+      result
     end
   end
 

--- a/app/views/navigator/_proposal_mail.html.erb
+++ b/app/views/navigator/_proposal_mail.html.erb
@@ -39,7 +39,7 @@
           <tr class="cart_item_information">
             <!-- Product -->
             <td class="first" valign="top">
-              <%= proposal.try(:name) %>
+              <%= proposal.name %>
             </td>
             <td class="first" valign="top">
               <%= (cart.properties.detect{|p| p.property == 'contractingVehicle'}.try(:value) || "") %>

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -57,6 +57,14 @@ describe "National Capital Region proposals" do
         proposal.approvers.first.email_address)
     end
 
+    it "requires a project_title" do
+      visit '/ncr/work_orders/new'
+      expect {
+        click_on 'Submit for approval'
+      }.to_not change { Proposal.count }
+      expect(page).to have_content("Project title can't be blank")
+    end
+
     with_feature 'HIDE_BA61_OPTION' do
       it "removes the radio button" do
         visit '/ncr/work_orders/new'

--- a/spec/features/proposal_listing_spec.rb
+++ b/spec/features/proposal_listing_spec.rb
@@ -19,7 +19,7 @@ describe "Listing Page" do
     visit '/proposals'
     expect(page).to have_content(default.public_identifier)
     expect(page).to have_content(ncr.public_identifier)
-    expect(page).to have_content(gsa18f.public_identifier)
+    expect(page).to have_content(gsa18f.proposal.public_identifier)
   end
 
   it "should not explode if client is ncr" do
@@ -27,7 +27,7 @@ describe "Listing Page" do
     visit '/proposals'
     expect(page).to have_content(default.public_identifier)
     expect(page).to have_content(ncr.public_identifier)
-    expect(page).to have_content(gsa18f.public_identifier)
+    expect(page).to have_content(gsa18f.proposal.public_identifier)
   end
 
   it "should not explode if client is gsa18f" do
@@ -35,6 +35,6 @@ describe "Listing Page" do
     visit '/proposals'
     expect(page).to have_content(default.public_identifier)
     expect(page).to have_content(ncr.public_identifier)
-    expect(page).to have_content(gsa18f.public_identifier)
+    expect(page).to have_content(gsa18f.proposal.public_identifier)
   end
 end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -22,16 +22,36 @@ describe Proposal do
     end
   end
 
-  describe '#name' do
-    it "gives the delegated #name from the client_data" do
+  describe '#delegate_with_default' do
+    it "returns the delegated value" do
       proposal = Proposal.new
-      client = double(name: 'foo')
-      expect(proposal).to receive(:client_data).and_return(client)
+      client_data = double(some_prop: 'foo')
+      expect(proposal).to receive(:client_data).and_return(client_data)
 
-      expect(proposal.name).to eq('foo')
+      result = proposal.delegate_with_default(:some_prop)
+      expect(result).to eq('foo')
     end
 
-    it "gives the #public_identifier by default" do
+    it "returns the default when the delegated value is #blank?" do
+      proposal = Proposal.new
+      client_data = double(some_prop: '')
+      expect(proposal).to receive(:client_data).and_return(client_data)
+
+      result = proposal.delegate_with_default(:some_prop) { 'foo' }
+      expect(result).to eq('foo')
+    end
+
+    it "returns the default when there is no method on the delegate" do
+      proposal = Proposal.new
+      expect(proposal).to receive(:client_data).and_return(double)
+
+      result = proposal.delegate_with_default(:some_prop) { 'foo' }
+      expect(result).to eq('foo')
+    end
+  end
+
+  describe '#name' do
+    it "returns the #public_identifier by default" do
       proposal = Proposal.new
       expect(proposal).to receive(:id).and_return(6)
 

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -22,6 +22,23 @@ describe Proposal do
     end
   end
 
+  describe '#name' do
+    it "gives the delegated #name from the client_data" do
+      proposal = Proposal.new
+      client = double(name: 'foo')
+      expect(proposal).to receive(:client_data).and_return(client)
+
+      expect(proposal.name).to eq('foo')
+    end
+
+    it "gives the #public_identifier by default" do
+      proposal = Proposal.new
+      expect(proposal).to receive(:id).and_return(6)
+
+      expect(proposal.name).to eq('Request #6')
+    end
+  end
+
   describe '#users' do
     it "returns all approvers, observers, and the requester" do
       requester = FactoryGirl.create(


### PR DESCRIPTION
Also make `WorkOrder#project_title` required. I know it wasn't in this sprint, but I had some time on the train and it was the easiest story to do offline :smile_cat: 