### PR TITLE
[Delivers #97070798] add budget-related fields to work order form

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -379,3 +379,6 @@ DEPENDENCIES
   turnip
   uglifier
   workflow
+
+BUNDLED WITH
+   1.10.3

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -70,7 +70,7 @@ module Ncr
     # split these into different models
     def self.relevant_fields(expense_type)
       fields = [:description, :amount, :expense_type, :vendor, :not_to_exceed,
-                :building_number, :org_code, :direct_pay]
+                :building_number, :org_code, :direct_pay, :cl_number, :function_code, :soc_code]
       case expense_type
       when 'BA61'
         fields << :emergency

--- a/app/views/ncr/work_orders/form.html.erb
+++ b/app/views/ncr/work_orders/form.html.erb
@@ -116,7 +116,7 @@
       </div>
     <% else %>
       <div class="form-group">
-        <%= f.label :cl_number, 'CL number' %>
+        <%= f.label :cl_number %>
         <%= f.text_field :cl_number, class: 'form-control' %>
       </div>
       <div class="form-group">
@@ -124,7 +124,7 @@
         <%= f.text_field :function_code, class: 'form-control' %>
       </div>
       <div class="form-group">
-        <%= f.label :soc_code, 'SOC code' %>
+        <%= f.label :soc_code %>
         <%= f.text_field :soc_code, class: 'form-control' %>
       </div>
     <% end %>

--- a/app/views/ncr/work_orders/form.html.erb
+++ b/app/views/ncr/work_orders/form.html.erb
@@ -114,7 +114,7 @@
           </ul>
         <%- end %>
       </div>
-    <% elsif @model_instance.approved? %>
+    <% else %>
       <div class="form-group">
         <%= f.label :cl_number, 'CL number' %>
         <%= f.text_field :cl_number, class: 'form-control' %>

--- a/app/views/ncr/work_orders/form.html.erb
+++ b/app/views/ncr/work_orders/form.html.erb
@@ -98,7 +98,7 @@
       <% end %>
     </div>
     <div class="form-group">
-      <%= label_tag :approver_email, "Approving Official's Email Address" %>
+      <%= label_tag :approver_email, "Approving official's email address" %>
       <%= email_field_tag :approver_email, @approver_email,
                           class: 'form-control js-selectize',
                           disabled: approver_email_frozen?,
@@ -113,6 +113,19 @@
           <%- end %>
           </ul>
         <%- end %>
+      </div>
+    <% elsif @model_instance.approved? %>
+      <div class="form-group">
+        <%= f.label :cl_number, 'CL number' %>
+        <%= f.text_field :cl_number, class: 'form-control' %>
+      </div>
+      <div class="form-group">
+        <%= f.label :function_code %>
+        <%= f.text_field :function_code, class: 'form-control' %>
+      </div>
+      <div class="form-group">
+        <%= f.label :soc_code, 'SOC code' %>
+        <%= f.text_field :soc_code, class: 'form-control' %>
       </div>
     <% end %>
     <%= f.submit "Submit for approval", class: 'btn btn-default' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,14 +26,10 @@ en:
   time:
     formats:
       default: "%b %-d, %Y at %I:%M%p %Z"
-  helpers:
-    label:
-      ncr/proposal:
-        rwa_number: "RWA Number"
-      cart:
-        rwa_number: "RWA Number"
   activerecord:
     attributes:
       ncr/work_order:
-        rwa_number: "RWA Number"
+        cl_number: "CL number"
         code: "Work Order / Maximo Ticket Number"
+        rwa_number: "RWA Number"
+        soc_code: "SOC code"

--- a/db/migrate/20150620004844_add_billing_fields_to_work_orders.rb
+++ b/db/migrate/20150620004844_add_billing_fields_to_work_orders.rb
@@ -1,0 +1,9 @@
+class AddBillingFieldsToWorkOrders < ActiveRecord::Migration
+  def change
+    change_table :ncr_work_orders do |t|
+      t.string :cl_number
+      t.string :function_code
+      t.string :soc_code
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -143,7 +143,7 @@ ActiveRecord::Schema.define(version: 20150620004844) do
     t.integer  "client_data_id"
     t.string   "client_data_type"
     t.integer  "requester_id"
-    t.string   "public_id"
+    t.string   "public_id",        limit: nil
   end
 
   add_index "proposals", ["client_data_id", "client_data_type"], name: "index_proposals_on_client_data_id_and_client_data_type", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150618193310) do
