### PR TITLE
[Delivers #98941214] Allow observers to modify ncr requests

### DIFF
--- a/app/policies/ncr/work_order_policy.rb
+++ b/app/policies/ncr/work_order_policy.rb
@@ -8,7 +8,7 @@ module Ncr
     end
 
     def can_edit!
-      check(self.requester? || self.approver?, "You must be the requester or an approver to edit")
+      check(self.requester? || self.approver? || self.observer?, "You must be the requester, approver, or observer to edit")
     end
     alias_method :can_update!, :can_edit!
 

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -509,7 +509,7 @@ describe "National Capital Region proposals" do
 
       visit "/ncr/work_orders/#{work_order.id}/edit"
       expect(current_path).to eq("/ncr/work_orders/new")
-      expect(page).to have_content("You must be the requester or an approver")
+      expect(page).to have_content("You must be the requester, approver, or observer")
     end
   end
 end

--- a/spec/policies/ncr/work_order_policy_spec.rb
+++ b/spec/policies/ncr/work_order_policy_spec.rb
@@ -14,10 +14,10 @@ describe Ncr::WorkOrderPolicy do
       expect(subject).to permit(work_order.approvers[1], work_order)
     end
 
-    it "doesn't allow an observer to edit it" do
+    it "allows an observer to edit it" do
       observer = FactoryGirl.create(:user)
       proposal.observations.create!(user: observer)
-      expect(subject).not_to permit(observer, work_order)
+      expect(subject).to permit(observer, work_order)
     end
 
     it "does not allow anyone else to edit it" do


### PR DESCRIPTION
Just adds another OR clause to permissions checking.