### PR TITLE
Remove default NCR navlink

### DIFF
--- a/app/views/layouts/_header_nav.html.erb
+++ b/app/views/layouts/_header_nav.html.erb
@@ -24,7 +24,7 @@
         <%= link_to "My Requests", proposals_path %>
         <%= image_tag "img-cart.png", width: '18px', height:'16px' %>
       </li>
-      <%= client_partial(current_user.client_slug || 'ncr', "header_links") %>
+      <%= client_partial(current_user.client_slug, "header_links") %>
     </ul>
   </div>
 <%- end %>

--- a/spec/features/link_to_new_proposal_spec.rb
+++ b/spec/features/link_to_new_proposal_spec.rb
@@ -1,6 +1,5 @@
 describe "Link to New Proposal" do
   it "is not visible if the user has no client" do
-    pending "skipping for user testing"
     login_as(FactoryGirl.create(:user))
     visit '/'
     expect(page).not_to have_content('New NCR Request')


### PR DESCRIPTION
Displays no default client link. 

If it looks good, please indicate a ship but please *no merge* until @phirefly has verified all ncr users have the correct client_slug.