+ActiveRecord::Schema.define(version: 20150620004844) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -116,6 +116,9 @@ ActiveRecord::Schema.define(version: 20150618193310) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "direct_pay"
+    t.string   "cl_number"
+    t.string   "function_code"
+    t.string   "soc_code"
   end
 
   create_table "observations", force: true do |t|

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -1,89 +1,30 @@
 describe "National Capital Region proposals" do
-  it "requires sign-in" do
-    visit '/ncr/work_orders/new'
-    expect(current_path).to eq('/')
-    expect(page).to have_content("You need to sign in")
-  end
-
-  context "when signed in as the requester" do
-    let(:requester) { FactoryGirl.create(:user) }
-
-    before do
-      login_as(requester)
-    end
-
-    it "saves a Proposal with the attributes" do
-      expect(Dispatcher).to receive(:deliver_new_proposal_emails)
-
+  describe "creating a work order" do
+    it "requires sign-in" do
       visit '/ncr/work_orders/new'
-      fill_in 'Project title', with: "buying stuff"
-      fill_in 'Description', with: "desc content"
-      choose 'BA80'
-      fill_in 'RWA Number', with: 'F1234567'
-      fill_in 'Vendor', with: 'ACME'
-      fill_in 'Amount', with: 123.45
-      check "I am going to be using direct pay for this transaction"
-      fill_in "Approving Official's Email Address", with: 'approver@example.com'
-      select Ncr::BUILDING_NUMBERS[0], :from => 'ncr_work_order_building_number'
-      select Ncr::Organization.all[0], :from => 'ncr_work_order_org_code'
-      expect {
-        click_on 'Submit for approval'
-      }.to change { Proposal.count }.from(0).to(1)
-
-      proposal = Proposal.last
-      expect(proposal.public_id).to have_content("FY")
-      expect(page).to have_content("Proposal submitted")
-      expect(current_path).to eq("/proposals/#{proposal.id}")
-
-      expect(proposal.name).to eq("buying stuff")
-      expect(proposal.flow).to eq('linear')
-      work_order = proposal.client_data
-      expect(work_order.client).to eq('ncr')
-      expect(work_order.expense_type).to eq('BA80')
-      expect(work_order.vendor).to eq('ACME')
-      expect(work_order.amount).to eq(123.45)
-      expect(work_order.direct_pay).to eq(true)
-      expect(work_order.building_number).to eq(Ncr::BUILDING_NUMBERS[0])
-      expect(work_order.org_code).to eq(Ncr::Organization.all[0].to_s)
-      expect(work_order.description).to eq('desc content')
-      expect(proposal.requester).to eq(requester)
-      expect(proposal.approvers.map(&:email_address)).to eq(%w(
-        approver@example.com
-        communicart.budget.approver@gmail.com
-      ))
+      expect(current_path).to eq('/')
+      expect(page).to have_content("You need to sign in")
     end
 
-    it "defaults to the approver from the last request" do
-      proposal = FactoryGirl.create(:proposal, :with_approvers,
-                                    requester: requester)
-      visit '/ncr/work_orders/new'
-      expect(find_field("Approving Official's Email Address").value).to eq(
-        proposal.approvers.first.email_address)
-    end
+    context "when signed in as the requester" do
+      let(:requester) { FactoryGirl.create(:user) }
 
-    it "requires a project_title" do
-      visit '/ncr/work_orders/new'
-      expect {
-        click_on 'Submit for approval'
-      }.to_not change { Proposal.count }
-      expect(page).to have_content("Project title can't be blank")
-    end
-
-    with_feature 'HIDE_BA61_OPTION' do
-      it "removes the radio button" do
-        visit '/ncr/work_orders/new'
-        expect(page).to_not have_content('BA61')
+      before do
+        login_as(requester)
       end
 
-      it "defaults to BA80" do
+      it "saves a Proposal with the attributes" do
+        expect(Dispatcher).to receive(:deliver_new_proposal_emails)
+
         visit '/ncr/work_orders/new'
         fill_in 'Project title', with: "buying stuff"
         fill_in 'Description', with: "desc content"
-        # no need to select BA80
+        choose 'BA80'
         fill_in 'RWA Number', with: 'F1234567'
         fill_in 'Vendor', with: 'ACME'
         fill_in 'Amount', with: 123.45
