### PR TITLE
[Delivers 94714266] link text to requests in emails

### DIFF
--- a/app/views/communicart_mailer/_email_reply.html.erb
+++ b/app/views/communicart_mailer/_email_reply.html.erb
@@ -7,12 +7,18 @@
         <p>
           <%= link_to "Approve", generate_approve_url(approval), class: 'form-button' %>
         </p>
+        <p>
+          <strong>
+            <%= link_to "Or Send a Comment", proposal_url(approval.proposal, anchor: 'comments'), {target: 'C2'} %>
+          </strong>
+        </p>
+      <% else %>
+        <p>
+          <strong>
+            <%= link_to "View This Request", proposal_url(approval.proposal), {target: 'C2'} %>
+          </strong>
+        </p>
       <% end %>
-      <p>
-        <strong>
-          <%= link_to "Or Send a Comment", proposal_url(approval.proposal, anchor: 'comments'), {target: 'C2'} %>
-        </strong>
-      </p>
     </td>
   </tr>
 </table>

--- a/app/views/communicart_mailer/_email_reply.html.erb
+++ b/app/views/communicart_mailer/_email_reply.html.erb
@@ -1,3 +1,4 @@
+<% # pass in show_approval_actions bool and an approval instance %>
 <table class='reply-section'>
   <tr height="25"><td colspan=2 height="25" bgcolor="#f5f5f5"></td></tr>
   <tr id="approval-actions">

--- a/spec/views/communicart_mailer/_email_reply.html.erb_spec.rb
+++ b/spec/views/communicart_mailer/_email_reply.html.erb_spec.rb
@@ -1,0 +1,20 @@
+describe "communicart_mailer/_email_reply.html.erb" do
+  it "renders 'Send a Comment' link with approve button" do
+    approval = FactoryGirl.create(:approval, :with_proposal, :with_user)
+    approval.create_api_token!
+    render partial: "communicart_mailer/email_reply", locals: {show_approval_actions: true, approval: approval}
+
+    expect(rendered).to include "Approve"
+    expect(rendered).to include "Or Send a Comment"
+    expect(rendered).to_not include "View this request"
+  end
+  it "renders 'View This Request' link without approve button" do
+    approval = FactoryGirl.create(:approval, :with_proposal, :with_user)
+    approval.create_api_token!
+    render partial: "communicart_mailer/email_reply", locals: {show_approval_actions: false, approval: approval}
+
+    expect(rendered).to_not include "Approve"
+    expect(rendered).to include "Or Send a Comment"
+    expect(rendered).to_not include "View This Request"
+  end
+end

--- a/spec/views/communicart_mailer/_email_reply.html.erb_spec.rb
+++ b/spec/views/communicart_mailer/_email_reply.html.erb_spec.rb
@@ -14,7 +14,7 @@ describe "communicart_mailer/_email_reply.html.erb" do
     render partial: "communicart_mailer/email_reply", locals: {show_approval_actions: false, approval: approval}
 
     expect(rendered).to_not include "Approve"
-    expect(rendered).to include "Or Send a Comment"
-    expect(rendered).to_not include "View This Request"
+    expect(rendered).to_not include "Or Send a Comment"
+    expect(rendered).to include "View This Request"
   end
 end


### PR DESCRIPTION
Paired with @afeld 

When a requester modifies a request that has already been approved, the approver that has already taken action gets an email. This email does not require action (i.e. we do not display an 'Approve' button), but we still display `Or Send a Comment`.  Change this link to say `View this request.`