### PR TITLE
[Delivers #94419078] Add scripts/manifest so that cloud foundry will run migrations on deploy

### DIFF
--- a/lib/tasks/cf.rake
+++ b/lib/tasks/cf.rake
@@ -1,0 +1,8 @@
+# From http://docs.cloudfoundry.org/buildpacks/ruby/ruby-tips.html#rake
+namespace :cf do
+  desc "Only run on the first application instance"
+  task :on_first_instance do
+    instance_index = JSON.parse(ENV["VCAP_APPLICATION"])["instance_index"] rescue nil
+    exit(0) unless instance_index == 0
+  end
+end

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,2 @@
+applications:
+- command: bundle exec rake cf:on_first_instance db:migrate && bundle exec rails s -p $PORT -e $RAILS_ENV


### PR DESCRIPTION
App continues to work when deployed to dev and the output from `cf push` indicates that the migration script is ran. However, we'll want to wait until there's an actual migration to confirm.