-        fill_in "Approving Official's Email Address", with: 'approver@example.com'
+        check "I am going to be using direct pay for this transaction"
+        fill_in "Approving official's email address", with: 'approver@example.com'
         select Ncr::BUILDING_NUMBERS[0], :from => 'ncr_work_order_building_number'
         select Ncr::Organization.all[0], :from => 'ncr_work_order_org_code'
         expect {
@@ -91,237 +32,326 @@ describe "National Capital Region proposals" do
         }.to change { Proposal.count }.from(0).to(1)
 
         proposal = Proposal.last
-        expect(proposal.client_data.expense_type).to eq('BA80')
+        expect(proposal.public_id).to have_content("FY")
+        expect(page).to have_content("Proposal submitted")
+        expect(current_path).to eq("/proposals/#{proposal.id}")
+
+        expect(proposal.name).to eq("buying stuff")
+        expect(proposal.flow).to eq('linear')
+        work_order = proposal.client_data
+        expect(work_order.client).to eq('ncr')
+        expect(work_order.expense_type).to eq('BA80')
+        expect(work_order.vendor).to eq('ACME')
+        expect(work_order.amount).to eq(123.45)
+        expect(work_order.direct_pay).to eq(true)
+        expect(work_order.building_number).to eq(Ncr::BUILDING_NUMBERS[0])
+        expect(work_order.org_code).to eq(Ncr::Organization.all[0].to_s)
+        expect(work_order.description).to eq('desc content')
+        expect(proposal.requester).to eq(requester)
+        expect(proposal.approvers.map(&:email_address)).to eq(%w(
+          approver@example.com
+          communicart.budget.approver@gmail.com
+        ))
       end
-    end
 
