### PR TITLE
[Delivers #94434346] Allow Custom Buildings

### DIFF
--- a/app/assets/javascripts/selectizer.js.coffee
+++ b/app/assets/javascripts/selectizer.js.coffee
@@ -12,20 +12,25 @@ class Selectizer
     !!@src()
   
   form_label: ->
-    $('label[for="'+@$el.attr('id')+'"]').text();
+    $('label[for="'+@$el.attr('id')+'"]').text()
 
   add_label: ->
     @selectizeObj().$control_input.attr('aria-label',@form_label())
 
   selectizeOpts: ->
     opts = {}
+    attr = @$el.attr('data-attr')
+    if @$el.attr('data-initial') && attr
+      opts.options = $.map @$el.data('initial'), (val) ->
+        result = {}
+        result[attr] = val
+        result
 
     if @isFreeForm()
       opts.create = true
       opts.maxItems = 1
 
     if @isRemote()
-      attr = @$el.attr('data-attr')
       opts.labelField = attr
       opts.searchField = [attr]
       opts.valueField = attr

--- a/app/views/ncr/work_orders/form.html.erb
+++ b/app/views/ncr/work_orders/form.html.erb
@@ -53,9 +53,11 @@
     <% end %>
     <div class="form-group">
       <%= f.label :building_number %>
-      <%= f.collection_select(
-            :building_number, Ncr::BUILDING_NUMBERS, :to_s, :to_s,
-            {include_blank: true, prompt: "Type here to search"}, {class: 'form-control js-selectize'}) %>
+      <%= f.text_field :building_number,
+            class: 'form-control js-selectize',
+            placeholder: "Type here to search or add",
+            data: {attr: 'building_number', src: '/api/v1/ncr/work_orders.json',
+                   initial: JSON.generate(Ncr::BUILDING_NUMBERS)} %>
     </div>
     <div class="form-group">
       <%= f.label :org_code %>

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -25,7 +25,7 @@ describe "National Capital Region proposals" do
         fill_in 'Amount', with: 123.45
         check "I am going to be using direct pay for this transaction"
         fill_in "Approving official's email address", with: 'approver@example.com'
-        select Ncr::BUILDING_NUMBERS[0], :from => 'ncr_work_order_building_number'
+        fill_in 'Building number', with: Ncr::BUILDING_NUMBERS[0]
         select Ncr::Organization.all[0], :from => 'ncr_work_order_org_code'
         expect {
           click_on 'Submit for approval'
@@ -92,7 +92,7 @@ describe "National Capital Region proposals" do
           fill_in 'Vendor', with: 'ACME'
           fill_in 'Amount', with: 123.45
           fill_in "Approving official's email address", with: 'approver@example.com'
-          select Ncr::BUILDING_NUMBERS[0], :from => 'ncr_work_order_building_number'
+          fill_in 'Building number', with: Ncr::BUILDING_NUMBERS[0]
           select Ncr::Organization.all[0], :from => 'ncr_work_order_org_code'
           expect {
             click_on 'Submit for approval'
@@ -128,7 +128,7 @@ describe "National Capital Region proposals" do
         fill_in 'Vendor', with: 'ACME'
         fill_in 'Amount', with: 123.45
         fill_in "Approving official's email address", with: 'approver@example.com'
-        select Ncr::BUILDING_NUMBERS[0], :from => 'ncr_work_order_building_number'
+        fill_in 'Building number', with: Ncr::BUILDING_NUMBERS[0]
         select Ncr::Organization.all[0], :from => 'ncr_work_order_org_code'
         click_on 'Submit for approval'
         expect(current_path).to eq("/proposals/#{Proposal.last.id}")
@@ -294,7 +294,7 @@ describe "National Capital Region proposals" do
           fill_in 'Vendor', with: 'ACME'
           fill_in 'Amount', with: 123.45
           fill_in "Approving official's email address", with: 'approver@example.com'
-          select Ncr::BUILDING_NUMBERS[0], :from => 'ncr_work_order_building_number'
+          fill_in 'Building number', with: Ncr::BUILDING_NUMBERS[0]
           select Ncr::Organization.all[0], :from => 'ncr_work_order_org_code'
         end
 

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -175,6 +175,29 @@ describe "National Capital Region proposals" do
         expect(page).to have_selector("input[type=file]", count: 2)
       end
 
+      it "includes an initial list of buildings", :js => true do
+        visit '/ncr/work_orders/new'
+        option = Ncr::BUILDING_NUMBERS.shuffle[0]
+
+        expect(page).not_to have_selector(".option[data-value='#{option}']")
+
+        find("input[aria-label='Building number']").native.send_keys(option)
+        expect(page).to have_selector("div.option[data-value='#{option}']")
+      end
+
+      it "does not include custom buildings initially", :js => true do
+        visit '/ncr/work_orders/new'
+        find("input[aria-label='Building number']").native.send_keys("BillDing")
+        expect(page).not_to have_selector("div.option[data-value='BillDing']")
+      end
+
+      it "includes previously entered buildings, too", :js => true do
+        FactoryGirl.create(:ncr_work_order, building_number: "BillDing")
+        visit '/ncr/work_orders/new'
+        find("input[aria-label='Building number']").native.send_keys("BillDing")
+        expect(page).to have_selector("div.option[data-value='BillDing']")
+      end
+
       let (:work_order) {
         wo = FactoryGirl.create(:ncr_work_order, requester: requester)
         wo.add_approvals('approver@example.com')

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -40,7 +40,7 @@ describe "searching" do
     fill_in 'Amount', with: 123.45
     check "I am going to be using direct pay for this transaction"
     fill_in "Approving official's email address", with: 'approver@example.com'
-    select Ncr::BUILDING_NUMBERS[0], :from => 'ncr_work_order_building_number'
+    fill_in 'Building number', with: Ncr::BUILDING_NUMBERS[0]
     select Ncr::Organization.all[0], :from => 'ncr_work_order_org_code'
     click_on 'Submit for approval'
 


### PR DESCRIPTION
This converts the select field for buildings into a text field (like vendor). The list of entries that it searches over is pre-populated to include all known buildings (i.e. the static list) + any additional buildings that have been used in previous requests.