### PR TITLE
Fix master failure 20150622

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 #
 MYUSA_KEY: consumer_public_key
 MYUSA_SECRET: consumer_secret_key
+# TODO: Remove require env vars that are client specific
+GSA18F_APPROVER_EMAIL: 18f_approver
 
 # optional
 #

--- a/spec/controllers/gsa18f/dashboard_controller_spec.rb
+++ b/spec/controllers/gsa18f/dashboard_controller_spec.rb
@@ -1,6 +1,11 @@
 describe Gsa18f::DashboardController do
   describe '#index' do
     let (:user) {FactoryGirl.create(:user)}
+
+    around(:each) do |example|
+      with_18f_procurement_env_variables(&example)
+    end
+
     before do
       login_as(user)
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,7 +64,10 @@ RSpec.configure do |config|
     config.include IntegrationSpecHelper, type: type
   end
   config.include FeatureSpecHelper, type: :feature
-  config.include EnvironmentSpecHelper, type: :model
+
+  [:controller, :model].each do |type|
+    config.include EnvironmentSpecHelper, type: type
+  end
 
   # Much of the config here pieced together from
   # http://stackoverflow.com/questions/8178120/capybara-with-js-true-causes-test-to-fail/28083267

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,9 +65,7 @@ RSpec.configure do |config|
   end
   config.include FeatureSpecHelper, type: :feature
 
-  [:controller, :model].each do |type|
-    config.include EnvironmentSpecHelper, type: type
-  end
+  config.include EnvironmentSpecHelper, type: :controller
 
   # Much of the config here pieced together from
   # http://stackoverflow.com/questions/8178120/capybara-with-js-true-causes-test-to-fail/28083267


### PR DESCRIPTION
Updated to fix test failures on master. 

Oddly, I noticed that only the `controller` type is needed to be explicitly mentioned. model and feature specs appear to be loading EnvironmentSpecHelper just fine. 