### PR TITLE
[#Delivers 98973752] Use default puma/newrelic config as it works out of the box

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'haml'
 gem 'html_pipeline_rails'
 gem 'jquery-rails'
 gem 'jquery-turbolinks'
-gem 'newrelic_rpm', require: false # https://github.com/Tomohiro/plate/commit/0a5a072c8d882f32a48d8bdbfa325e83719f58f8
+gem 'newrelic_rpm'
 gem 'omniauth-myusa', git: 'https://github.com/18F/omniauth-myusa.git'
 gem 'paperclip'
 gem 'peek'

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -193,7 +193,6 @@ development:
   <<: *default_settings
   # Turn on communication to New Relic service in development mode
   monitor_mode: true
-  app_name: C2 (Development)
 
   # Rails Only - when running in Developer Mode, the New Relic Agent will
   # present performance information on the last 100 transactions you have

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -14,8 +14,4 @@ on_worker_boot do
   # Worker specific setup for Rails 4.1+
   # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
   ActiveRecord::Base.establish_connection
-
-  # https://github.com/Tomohiro/plate/commit/0a5a072c8d882f32a48d8bdbfa325e83719f58f8
-  require 'newrelic_rpm'
-  NewRelic::Agent.manual_start
 end


### PR DESCRIPTION
We had a [configuration](https://github.com/puma/puma/issues/128#issuecomment-21050609) that worked for an older version of the newrelic gem; according to the [current docs](https://docs.newrelic.com/docs/agents/ruby-agent/troubleshooting/new-relic-puma) this is no longer required.

Tested by pushing to staging; started logging almost immediately.