### PR TITLE
[Delivers #98910592] warning banner for sandbox sites.

### DIFF
--- a/app/assets/stylesheets/common/header.scss
+++ b/app/assets/stylesheets/common/header.scss
@@ -22,16 +22,6 @@ header {
   }
 }
 
-.sandbox-banner {
-  width: 100%;
-  display: block;
-  background: #fff2bb;
-  border: 1px solid #d9d9d9;
-  border-top: none;
-  text-align: center;
-  padding: 10px 10px;
-}
-
 .header-nav {
   display: inline-block;
   float: right;

--- a/app/assets/stylesheets/common/header.scss
+++ b/app/assets/stylesheets/common/header.scss
@@ -22,6 +22,16 @@ header {
   }
 }
 
+.sandbox-banner {
+  width: 100%;
+  display: block;
+  background: #fff2bb;
+  border: 1px solid #d9d9d9;
+  border-top: none;
+  text-align: center;
+  padding: 10px 10px;
+}
+
 .header-nav {
   display: inline-block;
   float: right;

--- a/app/assets/stylesheets/common/sandbox_banner.scss
+++ b/app/assets/stylesheets/common/sandbox_banner.scss
@@ -1,0 +1,9 @@
+.sandbox-banner {
+  width: 100%;
+  display: block;
+  background: #fff2bb;
+  border: 1px solid #d9d9d9;
+  border-top: none;
+  text-align: center;
+  padding: 10px 10px;
+}

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -10,6 +10,7 @@
  *
  *= require_self
  *= require common/header
+ *= require common/sandbox_banner
  *= require common/button_to
  */
 

--- a/app/assets/stylesheets/webapp/webviews.scss
+++ b/app/assets/stylesheets/webapp/webviews.scss
@@ -252,6 +252,10 @@ body.webapp {
     margin-bottom: $webpadding;
     padding: $webpadding;
   }
+  .sandbox-banner {
+    font-size: 14px;
+    color: #333;
+  }
 }
 
 .controller-proposals {

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -5,10 +5,7 @@
   Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 %html{lang: 'en'}
   - unless ENV["DISABLE_SANDBOX_WARNING"]
-    %div{class: "sandbox-banner"}
-      %span
-        This sandbox site is for testing and training purposes only. To view and make live requests,
-        %a{href: "https://cap.18f.gov"} go to the live site.
+    = render 'shared/sandbox_warning'
   %head
     %title Communicart
     %meta{'http-equiv' => "content-type", content: "text/html; charset=utf-8"}

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -4,6 +4,11 @@
   html5up.net | @n33co
   Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 %html{lang: 'en'}
+  - unless ENV["DISABLE_SANDBOX_WARNING"]
+    %div{class: "sandbox-banner"}
+      %span
+        This sandbox site is for testing and training purposes only. To view and make live requests,
+        %a{href: "https://cap.18f.gov"} go to the live site.
   %head
     %title Communicart
     %meta{'http-equiv' => "content-type", content: "text/html; charset=utf-8"}

--- a/app/views/layouts/_communicart_header.html.erb
+++ b/app/views/layouts/_communicart_header.html.erb
@@ -1,7 +1,5 @@
 <% unless ENV["DISABLE_SANDBOX_WARNING"] %>
-<div class="sandbox-banner">
-  <span>This sandbox site is for testing and training purposes only. To view and make live requests, <a href="https://cap.18f.gov">go to the live site</a>.</span>
-</div>
+  <%= render partial: 'shared/sandbox_warning' %>
 <% end %>
 <header>
   <div class='container'>

--- a/app/views/layouts/_communicart_header.html.erb
+++ b/app/views/layouts/_communicart_header.html.erb
@@ -1,3 +1,8 @@
+<% unless ENV["DISABLE_SANDBOX_WARNING"] %>
+<div class="sandbox-banner">
+  <span>This sandbox site is for testing and training purposes only. To view and make live requests, <a href="https://cap.18f.gov">go to the live site</a>.</span>
+</div>
+<% end %>
 <header>
   <div class='container'>
     <div id='header-identity'>

--- a/app/views/shared/_sandbox_warning.html.haml
+++ b/app/views/shared/_sandbox_warning.html.haml
@@ -1,0 +1,4 @@
+%div{class: "sandbox-banner"}
+  %span
+    This sandbox site is for testing and training purposes only. To view and make live requests,
+    %a{href: "https://cap.18f.gov"} go to the live site.

--- a/spec/features/sandbox_warning_spec.rb
+++ b/spec/features/sandbox_warning_spec.rb
@@ -11,20 +11,16 @@ describe "display sandbox warning" do
   end
 
   context 'hides sandbox warning in production' do
-    before do
-      ENV["DISABLE_SANDBOX_WARNING"] = "true"
-    end
-    after do
-      ENV["DISABLE_SANDBOX_WARNING"] = nil
-    end
-    it "on homepage" do
-      visit root_path
-      expect(page).not_to have_content("This sandbox site is for testing and training purposes only")
-    end
+    with_feature 'DISABLE_SANDBOX_WARNING' do
+      it "on homepage" do
+        visit root_path
+        expect(page).not_to have_content("This sandbox site is for testing and training purposes only")
+      end
 
-    it "on internal pages" do
-      visit proposals_path
-      expect(page).not_to have_content("This sandbox site is for testing and training purposes only")
+      it "on internal pages" do
+        visit proposals_path
+        expect(page).not_to have_content("This sandbox site is for testing and training purposes only")
+      end
     end
   end
 end

--- a/spec/features/sandbox_warning_spec.rb
+++ b/spec/features/sandbox_warning_spec.rb
@@ -1,0 +1,30 @@
+describe "display sandbox warning" do
+  context 'showing sandbox warning' do
+    it "on homepage" do
+      visit root_path
+      expect(page).to have_content("This sandbox site is for testing and training purposes only")
+    end
+    it "on internal pages" do
+      visit proposals_path
+      expect(page).to have_content("This sandbox site is for testing and training purposes only")
+    end
+  end
+
+  context 'hides sandbox warning in production' do
+    before do
+      ENV["DISABLE_SANDBOX_WARNING"] = "true"
+    end
+    after do
+      ENV["DISABLE_SANDBOX_WARNING"] = nil
+    end
+    it "on homepage" do
+      visit root_path
+      expect(page).not_to have_content("This sandbox site is for testing and training purposes only")
+    end
+
+    it "on internal pages" do
+      visit proposals_path
+      expect(page).not_to have_content("This sandbox site is for testing and training purposes only")
+    end
+  end
+end


### PR DESCRIPTION
"As a SANDBOX USER, I can see a reminder that the website is a sandbox so that I don't accidentally make live requests."
<img width="1280" alt="screen shot 2015-07-17 at 5 34 49 pm" src="https://cloud.githubusercontent.com/assets/1122643/8757676/5114406a-2caa-11e5-82c2-be53d184a6b5.png">
<img width="1280" alt="screen shot 2015-07-17 at 5 35 11 pm" src="https://cloud.githubusercontent.com/assets/1122643/8757680/5ab03fb6-2caa-11e5-95fd-1397ead32f47.png">