-    it "doesn't save when the amount is too high" do
-      visit '/ncr/work_orders/new'
-      fill_in 'Project title', with: "buying stuff"
-      choose 'BA80'
-      fill_in 'Vendor', with: 'ACME'
-      fill_in 'Amount', with: 10_000
-
-      expect {
-        click_on 'Submit for approval'
-      }.to_not change { Proposal.count }
-
-      expect(current_path).to eq('/ncr/work_orders')
-      expect(page).to have_content("Amount must be less than or equal to $3,000")
-      # keeps the form values
-      expect(find_field('Amount').value).to eq('10000')
-    end
-
-    it "includes has overwritten field names" do
-      visit '/ncr/work_orders/new'
-      fill_in 'Project title', with: "buying stuff"
-      choose 'BA80'
-      fill_in 'RWA Number', with: 'B9876543'
-      fill_in 'Vendor', with: 'ACME'
-      fill_in 'Amount', with: 123.45
-      fill_in "Approving Official's Email Address", with: 'approver@example.com'
-      select Ncr::BUILDING_NUMBERS[0], :from => 'ncr_work_order_building_number'
-      select Ncr::Organization.all[0], :from => 'ncr_work_order_org_code'
-      click_on 'Submit for approval'
-      expect(current_path).to eq("/proposals/#{Proposal.last.id}")
-      expect(page).to have_content("RWA Number")
-    end
-
-    it "hides fields based on expense", js: true do
-      visit '/ncr/work_orders/new'
-      expect(page).to have_no_field("RWA Number")
-      expect(page).to have_no_field("Work Order")
-      expect(page).to have_no_field("emergency")
-      choose 'BA61'
-      expect(page).to have_no_field("RWA Number")
-      expect(page).to have_no_field("Work Order")
-      expect(page).to have_field("emergency")
-      expect(find_field("emergency", visible: false)).to be_visible
-      choose 'BA80'
-      expect(page).to have_field("RWA Number")
-      expect(page).to have_field("Work Order")
-      expect(page).to have_no_field("emergency")
-      expect(find_field("RWA Number")).to be_visible
-    end
-
-    it "allows attachments to be added during intake without JS" do
-      visit '/ncr/work_orders/new'
-      expect(page).to have_content("Attachments")
-      expect(page).not_to have_selector(".js-am-minus")
-      expect(page).not_to have_selector(".js-am-plus")
-      expect(page).to have_selector("input[type=file]", count: 10)
-    end
-
-    it "allows attachments to be added during intake with JS", :js => true do
-      visit '/ncr/work_orders/new'
-      expect(page).to have_content("Attachments")
-      first_minus = find(".js-am-minus")
-      first_plus = find(".js-am-plus")
-      expect(first_minus).to be_visible
-      expect(first_plus).to be_visible
-      expect(first_minus).to be_disabled
-      expect(find("input[type=file]")[:name]).to eq("attachments[]")
-      first_plus.click    # Adds one row
-      expect(page).to have_selector(".js-am-minus", count: 2)
-      expect(page).to have_selector(".js-am-plus", count: 2)
-      expect(page).to have_selector("input[type=file]", count: 2)
-    end
-
-    let (:work_order) {
-      wo = FactoryGirl.create(:ncr_work_order, requester: requester)
-      wo.add_approvals('approver@example.com')
-      wo
-    }
-    let(:ncr_proposal) {
-      work_order.proposal
-    }
-    it "can be edited if pending" do
-      visit "/ncr/work_orders/#{work_order.id}/edit"
-      expect(find_field("ncr_work_order_building_number").value).to eq(
-        Ncr::BUILDING_NUMBERS[0])
-      fill_in 'Vendor', with: 'New ACME'
-      click_on 'Submit for approval'
-      expect(current_path).to eq("/proposals/#{ncr_proposal.id}")
-      expect(page).to have_content("New ACME")
-      expect(page).to have_content("modified")
-      # Verify it is actually saved
-      work_order.reload
-      expect(work_order.vendor).to eq("New ACME")
-    end
-
-    it "creates a special comment when editing" do
-      visit "/ncr/work_orders/#{work_order.id}/edit"
-      fill_in 'Vendor', with: "New Test Vendor"
-      fill_in 'Description', with: "New Description"
-      click_on 'Submit for approval'
-
-      expect(page).to have_content("Request modified by")
-      expect(page).to have_content("Description was changed to New Description")
-      expect(page).to have_content("Vendor was changed to New Test Vendor")
-    end
-
-    it "has 'Discard Changes' link" do
-      visit "/ncr/work_orders/#{work_order.id}/edit"
-      expect(page).to have_content("Discard Changes")
-      click_on "Discard Changes"
-      expect(current_path).to eq("/proposals/#{work_order.proposal.id}")
-    end
-
-    it "has a disabled field if first approval is done" do
-      visit "/ncr/work_orders/#{work_order.id}/edit"
-      expect(find("[name=approver_email]")["disabled"]).to be_nil
-      work_order.approvals.first.approve!
-      visit "/ncr/work_orders/#{work_order.id}/edit"
-      expect(find("[name=approver_email]")["disabled"]).to eq("disabled")
-      # And we can still submit
-      fill_in 'Vendor', with: 'New ACME'
-      click_on 'Submit for approval'
-      expect(current_path).to eq("/proposals/#{ncr_proposal.id}")
-      # Verify it is actually saved
-      work_order.reload
-      expect(work_order.vendor).to eq("New ACME")
-    end
-
-    it "can be edited if rejected" do
-      ncr_proposal.update_attributes(status: 'rejected')  # avoid workflow
-
-      visit "/ncr/work_orders/#{work_order.id}/edit"
-      expect(current_path).to eq("/ncr/work_orders/#{work_order.id}/edit")
-    end
-
-    it "can be edited if approved" do
-      ncr_proposal.update_attributes(status: 'approved')  # avoid workflow
-
-      visit "/ncr/work_orders/#{work_order.id}/edit"
-      expect(current_path).to eq("/ncr/work_orders/#{work_order.id}/edit")
-    end
-
-    it "cannot be edited by someone other than the requester" do
-      ncr_proposal.set_requester(FactoryGirl.create(:user))
-
-      visit "/ncr/work_orders/#{work_order.id}/edit"
-      expect(current_path).to eq("/ncr/work_orders/new")
-      expect(page).to have_content('not the requester')
-    end
-
-    it "shows a edit link from a pending cart" do
-      visit "/proposals/#{ncr_proposal.id}"
-      expect(page).to have_content('Modify Request')
-      click_on('Modify Request')
-      expect(current_path).to eq("/ncr/work_orders/#{work_order.id}/edit")
-    end
-
-    it "shows a edit link from a rejected cart" do
-      ncr_proposal.update_attribute(:status, 'rejected') # avoid state machine
-
-      visit "/proposals/#{ncr_proposal.id}"
-      expect(page).to have_content('Modify Request')
-    end
-
-    it "shows a edit link for an approved cart" do
-      ncr_proposal.update_attribute(:status, 'approved') # avoid state machine
-
-      visit "/proposals/#{ncr_proposal.id}"
-      expect(page).to have_content('Modify Request')
-    end
-
-    it "does not show a edit link for another client" do
-      ncr_proposal.client_data = nil
-      ncr_proposal.save()
-      visit "/proposals/#{ncr_proposal.id}"
-      expect(page).not_to have_content('Modify Request')
-    end
-
-    it "does not show a edit link for non requester" do
-      ncr_proposal.set_requester(FactoryGirl.create(:user))
-      visit "/proposals/#{ncr_proposal.id}"
-      expect(page).not_to have_content('Modify Request')
-    end
-
-    context "selected common values on proposal page" do
-      before do
+      it "defaults to the approver from the last request" do
+        proposal = FactoryGirl.create(:proposal, :with_approvers,
+                                      requester: requester)
         visit '/ncr/work_orders/new'
