### PR TITLE
[Delivers #98953098] Add an email field to feedback form

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -4,7 +4,7 @@ class FeedbackController < ApplicationController
   end
 
   def create
-    fields = [:bug, :context, :expected, :actually, :comments, :satisfaction, :referral]
+    fields = [:email, :bug, :context, :expected, :actually, :comments, :satisfaction, :referral]
     fields = fields.select {|key| !params[key].blank?}
     form_values = fields.map {|key| [key, params[key]]}
     unless form_values.empty?

--- a/app/views/feedback/index.html.haml
+++ b/app/views/feedback/index.html.haml
@@ -12,6 +12,12 @@
 
     %hr
 
+    - if current_user.nil?
+      %p Please provide an email address with which we can reach you.
+      .form-group
+        = label_tag :email, "E-mail"
+        = email_field_tag :email, nil, class: 'form-control'
+
     .form-group
       = label_tag :bug do
         = check_box_tag(:bug, "yes", false, "data-filter-control" => 'is-bug')

--- a/spec/controllers/feedback_controller_spec.rb
+++ b/spec/controllers/feedback_controller_spec.rb
@@ -8,13 +8,19 @@ describe FeedbackController do
         actually: 'it did not',
         comments: 'Comments here',
         satisfaction: '4',
+        email: 'someone@example.com',
         referral: '/somewhere/else'
       }
       expect(deliveries.count).to be(1)
-      expect(deliveries[0].body.to_s).to eq(
-        ["bug: Yes", "context: Some context here", "expected: it to work",
-         "actually: it did not", "comments: Comments here", "satisfaction: 4",
-         "referral: /somewhere/else"].join("\n"))
+      expect(deliveries[0].body.to_s).to eq([
+        "email: someone@example.com",
+        "bug: Yes",
+        "context: Some context here",
+        "expected: it to work",
+        "actually: it did not",
+        "comments: Comments here",
+        "satisfaction: 4",
+        "referral: /somewhere/else"].join("\n"))
       expect(deliveries[0].cc).to eq([])
     end
 


### PR DESCRIPTION
For logged in users, continues to look like:
<img width="407" alt="screen shot 2015-07-13 at 5 48 13 pm" src="https://cloud.githubusercontent.com/assets/326918/8661730/a7ee2b06-2987-11e5-94ac-e157d27e5b66.png">

For non-logged in users, looks like:
<img width="427" alt="screen shot 2015-07-13 at 5 48 02 pm" src="https://cloud.githubusercontent.com/assets/326918/8661729/a7ed3606-2987-11e5-8454-429ec6e8db15.png">
