### PR TITLE
[Delivers #93381468] Add link to feedback in mail messages

### DIFF
--- a/app/views/communicart_mailer/approval_reply_received_email.html.erb
+++ b/app/views/communicart_mailer/approval_reply_received_email.html.erb
@@ -1,4 +1,3 @@
-<body class="communicart-notification">
     <table class='reply-section'>
       <%- if @alert_partial %>
         <%= client_partial(@proposal.client, 'email_header/' + @alert_partial.to_s) %>
@@ -25,5 +24,3 @@
         </td>
       </tr>
     </table>
-
-</body>

--- a/app/views/communicart_mailer/comment_added_email.html.erb
+++ b/app/views/communicart_mailer/comment_added_email.html.erb
@@ -1,4 +1,3 @@
-<body class="communicart-notification">
   <table class="w-container main-container" width='800'>
     <% proposal = @comment.proposal %>
     <tr><td class="w-container html-email-message">
@@ -15,4 +14,3 @@
       <%= link_to "View / Update Request", proposal_url(proposal, anchor: 'comments'), {class: 'form-button', target: 'C2'} %>
     </td></tr>
   </table>
-</body>

--- a/app/views/communicart_mailer/proposal_created_confirmation.html.erb
+++ b/app/views/communicart_mailer/proposal_created_confirmation.html.erb
@@ -1,4 +1,3 @@
-<body class="communicart-notification">
   <div>
     Hi <%= @proposal.requester.full_name %>,<br/>
     You just submitted a request for approval. Here is are details about your request:
@@ -7,4 +6,3 @@
   <%= render partial: 'attachments', locals: { proposal: @proposal, attachments: @proposal.attachments } %>
   <%= client_partial(@proposal.client, 'proposal_mail',
                      locals: {proposal: @proposal, title: "Purchase Request"}) %>
-</body>

--- a/app/views/communicart_mailer/proposal_notification_email.html.erb
+++ b/app/views/communicart_mailer/proposal_notification_email.html.erb
@@ -1,4 +1,3 @@
-<body class="communicart-notification">
   <table class='reply-section'>
     <%= client_partial(@proposal.client, 'email_header/' + @alert_partial.to_s) %>
     <tr>
@@ -20,4 +19,3 @@
   <%= render partial: 'email_reply', locals: { approval: @approval, show_approval_actions: @show_approval_actions } %>
 
 </div>
-</body>

--- a/app/views/communicart_mailer/proposal_observer_email.html.erb
+++ b/app/views/communicart_mailer/proposal_observer_email.html.erb
@@ -1,4 +1,2 @@
-<body class="communicart-notification">
   <%= client_partial(@proposal.client, 'proposal_mail',
                      locals: {proposal: @proposal, title: "Purchase Request"}) %>
-</body>

--- a/app/views/layouts/communicart_mailer.html.erb
+++ b/app/views/layouts/communicart_mailer.html.erb
@@ -6,5 +6,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" type="text/css" href="<%= stylesheet_url('common/communicarts.css') %>">
 </head>
+<body class="communicart-notification">
   <%= yield %>
+  <hr>
+  <div id="footer" class="inset">
+    <p>Find a bug, have a recommendation, or want to provide other feedback? We'd love to <a target="_blank" href="<%= feedback_url %>">hear from you!</a></p>
+  </div>
+</body>
 </html>


### PR DESCRIPTION
Also moves the `body` tag into the containing template.