+        expect(find_field("Approving official's email address").value).to eq(
+          proposal.approvers.first.email_address)
+      end
 
+      it "requires a project_title" do
+        visit '/ncr/work_orders/new'
+        expect {
+          click_on 'Submit for approval'
+        }.to_not change { Proposal.count }
+        expect(page).to have_content("Project title can't be blank")
+      end
+
+      it "doesn't show the budget fields" do
+        visit '/ncr/work_orders/new'
+        expect(page).to_not have_field('CL number')
+        expect(page).to_not have_field('Function code')
+        expect(page).to_not have_field('SOC code')
+      end
+
+      with_feature 'HIDE_BA61_OPTION' do
+        it "removes the radio button" do
+          visit '/ncr/work_orders/new'
+          expect(page).to_not have_content('BA61')
+        end
+
+        it "defaults to BA80" do
+          visit '/ncr/work_orders/new'
+          fill_in 'Project title', with: "buying stuff"
+          fill_in 'Description', with: "desc content"
+          # no need to select BA80
+          fill_in 'RWA Number', with: 'F1234567'
+          fill_in 'Vendor', with: 'ACME'
+          fill_in 'Amount', with: 123.45
+          fill_in "Approving official's email address", with: 'approver@example.com'
+          select Ncr::BUILDING_NUMBERS[0], :from => 'ncr_work_order_building_number'
+          select Ncr::Organization.all[0], :from => 'ncr_work_order_org_code'
+          expect {
+            click_on 'Submit for approval'
+          }.to change { Proposal.count }.from(0).to(1)
+
+          proposal = Proposal.last
+          expect(proposal.client_data.expense_type).to eq('BA80')
+        end
+      end
+
+      it "doesn't save when the amount is too high" do
+        visit '/ncr/work_orders/new'
         fill_in 'Project title', with: "buying stuff"
+        choose 'BA80'
+        fill_in 'Vendor', with: 'ACME'
+        fill_in 'Amount', with: 10_000
+
+        expect {
+          click_on 'Submit for approval'
+        }.to_not change { Proposal.count }
+
+        expect(current_path).to eq('/ncr/work_orders')
+        expect(page).to have_content("Amount must be less than or equal to $3,000")
+        # keeps the form values
+        expect(find_field('Amount').value).to eq('10000')
+      end
+
+      it "includes has overwritten field names" do
+        visit '/ncr/work_orders/new'
+        fill_in 'Project title', with: "buying stuff"
+        choose 'BA80'
+        fill_in 'RWA Number', with: 'B9876543'
         fill_in 'Vendor', with: 'ACME'
         fill_in 'Amount', with: 123.45
-        fill_in "Approving Official's Email Address", with: 'approver@example.com'
+        fill_in "Approving official's email address", with: 'approver@example.com'
         select Ncr::BUILDING_NUMBERS[0], :from => 'ncr_work_order_building_number'
         select Ncr::Organization.all[0], :from => 'ncr_work_order_org_code'
+        click_on 'Submit for approval'
+        expect(current_path).to eq("/proposals/#{Proposal.last.id}")
+        expect(page).to have_content("RWA Number")
       end
 
-      it "approves emergencies" do
+      it "hides fields based on expense", js: true do
+        visit '/ncr/work_orders/new'
+        expect(page).to have_no_field("RWA Number")
+        expect(page).to have_no_field("Work Order")
+        expect(page).to have_no_field("emergency")
         choose 'BA61'
-        check "This request was an emergency and I received a verbal Notice to Proceed (NTP)"
-        expect {
-          click_on 'Submit for approval'
-        }.to change { Proposal.count }.from(0).to(1)
-
-        proposal = Proposal.last
-        expect(page).to have_content("Proposal submitted")
-        expect(current_path).to eq("/proposals/#{proposal.id}")
-        expect(page).to have_content("0 of 0 approved")
-
-        expect(proposal.client_data.emergency).to eq(true)
-        expect(proposal.approved?).to eq(true)
-      end
-
-      it "does not set emergencies if form type changes" do
-        choose 'BA61'
-        check "This request was an emergency and I received a verbal Notice to Proceed (NTP)"
+        expect(page).to have_no_field("RWA Number")
+        expect(page).to have_no_field("Work Order")
+        expect(page).to have_field("emergency")
+        expect(find_field("emergency", visible: false)).to be_visible
         choose 'BA80'
