### PR TITLE
[#96904782] NCR email subject should only include codes

### DIFF
--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -214,6 +214,19 @@ module Ncr
       ENV['NCR_BA80_BUDGET_MAILBOX'] || 'communicart.budget.approver@gmail.com'
     end
 
+    def org_id
+      self.organization.try(:code)
+    end
+
+    def building_id
+      regex = /\A(\w{8}) .*\z/
+      if self.building_number && regex.match(self.building_number)
+        regex.match(self.building_number)[1]
+      else
+        self.building_number
+      end
+    end
+
     protected
 
     # TODO move to Proposal model

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -227,6 +227,10 @@ module Ncr
       end
     end
 
+    def as_json
+      super.merge(org_id: self.org_id, building_id: self.building_id)
+    end
+
     protected
 
     # TODO move to Proposal model

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,4 +44,4 @@ en:
   mail:
     subject:
       proposal: "Request %{public_identifier}"
-      ncr/work_order: "Request %{public_identifier}, %{org_code}, %{building_number}, from %{requester_email_address}"
+      ncr/work_order: "Request %{public_identifier}, %{org_id}, %{building_id} from %{requester_email_address}"

--- a/spec/mailers/communicart_mailer_spec.rb
+++ b/spec/mailers/communicart_mailer_spec.rb
@@ -235,9 +235,9 @@ describe CommunicartMailer do
 
     it 'includes custom text for ncr work orders' do
       requester = FactoryGirl.create(:user, email_address: 'someone@somewhere.gov')
-      wo = FactoryGirl.create(:ncr_work_order, org_code: 'some org', building_number: 'some build', requester: requester)
+      wo = FactoryGirl.create(:ncr_work_order, org_code: 'P0000000 (192X,192M) PRIOR YEAR ACTIVITIES', building_number: 'DC0000ZZ - Building', requester: requester)
       mail = CommunicartMailer.proposal_created_confirmation(wo.proposal)
-      expect(mail.subject).to eq("Request #{wo.public_identifier}, some org, some build, from someone@somewhere.gov")
+      expect(mail.subject).to eq("Request #{wo.public_identifier}, P0000000, DC0000ZZ from someone@somewhere.gov")
     end
   end
 end

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -304,4 +304,33 @@ describe Ncr::WorkOrder do
       expect(comment.user).to eq(modifier)
     end
   end
+
+  describe "#org_id" do
+    it "pulls out the organization id when present" do
+      wo = FactoryGirl.create(:ncr_work_order, org_code: 'P0000000 (192X,192M) PRIOR YEAR ACTIVITIES')
+      expect(wo.org_id).to eq("P0000000")
+    end
+
+    it "returns nil when no organization is present" do
+      wo = FactoryGirl.create(:ncr_work_order, org_code: nil)
+      expect(wo.org_id).to be_nil
+    end
+  end
+
+  describe "#building_id" do
+    it "pulls out the building id when an identifier is present" do
+      wo = FactoryGirl.build(:ncr_work_order, building_number: "AB1234CD then some more")
+      expect(wo.building_id).to eq("AB1234CD")
+    end
+
+    it "defaults to the whole building number" do
+      wo = FactoryGirl.build(:ncr_work_order, building_number: "Another String")
+      expect(wo.building_id).to eq("Another String")
+    end
+
+    it "allows nil" do
+      wo = FactoryGirl.build(:ncr_work_order, building_number: nil)
+      expect(wo.building_id).to be_nil
+    end
+  end
 end

--- a/spec/support/environment_spec_helper.rb
+++ b/spec/support/environment_spec_helper.rb
@@ -1,4 +1,5 @@
 module EnvironmentSpecHelper
+  # @todo rewrite using with_env_vars
   def with_18f_procurement_env_variables
     old_approver_email = ENV['GSA18F_APPROVER_EMAIL']
     old_purchaser_email = ENV['GSA18F_PURCHASER_EMAIL']

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -1,15 +1,21 @@
 # https://github.com/rspec/rspec-core/issues/1378#issuecomment-37248037
-def with_env_var(name, val, &block)
-  context "with #{name}=#{val}" do
+def with_env_vars(env={}, &block)
+  context "with ENV vars #{env}" do
+    env = env.stringify_keys
     around(:each) do |example|
-      old_val = ENV[name]
-      ENV[name] = val
+      old_values = {}
+      env.each_key{ |k| old_values[k] = ENV[k] }
+      env.each{ |k, v| ENV[k] = v }
       example.run
-      ENV[name] = old_val
+      old_values.each{ |k, v| ENV[k] = v}
     end
 
     class_exec(&block)
   end
+end
+
+def with_env_var(name, val, &block)
+  with_env_vars({name => val}, &block)
 end
 
 def with_feature(name, &block)


### PR DESCRIPTION
It does this by reusing `self.organization.code` and applying a regex for buildings.

Also updated some specs which were testing the executing environment via `with_env_vars`, an extension of `with_env_var`.