### PR TITLE
[Delivers #98775964] Emergency fields is disabled when editing

### DIFF
--- a/app/controllers/ncr/work_orders_controller.rb
+++ b/app/controllers/ncr/work_orders_controller.rb
@@ -26,7 +26,7 @@ module Ncr
       @approver_email = params[:approver_email]
       @model_instance.modifier = current_user
       super
-      if self.errors.empty?
+      if self.errors.empty? && !@model_instance.emergency  # skip approvals if emergency
         if !self.approver_email_frozen? && !@model_not_changing
           @model_instance.update_approvers(@approver_email)
           @model_instance.email_approvers
@@ -65,6 +65,9 @@ module Ncr
     def permitted_params
       fields = Ncr::WorkOrder.relevant_fields(
         params[:ncr_work_order][:expense_type])
+      if @model_instance
+        fields.delete(:emergency)   # emergency field cannot be edited
+      end
       params.require(:ncr_work_order).permit(:project_title, *fields)
     end
 

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -111,8 +111,8 @@ module Ncr
     end
 
     def approver_changed?(approval_email)
-      first_approval = self.proposal.approvals.first.user_email_address
-      first_approval != approval_email
+      first_approver = self.proposal.approvers.first
+      first_approver && first_approver.email_address != approval_email
     end
 
     def add_approvals(approver_email)

--- a/app/views/ncr/work_orders/form.html.erb
+++ b/app/views/ncr/work_orders/form.html.erb
@@ -46,7 +46,7 @@
             <div class="checkbox" data-filter-key="expense-type"
                                     data-filter-value="BA61">
               <%= f.label :emergency do %>
-                <%= f.check_box :emergency %>
+                <%= f.check_box :emergency, disabled: @model_instance.persisted? %>
                 This request was an emergency and I received a verbal Notice to Proceed (NTP)
               <% end %>
             </div>

--- a/spec/controllers/ncr/work_orders_controller_spec.rb
+++ b/spec/controllers/ncr/work_orders_controller_spec.rb
@@ -116,37 +116,28 @@ describe Ncr::WorkOrdersController do
       expect(work_order.approvers.map(&:email_address)).not_to include('a@b.com')
     end
 
-    it 'removes approvals and adds observers when switching to an emergency' do
-      pending   # https://www.pivotaltracker.com/story/show/98775964
+    it 'will not modify emergency status on non-emergencies' do
       expect(work_order.approvals.empty?).to be false
       expect(work_order.observers.empty?).to be true
       post :update, {id: work_order.id, approver_email: work_order.approvers.first.email_address,
                      ncr_work_order: {expense_type: 'BA61', emergency: '1'}}
       work_order.reload
-      expect(work_order.approvals.empty?).to be true
-      expect(work_order.observers.empty?).to be false
-    end
-
-    it 'removes observers and adds approvers when switching to an emergency' do
-      pending   # https://www.pivotaltracker.com/story/show/98775964
-      work_order = FactoryGirl.create(:ncr_work_order, :is_emergency, requester: requester)
-      expect(work_order.approvals.empty?).to be true
-      expect(work_order.observers.empty?).to be false
-      post :update, {id: work_order.id, approver_email: work_order.observers.first.email_address,
-                     ncr_work_order: {expense_type: 'BA61', emergency: '0'}}
-      work_order.reload
+      expect(work_order.emergency).to be false
       expect(work_order.approvals.empty?).to be false
       expect(work_order.observers.empty?).to be true
     end
 
-    it 'allows editing an emergency' do
-      pending   # https://www.pivotaltracker.com/story/show/98775964
-      expect(work_order.amount).not_to eq(55.22)
+    it 'will not modify emergency status on emergencies' do
       work_order = FactoryGirl.create(:ncr_work_order, :is_emergency, requester: requester)
+      expect(work_order.approvals.empty?).to be true
+      expect(work_order.observers.empty?).to be false
       post :update, {id: work_order.id, approver_email: work_order.observers.first.email_address,
-                     ncr_work_order: {expense_type: 'BA61', emergency: '1', amount: '55.22'}}
+                     ncr_work_order: {expense_type: 'BA61', building_number: 'BillDing', emergency: '0'}}
       work_order.reload
-      expect(work_order.amount).to eq(55.22)
+      expect(work_order.emergency).to be true
+      expect(work_order.building_number).to eq "BillDing"
+      expect(work_order.approvals.empty?).to be true
+      expect(work_order.observers.empty?).to be false
     end
   end
 end

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -295,6 +295,11 @@ describe "National Capital Region proposals" do
           expect(proposal.approved?).to eq(false)
         end
       end
+
+      it "does not disable the emergency field" do
+        visit '/ncr/work_orders/new'
+        expect(find_field('emergency')).not_to be_disabled
+      end
     end
   end
 
@@ -487,6 +492,11 @@ describe "National Capital Region proposals" do
         expect(work_order.cl_number).to eq('CL1234567')
         expect(work_order.function_code).to eq('PG123')
         expect(work_order.soc_code).to eq('789')
+      end
+
+      it "disables the emergency field" do
+        visit "/ncr/work_orders/#{work_order.id}/edit"
+        expect(find_field('emergency', disabled: true)).to be_disabled
       end
     end
 


### PR DESCRIPTION
Users can no longer switch requests between emergency and non-emergency status, as this messes up approvals and observers.