-        fill_in 'RWA Number', with: 'R9876543'
-        expect {
-          click_on 'Submit for approval'
-        }.to change { Proposal.count }.from(0).to(1)
-
-        proposal = Proposal.last
-        expect(page).to have_content("Proposal submitted")
-        expect(current_path).to eq("/proposals/#{proposal.id}")
-
-        expect(proposal.client_data.emergency).to eq(false)
-        expect(proposal.approved?).to eq(false)
+        expect(page).to have_field("RWA Number")
+        expect(page).to have_field("Work Order")
+        expect(page).to have_no_field("emergency")
+        expect(find_field("RWA Number")).to be_visible
       end
+
+      it "allows attachments to be added during intake without JS" do
+        visit '/ncr/work_orders/new'
+        expect(page).to have_content("Attachments")
+        expect(page).not_to have_selector(".js-am-minus")
+        expect(page).not_to have_selector(".js-am-plus")
+        expect(page).to have_selector("input[type=file]", count: 10)
+      end
+
+      it "allows attachments to be added during intake with JS", :js => true do
+        visit '/ncr/work_orders/new'
+        expect(page).to have_content("Attachments")
+        first_minus = find(".js-am-minus")
+        first_plus = find(".js-am-plus")
+        expect(first_minus).to be_visible
+        expect(first_plus).to be_visible
+        expect(first_minus).to be_disabled
+        expect(find("input[type=file]")[:name]).to eq("attachments[]")
+        first_plus.click    # Adds one row
+        expect(page).to have_selector(".js-am-minus", count: 2)
+        expect(page).to have_selector(".js-am-plus", count: 2)
+        expect(page).to have_selector("input[type=file]", count: 2)
+      end
+
+      let (:work_order) {
+        wo = FactoryGirl.create(:ncr_work_order, requester: requester)
+        wo.add_approvals('approver@example.com')
+        wo
+      }
+      let(:ncr_proposal) {
+        work_order.proposal
+      }
+      it "can be edited if pending" do
+        visit "/ncr/work_orders/#{work_order.id}/edit"
+        expect(find_field("ncr_work_order_building_number").value).to eq(
+          Ncr::BUILDING_NUMBERS[0])
+        fill_in 'Vendor', with: 'New ACME'
+        click_on 'Submit for approval'
+        expect(current_path).to eq("/proposals/#{ncr_proposal.id}")
+        expect(page).to have_content("New ACME")
+        expect(page).to have_content("modified")
+        # Verify it is actually saved
+        work_order.reload
+        expect(work_order.vendor).to eq("New ACME")
+      end
+
+      it "creates a special comment when editing" do
+        visit "/ncr/work_orders/#{work_order.id}/edit"
+        fill_in 'Vendor', with: "New Test Vendor"
+        fill_in 'Description', with: "New Description"
+        click_on 'Submit for approval'
+
+        expect(page).to have_content("Request modified by")
+        expect(page).to have_content("Description was changed to New Description")
+        expect(page).to have_content("Vendor was changed to New Test Vendor")
+      end
+
+      it "has 'Discard Changes' link" do
+        visit "/ncr/work_orders/#{work_order.id}/edit"
+        expect(page).to have_content("Discard Changes")
+        click_on "Discard Changes"
+        expect(current_path).to eq("/proposals/#{work_order.proposal.id}")
+      end
+
+      it "has a disabled field if first approval is done" do
+        visit "/ncr/work_orders/#{work_order.id}/edit"
+        expect(find("[name=approver_email]")["disabled"]).to be_nil
+        work_order.approvals.first.approve!
+        visit "/ncr/work_orders/#{work_order.id}/edit"
+        expect(find("[name=approver_email]")["disabled"]).to eq("disabled")
+        # And we can still submit
+        fill_in 'Vendor', with: 'New ACME'
+        click_on 'Submit for approval'
+        expect(current_path).to eq("/proposals/#{ncr_proposal.id}")
+        # Verify it is actually saved
+        work_order.reload
+        expect(work_order.vendor).to eq("New ACME")
+      end
+
+      it "can be edited if rejected" do
+        ncr_proposal.update_attributes(status: 'rejected')  # avoid workflow
+
+        visit "/ncr/work_orders/#{work_order.id}/edit"
+        expect(current_path).to eq("/ncr/work_orders/#{work_order.id}/edit")
+      end
+
+      it "can be edited if approved" do
+        ncr_proposal.update_attributes(status: 'approved')  # avoid workflow
+
+        visit "/ncr/work_orders/#{work_order.id}/edit"
+        expect(current_path).to eq("/ncr/work_orders/#{work_order.id}/edit")
+      end
+
+      it "cannot be edited by someone other than the requester" do
+        ncr_proposal.set_requester(FactoryGirl.create(:user))
+
+        visit "/ncr/work_orders/#{work_order.id}/edit"
+        expect(current_path).to eq("/ncr/work_orders/new")
+        expect(page).to have_content('not the requester')
+      end
+
+      it "shows a edit link from a pending cart" do
+        visit "/proposals/#{ncr_proposal.id}"
+        expect(page).to have_content('Modify Request')
+        click_on('Modify Request')
+        expect(current_path).to eq("/ncr/work_orders/#{work_order.id}/edit")
+      end
+
+      it "shows a edit link from a rejected cart" do
+        ncr_proposal.update_attribute(:status, 'rejected') # avoid state machine
+
+        visit "/proposals/#{ncr_proposal.id}"
+        expect(page).to have_content('Modify Request')
+      end
+
+      it "shows a edit link for an approved cart" do
+        ncr_proposal.update_attribute(:status, 'approved') # avoid state machine
+
+        visit "/proposals/#{ncr_proposal.id}"
+        expect(page).to have_content('Modify Request')
+      end
+
+      it "does not show a edit link for another client" do
+        ncr_proposal.client_data = nil
+        ncr_proposal.save()
+        visit "/proposals/#{ncr_proposal.id}"
+        expect(page).not_to have_content('Modify Request')
+      end
+
+      it "does not show a edit link for non requester" do
+        ncr_proposal.set_requester(FactoryGirl.create(:user))
+        visit "/proposals/#{ncr_proposal.id}"
+        expect(page).not_to have_content('Modify Request')
+      end
+
+      context "selected common values on proposal page" do
+        before do
+          visit '/ncr/work_orders/new'
+
+          fill_in 'Project title', with: "buying stuff"
+          fill_in 'Vendor', with: 'ACME'
+          fill_in 'Amount', with: 123.45
+          fill_in "Approving official's email address", with: 'approver@example.com'
+          select Ncr::BUILDING_NUMBERS[0], :from => 'ncr_work_order_building_number'
+          select Ncr::Organization.all[0], :from => 'ncr_work_order_org_code'
+        end
+
+        it "approves emergencies" do
+          choose 'BA61'
+          check "This request was an emergency and I received a verbal Notice to Proceed (NTP)"
+          expect {
+            click_on 'Submit for approval'
+          }.to change { Proposal.count }.from(0).to(1)
+
+          proposal = Proposal.last
+          expect(page).to have_content("Proposal submitted")
+          expect(current_path).to eq("/proposals/#{proposal.id}")
+          expect(page).to have_content("0 of 0 approved")
+
+          expect(proposal.client_data.emergency).to eq(true)
+          expect(proposal.approved?).to eq(true)
+        end
+
+        it "does not set emergencies if form type changes" do
+          choose 'BA61'
+          check "This request was an emergency and I received a verbal Notice to Proceed (NTP)"
+          choose 'BA80'
+          fill_in 'RWA Number', with: 'R9876543'
+          expect {
+            click_on 'Submit for approval'
+          }.to change { Proposal.count }.from(0).to(1)
+
+          proposal = Proposal.last
+          expect(page).to have_content("Proposal submitted")
+          expect(current_path).to eq("/proposals/#{proposal.id}")
+
+          expect(proposal.client_data.emergency).to eq(false)
+          expect(proposal.approved?).to eq(false)
+        end
+      end
+    end
+  end
+
+  describe "editing a work order" do
+    let(:work_order) { FactoryGirl.create(:ncr_work_order, :with_approvers) }
+
+    it "allows the user to edit the budget-related fields when fully approved" do
+      work_order.proposal.update_attribute(:status, 'approved') # avoid workflow
+
+      login_as(work_order.requester)
+      visit "/ncr/work_orders/#{work_order.id}/edit"
+
+      fill_in 'CL number', with: '123'
+      fill_in 'Function code', with: '456'
+      fill_in 'SOC code', with: '789'
+      click_on 'Submit for approval'
+
+      work_order.reload
+      expect(work_order.cl_number).to eq('123')
+      expect(work_order.function_code).to eq('456')
+      expect(work_order.soc_code).to eq('789')
     end
   end
 end

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -337,9 +337,7 @@ describe "National Capital Region proposals" do
   describe "editing a work order" do
     let(:work_order) { FactoryGirl.create(:ncr_work_order, :with_approvers) }
 
