### PR TITLE
Minor UI tweak: link hover now less jarring

### DIFF
--- a/vendor/assets/stylesheets/photon/style.css
+++ b/vendor/assets/stylesheets/photon/style.css
@@ -50,8 +50,10 @@
 	}
 
 		a:hover {
-			border-bottom-color: transparent !important;
+			border-bottom-style: solid; 
+			border-bottom-width: 3px;
 			color: #6bd4c8;
+			text-decoration: none;
 		}
 
 	strong, b {


### PR DESCRIPTION
This fixes a pet peeve of mine with the Photon template you guys are using. There's a nice dotted underline for the links, but when you hover over it, that line is replaced with a solid line at a different vertical offset. I found this pretty jarring / annoying. I got rid of the text decoration on :hover and replaced it with a thicker, solid bottom border.

If you guys didn't mind the original styling or just don't want to start messing with Photon, no hard feelings. 