### PR TITLE
[Delivers #97070798] allow approvers to edit WorkOrders

### DIFF
--- a/app/policies/ncr/work_order_policy.rb
+++ b/app/policies/ncr/work_order_policy.rb
@@ -6,7 +6,7 @@ module Ncr
     end
 
     def can_edit!
-      requester!
+      check(self.requester? || self.approver?, "You must be the requester or an approver to edit")
     end
     alias_method :can_update!, :can_edit!
   end

--- a/app/policies/ncr/work_order_policy.rb
+++ b/app/policies/ncr/work_order_policy.rb
@@ -6,7 +6,7 @@ module Ncr
     end
 
     def can_edit!
-      author!
+      requester!
     end
     alias_method :can_update!, :can_edit!
   end

--- a/app/policies/proposal_policy.rb
+++ b/app/policies/proposal_policy.rb
@@ -5,9 +5,12 @@ class ProposalPolicy
     @proposal = record
   end
 
-  def author!
-    check(@proposal.requester_id == @user.id,
-          "You are not the requester")
+  def requester?
+    @proposal.requester_id == @user.id
+  end
+
+  def requester!
+    check(self.requester?, "You are not the requester")
   end
 
   def not_approved!
@@ -52,7 +55,7 @@ class ProposalPolicy
   alias_method :can_approve!, :can_approve_or_reject!
 
   def can_edit!
-    author! && not_approved!
+    requester! && not_approved!
   end
   alias_method :can_update!, :can_edit!
 

--- a/app/views/ncr/work_orders/form.html.erb
+++ b/app/views/ncr/work_orders/form.html.erb
@@ -115,18 +115,20 @@
         <%- end %>
       </div>
     <% else %>
-      <div class="form-group">
-        <%= f.label :cl_number %>
-        <%= f.text_field :cl_number, class: 'form-control' %>
-      </div>
-      <div class="form-group">
-        <%= f.label :function_code %>
-        <%= f.text_field :function_code, class: 'form-control' %>
-      </div>
-      <div class="form-group">
-        <%= f.label :soc_code %>
-        <%= f.text_field :soc_code, class: 'form-control' %>
-      </div>
+      <%= field_set_tag "Budget codes" do %>
+        <div class="form-group">
+          <%= f.label :cl_number %>
+          <%= f.text_field :cl_number, class: 'form-control' %>
+        </div>
+        <div class="form-group">
+          <%= f.label :function_code %>
+          <%= f.text_field :function_code, class: 'form-control' %>
+        </div>
+        <div class="form-group">
+          <%= f.label :soc_code %>
+          <%= f.text_field :soc_code, class: 'form-control' %>
+        </div>
+      <% end %>
     <% end %>
     <%= f.submit class: 'form-button' %>
     <% if @model_instance.persisted? %>

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -249,7 +249,7 @@ describe "National Capital Region proposals" do
 
         visit "/ncr/work_orders/#{work_order.id}/edit"
         expect(current_path).to eq("/ncr/work_orders/new")
-        expect(page).to have_content('not the requester')
+        expect(page).to have_content("You must be the requester or an approver")
       end
 
       it "shows a edit link from a pending cart" do

--- a/spec/policies/ncr/work_order_policy_spec.rb
+++ b/spec/policies/ncr/work_order_policy_spec.rb
@@ -1,0 +1,22 @@
+describe Ncr::WorkOrderPolicy do
+  subject { described_class }
+
+  permissions :can_edit? do
+    let(:work_order) { FactoryGirl.create(:ncr_work_order, :with_approvers) }
+
+    it "allows the requester to edit it" do
+      expect(subject).to permit(work_order.requester, work_order)
+    end
+
+    it "doesn't allow an approver to edit it" do
+      expect(subject).not_to permit(work_order.approvers[0], work_order)
+      expect(subject).not_to permit(work_order.approvers[1], work_order)
+    end
+
+    it "doesn't allow an observer to edit it"
+
+    it "does not allow anyone else to edit it" do
+      expect(subject).not_to permit(FactoryGirl.create(:user), work_order)
+    end
+  end
+end

--- a/spec/policies/ncr/work_order_policy_spec.rb
+++ b/spec/policies/ncr/work_order_policy_spec.rb
@@ -3,6 +3,7 @@ describe Ncr::WorkOrderPolicy do
 
   permissions :can_edit? do
     let(:work_order) { FactoryGirl.create(:ncr_work_order, :with_approvers) }
+    let(:proposal) { work_order.proposal }
 
     it "allows the requester to edit it" do
       expect(subject).to permit(work_order.requester, work_order)
@@ -13,10 +14,19 @@ describe Ncr::WorkOrderPolicy do
       expect(subject).to permit(work_order.approvers[1], work_order)
     end
 
-    it "doesn't allow an observer to edit it"
+    it "doesn't allow an observer to edit it" do
+      observer = FactoryGirl.create(:user)
+      proposal.observations.create!(user: observer)
+      expect(subject).not_to permit(observer, work_order)
+    end
 
     it "does not allow anyone else to edit it" do
       expect(subject).not_to permit(FactoryGirl.create(:user), work_order)
+    end
+
+    it "allows an approved request to be edited" do
+      proposal.update_attribute(:status, 'approved')  # skip state machine
+      expect(subject).to permit(proposal.requester, work_order)
     end
   end
 end

--- a/spec/policies/ncr/work_order_policy_spec.rb
+++ b/spec/policies/ncr/work_order_policy_spec.rb
@@ -8,9 +8,9 @@ describe Ncr::WorkOrderPolicy do
       expect(subject).to permit(work_order.requester, work_order)
     end
 
-    it "doesn't allow an approver to edit it" do
-      expect(subject).not_to permit(work_order.approvers[0], work_order)
-      expect(subject).not_to permit(work_order.approvers[1], work_order)
+    it "allows an approver to edit it" do
+      expect(subject).to permit(work_order.approvers[0], work_order)
+      expect(subject).to permit(work_order.approvers[1], work_order)
     end
 
     it "doesn't allow an observer to edit it"

--- a/spec/policies/proposal_policy_spec.rb
+++ b/spec/policies/proposal_policy_spec.rb
@@ -121,6 +121,11 @@ describe ProposalPolicy do
     it "does not allow anyone else to edit it" do
       expect(subject).not_to permit(FactoryGirl.create(:user), proposal)
     end
+
+    it "does not allow an approved request to be edited" do
+      proposal.update_attribute(:status, 'approved')  # skip state machine
+      expect(subject).not_to permit(proposal.requester, proposal)
+    end
   end
 
   context "testing scope" do

--- a/spec/policies/proposal_policy_spec.rb
+++ b/spec/policies/proposal_policy_spec.rb
@@ -102,6 +102,27 @@ describe ProposalPolicy do
     end
   end
 
+  permissions :can_edit? do
+    let(:proposal) { FactoryGirl.create(:proposal, :with_approvers, :with_observers) }
+
+    it "allows the requester to edit it" do
+      expect(subject).to permit(proposal.requester, proposal)
+    end
+
+    it "doesn't allow an approver to edit it" do
+      expect(subject).not_to permit(proposal.approvers[0], proposal)
+      expect(subject).not_to permit(proposal.approvers[1], proposal)
+    end
+
+    it "doesn't allow an observer to edit it" do
+      expect(subject).not_to permit(proposal.observers[0], proposal)
+    end
+
+    it "does not allow anyone else to edit it" do
+      expect(subject).not_to permit(FactoryGirl.create(:user), proposal)
+    end
+  end
+
   context "testing scope" do
     let(:proposal) {
       FactoryGirl.create(:proposal, :with_approvers, :with_observers)}


### PR DESCRIPTION
Also added a header around the budget fields.

![screen shot 2015-06-23 at 3 02 38 am](https://cloud.githubusercontent.com/assets/86842/8300584/59025c6c-1954-11e5-984c-c486c42a44db.png)