-    it "allows the user to edit the budget-related fields when fully approved" do
-      work_order.proposal.update_attribute(:status, 'approved') # avoid workflow
-
+    it "allows the user to edit the budget-related fields" do
       login_as(work_order.requester)
       visit "/ncr/work_orders/#{work_order.id}/edit"
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -39,7 +39,7 @@ describe "searching" do
     fill_in 'Vendor', with: 'ACME'
     fill_in 'Amount', with: 123.45
     check "I am going to be using direct pay for this transaction"
-    fill_in "Approving Official's Email Address", with: 'approver@example.com'
+    fill_in "Approving official's email address", with: 'approver@example.com'
     select Ncr::BUILDING_NUMBERS[0], :from => 'ncr_work_order_building_number'
     select Ncr::Organization.all[0], :from => 'ncr_work_order_org_code'
     click_on 'Submit for approval'

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -9,13 +9,16 @@ describe Ncr::WorkOrder do
       expect(wo.fields_for_display.sort).to eq([
         ["Amount", 1000],
         ["Building number", Ncr::BUILDING_NUMBERS[0]],
+        ["Cl number", nil],
         ["Description", "Ddddd"],
         ["Direct pay", true],
         ["Emergency", true],
         ["Expense type", "BA61"],
+        ["Function code", nil],
         ["Not to exceed", false],
         ["Org code", Ncr::Organization.all[0]],
         # No RWA Number
+        ["Soc code", nil],
         ["Vendor", "Some Vend"]
         # No Work Order
       ])
