### PR TITLE
97171464 fix email icons

### DIFF
--- a/app/assets/stylesheets/modules/shared/email_status.scss
+++ b/app/assets/stylesheets/modules/shared/email_status.scss
@@ -36,7 +36,7 @@
 
     &.last {
       img.approved.linear, img.pending.linear, img.rejected.linear {
-        background-image: none;
+        background-image: none !important;
       }
 
       img {

--- a/app/assets/stylesheets/modules/shared/email_status.scss
+++ b/app/assets/stylesheets/modules/shared/email_status.scss
@@ -42,7 +42,7 @@
 
     &.last {
       img.approved.linear, img.pending.linear, img.rejected.linear {
-        background-image: none !important;
+        background-image: none;
       }
 
       img {
@@ -60,22 +60,12 @@
 
     img {
       float: left;
-      padding-top: 2px;
-      &.approved.linear {
-        background-image: image-url('bg_approved_status.gif');
-      }
-
-      &.pending.linear {
-        background-image: image-url('bg_pending_status.gif');
-      }
-
-      &.rejected.linear {
-        background-image: image-url('bg_rejected_status.gif');
-      }
     }
 
     .approver {
       padding-left: 7px;
+      position: relative;
+      top: -5px;
     }
   }
 }

--- a/app/assets/stylesheets/modules/shared/email_status.scss
+++ b/app/assets/stylesheets/modules/shared/email_status.scss
@@ -23,6 +23,12 @@
     .status-icon {
       padding-bottom: 5px;
     }
+
+    &.status-header {
+      strong {
+        padding: 0 3px;
+      }
+    }
   }
 
   .status-icon {

--- a/app/helpers/communicart_mailer_helper.rb
+++ b/app/helpers/communicart_mailer_helper.rb
@@ -1,8 +1,9 @@
 module CommunicartMailerHelper
   def status_icon_tag(status, linear=false)
-    bg_linear_image = root_url.gsub(/\?.*$/,'').chomp("/")+image_path("bg_#{status}_status.gif")
+    base_url = root_url.gsub(/\?.*$/,'').chomp("/")
+    bg_linear_image = base_url + image_path("bg_#{status}_status.gif")
 
-    image_tag(root_url.gsub(/\?.*$/,'').chomp("/")+image_path("icon-#{status}.png"),
+    image_tag(base_url + image_path("icon-#{status}.png"),
               class: "status-icon #{status} #{'linear' if linear}",
               style: "background-image: url('#{bg_linear_image}');"
     )

--- a/app/helpers/communicart_mailer_helper.rb
+++ b/app/helpers/communicart_mailer_helper.rb
@@ -1,11 +1,11 @@
 module CommunicartMailerHelper
-  def status_icon_tag(status, linear_display=false)
+  def status_icon_tag(status, linear_display=false, last_approver=false)
     base_url = root_url.gsub(/\?.*$/,'').chomp("/")
     bg_linear_image = base_url + image_path("bg_#{status}_status.gif")
 
     image_tag(base_url + image_path("icon-#{status}.png"),
               class: "status-icon #{status} #{'linear' if linear_display}",
-              style: ("background-image: url('#{bg_linear_image}');" if linear_display)
+              style: ("background-image: url('#{bg_linear_image}');" if linear_display && !last_approver)
     )
   end
 

--- a/app/helpers/communicart_mailer_helper.rb
+++ b/app/helpers/communicart_mailer_helper.rb
@@ -1,6 +1,6 @@
 module CommunicartMailerHelper
   def status_icon_tag(status, linear=false)
-    image_tag( image_url("icon-#{status}.png"), class: "status-icon #{status} #{'linear' if linear}")
+    image_tag(root_url.gsub(/\?.*$/,'').chomp("/")+image_path("icon-#{status}.png"), class: "status-icon #{status} #{'linear' if linear}")
   end
 
   def generate_bookend_class(index, count)

--- a/app/helpers/communicart_mailer_helper.rb
+++ b/app/helpers/communicart_mailer_helper.rb
@@ -1,6 +1,6 @@
 module CommunicartMailerHelper
   def status_icon_tag(status, linear=false)
-    image_tag("icon-#{status}.png", class: "status-icon #{status} #{'linear' if linear}")
+    image_tag( image_url("icon-#{status}.png"), class: "status-icon #{status} #{'linear' if linear}")
   end
 
   def generate_bookend_class(index, count)

--- a/app/helpers/communicart_mailer_helper.rb
+++ b/app/helpers/communicart_mailer_helper.rb
@@ -1,13 +1,12 @@
 module CommunicartMailerHelper
-  def status_icon_tag(status, linear=false)
+  def status_icon_tag(status, linear_display=false)
     base_url = root_url.gsub(/\?.*$/,'').chomp("/")
     bg_linear_image = base_url + image_path("bg_#{status}_status.gif")
 
     image_tag(base_url + image_path("icon-#{status}.png"),
-              class: "status-icon #{status} #{'linear' if linear}",
-              style: "background-image: url('#{bg_linear_image}');"
+              class: "status-icon #{status} #{'linear' if linear_display}",
+              style: ("background-image: url('#{bg_linear_image}');" if linear_display)
     )
-
   end
 
   def generate_bookend_class(index, count)

--- a/app/helpers/communicart_mailer_helper.rb
+++ b/app/helpers/communicart_mailer_helper.rb
@@ -1,6 +1,12 @@
 module CommunicartMailerHelper
   def status_icon_tag(status, linear=false)
-    image_tag(root_url.gsub(/\?.*$/,'').chomp("/")+image_path("icon-#{status}.png"), class: "status-icon #{status} #{'linear' if linear}")
+    bg_linear_image = root_url.gsub(/\?.*$/,'').chomp("/")+image_path("bg_#{status}_status.gif")
+
+    image_tag(root_url.gsub(/\?.*$/,'').chomp("/")+image_path("icon-#{status}.png"),
+              class: "status-icon #{status} #{'linear' if linear}",
+              style: "background-image: url('#{bg_linear_image}');"
+    )
+
   end
 
   def generate_bookend_class(index, count)

--- a/app/views/shared/_email_status.html.erb
+++ b/app/views/shared/_email_status.html.erb
@@ -5,7 +5,7 @@
         <td>
           <strong>Approval Status</strong>
         </td>
-        <td>
+        <td class="status-header">
           <%= status_icon_tag(@proposal.status) %>
           <strong><%= @proposal.status %></strong>
           (<%= @proposal.number_approved %> of <%= @proposal.total_approvers %> approved)

--- a/app/views/shared/_email_status.html.erb
+++ b/app/views/shared/_email_status.html.erb
@@ -23,10 +23,9 @@
                     <strong><%= display_status %></strong>
                   <%- end %>
                 </td>
-                <td
-                  <%= generate_bookend_class(index, @proposal.approvals_in_list_order.count) %>
-                >
-                  <%= status_icon_tag(display_status, @proposal.linear?) %>
+                <td>
+                  <%- last_approver = index == @proposal.approvals_in_list_order.count - 1 %>
+                  <%= status_icon_tag(display_status, @proposal.linear?, last_approver) %>
                   <span class="approver">
                     <%= mail_to approval.user_email_address, approval.user_full_name %>
                   </span>


### PR DESCRIPTION
Bypass the stripping of full domain url for css images that need to display within emails; temporary workaround pending updates to roady-rails and likely email design updates.

![screen shot 2015-06-25 at 11 23 35 pm](https://cloud.githubusercontent.com/assets/11333/8377679/e4f71344-1bd8-11e5-8517-19d0ec49dbb0.png)
