### PR TITLE
[Delivers #98958450] Start with the approver selection blank

### DIFF
--- a/app/views/ncr/work_orders/form.html.erb
+++ b/app/views/ncr/work_orders/form.html.erb
@@ -112,7 +112,7 @@
     <div class="form-group">
       <%= label_tag :approver_email, "Approving official's email address", class: "required" %>
       <%= select_tag :approver_email, options_from_collection_for_select(approver_options, :to_s, :to_s, @approver_email),
-                     class: 'form-control js-selectize', disabled: approver_email_frozen? %>
+                     class: 'form-control js-selectize', disabled: approver_email_frozen?, include_blank: true, prompt: 'Type here to search' %>
     </div>
     <% if @model_instance.new_record? %>
       <div class="form-group">

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -104,6 +104,11 @@ describe "National Capital Region proposals" do
         end
       end
 
+      it "defaults to no approver if there was no previous request" do
+        visit '/ncr/work_orders/new'
+        expect(find_field("Approving official's email address").value).to eq('')
+      end
+
       it "defaults to the approver from the last request" do
         proposal = FactoryGirl.create(:proposal, :with_approvers,
                                       requester: requester)


### PR DESCRIPTION
We were generating a select box for approving official, but not providing a blank option. This meant that the first time a user filled out an entry, they were defaulting the approving official to the first user in the drop down.