@@ -29,13 +32,16 @@ describe Ncr::WorkOrder do
       expect(wo.fields_for_display.sort).to eq([
         ["Amount", 1000],
         ["Building number", Ncr::BUILDING_NUMBERS[0]],
+        ["Cl number", nil],
         ["Description", "Ddddd"],
         ["Direct pay", true],
         # No Emergency
         ["Expense type", "BA80"],
+        ["Function code", nil],
         ["Not to exceed", false],
         ["Org code", Ncr::Organization.all[0]],
         ["RWA Number", "RWWAAA #"],
+        ["Soc code", nil],
         ["Vendor", "Some Vend"],
         ["Work Order / Maximo Ticket Number", "Some WO#"]
       ])

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -9,7 +9,7 @@ describe Ncr::WorkOrder do
       expect(wo.fields_for_display.sort).to eq([
         ["Amount", 1000],
         ["Building number", Ncr::BUILDING_NUMBERS[0]],
-        ["Cl number", nil],
+        ["CL number", nil],
         ["Description", "Ddddd"],
         ["Direct pay", true],
         ["Emergency", true],
@@ -18,7 +18,7 @@ describe Ncr::WorkOrder do
         ["Not to exceed", false],
         ["Org code", Ncr::Organization.all[0]],
         # No RWA Number
-        ["Soc code", nil],
+        ["SOC code", nil],
         ["Vendor", "Some Vend"]
         # No Work Order
       ])
@@ -32,7 +32,7 @@ describe Ncr::WorkOrder do
       expect(wo.fields_for_display.sort).to eq([
         ["Amount", 1000],
         ["Building number", Ncr::BUILDING_NUMBERS[0]],
-        ["Cl number", nil],
+        ["CL number", nil],
         ["Description", "Ddddd"],
         ["Direct pay", true],
         # No Emergency
@@ -41,7 +41,7 @@ describe Ncr::WorkOrder do
         ["Not to exceed", false],
         ["Org code", Ncr::Organization.all[0]],
         ["RWA Number", "RWWAAA #"],
-        ["Soc code", nil],
+        ["SOC code", nil],
         ["Vendor", "Some Vend"],
         ["Work Order / Maximo Ticket Number", "Some WO#"]
       ])


### PR DESCRIPTION
Easier to understand the spec changes [ignoring whitespace](https://github.com/18F/C2/pull/408/files?w=1).

---

![screen shot 2015-06-19 at 9 34 10 pm](https://cloud.githubusercontent.com/assets/86842/8265535/f7a646d0-16ca-11e5-9007-1e62f9a5b4b3.png)
