### PR TITLE
[#97405884][#98775964] Editing Emergencies

### DIFF
--- a/app/controllers/ncr/work_orders_controller.rb
+++ b/app/controllers/ncr/work_orders_controller.rb
@@ -17,7 +17,8 @@ module Ncr
       if self.proposal.approved?
         flash[:warning] = "You are about to modify a fully approved request. Changes will be logged and sent to approvers but this request will not require re-approval."
       end
-      @approver_email = self.proposal.approvers.first.email_address
+      first_approver = self.proposal.approvers.first
+      @approver_email = first_approver.email_address if first_approver
       super
     end
 

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -22,9 +22,6 @@ module Ncr
     before_validation :normalize_values
     before_update :record_changes
 
-    # after_update :update_approver
-    # after_update :email_approvers
-
     # @TODO: use integer number of cents to avoid floating point issues
     validates :amount, numericality: {
       less_than_or_equal_to: 3000,
@@ -87,7 +84,6 @@ module Ncr
 
     # A requester can change his/her approving official
     def update_approvers(approver_email=nil)
-      # binding.pry
       first_approval = self.approvals.first
       if approver_email && self.approver_changed?(approver_email)
         first_approval.destroy
@@ -99,7 +95,7 @@ module Ncr
       
       current_approvers = self.approvers.map {|a| a[:email_address]}
       #remove approving official
-      approving_official = current_approvers.shift
+      current_approvers.shift
       if (current_approvers != system_approvers)
         current_approvers.each do |email|
           self.remove_approver(email)

--- a/spec/controllers/ncr/work_orders_controller_spec.rb
+++ b/spec/controllers/ncr/work_orders_controller_spec.rb
@@ -78,8 +78,9 @@ describe Ncr::WorkOrdersController do
 
   describe '#update' do
     let (:work_order) { FactoryGirl.create(:ncr_work_order, :with_approvers) }
+    let (:requester) { work_order.proposal.requester }
     before do
-      login_as(work_order.proposal.requester)
+      login_as(requester)
     end
 
     it 'does not modify the work order when there is a blank approver' do
@@ -113,6 +114,39 @@ describe Ncr::WorkOrdersController do
                      ncr_work_order: {expense_type: 'BA61'}}
       work_order.reload
       expect(work_order.approvers.map(&:email_address)).not_to include('a@b.com')
+    end
+
+    it 'removes approvals and adds observers when switching to an emergency' do
+      pending   # https://www.pivotaltracker.com/story/show/98775964
+      expect(work_order.approvals.empty?).to be false
+      expect(work_order.observers.empty?).to be true
+      post :update, {id: work_order.id, approver_email: work_order.approvers.first.email_address,
+                     ncr_work_order: {expense_type: 'BA61', emergency: '1'}}
+      work_order.reload
+      expect(work_order.approvals.empty?).to be true
+      expect(work_order.observers.empty?).to be false
+    end
+
+    it 'removes removes observers and adds approvers when switching to an emergency' do
+      pending   # https://www.pivotaltracker.com/story/show/98775964
+      work_order = FactoryGirl.create(:ncr_work_order, :is_emergency, requester: requester)
+      expect(work_order.approvals.empty?).to be true
+      expect(work_order.observers.empty?).to be false
+      post :update, {id: work_order.id, approver_email: work_order.observers.first.email_address,
+                     ncr_work_order: {expense_type: 'BA61', emergency: '0'}}
+      work_order.reload
+      expect(work_order.approvals.empty?).to be false
+      expect(work_order.observers.empty?).to be true
+    end
+
+    it 'allows editing an emergency' do
+      pending   # https://www.pivotaltracker.com/story/show/98775964
+      expect(work_order.amount).not_to eq(55.22)
+      work_order = FactoryGirl.create(:ncr_work_order, :is_emergency, requester: requester)
+      post :update, {id: work_order.id, approver_email: work_order.observers.first.email_address,
+                     ncr_work_order: {expense_type: 'BA61', emergency: '1', amount: '55.22'}}
+      work_order.reload
+      expect(work_order.amount).to eq(55.22)
     end
   end
 end

--- a/spec/controllers/ncr/work_orders_controller_spec.rb
+++ b/spec/controllers/ncr/work_orders_controller_spec.rb
@@ -127,7 +127,7 @@ describe Ncr::WorkOrdersController do
       expect(work_order.observers.empty?).to be false
     end
 
-    it 'removes removes observers and adds approvers when switching to an emergency' do
+    it 'removes observers and adds approvers when switching to an emergency' do
       pending   # https://www.pivotaltracker.com/story/show/98775964
       work_order = FactoryGirl.create(:ncr_work_order, :is_emergency, requester: requester)
       expect(work_order.approvals.empty?).to be true

--- a/spec/controllers/ncr/work_orders_controller_spec.rb
+++ b/spec/controllers/ncr/work_orders_controller_spec.rb
@@ -53,8 +53,9 @@ describe Ncr::WorkOrdersController do
 
   describe '#edit' do
     let (:work_order) { FactoryGirl.create(:ncr_work_order, :with_approvers) }
+    let (:requester) { work_order.proposal.requester }
     before do
-      login_as(work_order.proposal.requester)
+      login_as(requester)
     end
 
     it 'does not display a message when the proposal is not fully approved' do
@@ -66,6 +67,12 @@ describe Ncr::WorkOrdersController do
       work_order.approve!
       get :edit, {id: work_order.id}
       expect(flash[:warning]).to be_present
+    end
+
+    it 'does not explode if editing an emergency' do
+      work_order = FactoryGirl.create(:ncr_work_order, :is_emergency,
+                                      requester: requester)
+      get :edit, {id: work_order.id}
     end
   end
 

--- a/spec/factories/ncr/work_orders.rb
+++ b/spec/factories/ncr/work_orders.rb
@@ -14,5 +14,10 @@ FactoryGirl.define do
     trait :with_approvers do
       association :proposal, :with_approvers, flow: 'linear'
     end
+
+    trait :is_emergency do
+      emergency true
+      association :proposal, :with_observers, flow: 'linear'
+    end
   end
 end


### PR DESCRIPTION
Originally to resolve a 500 when loading the "edit" screen, I found a deeper issue around editing emergency work orders. That'll take a deeper dive and is not a priority, so we'll swing back to it; in the mean time, I fixed the immediate 500 and added some pending tests.