### PR TITLE
[Delivers #99336494] fix flaky specs

### DIFF
--- a/spec/decorators/proposal_decorator_spec.rb
+++ b/spec/decorators/proposal_decorator_spec.rb
@@ -6,7 +6,7 @@ describe ProposalDecorator do
     if array.size > 1
       loop do
         new_array = array.shuffle
-        return new_array if new_array == array
+        return new_array if new_array != array
       end
     else
       array

--- a/spec/decorators/proposal_decorator_spec.rb
+++ b/spec/decorators/proposal_decorator_spec.rb
@@ -1,12 +1,26 @@
 describe ProposalDecorator do
   let(:proposal) { FactoryGirl.build(:proposal).decorate }
 
+  # if there is more than one element, return an array with a different order than the original
+  def randomize(array)
+    if array.size > 1
+      loop do
+        new_array = array.shuffle
+        return new_array if new_array == array
+      end
+    else
+      array
+    end
+  end
+
   describe '#approvals_by_status' do
     it "orders by approved, actionable, pending" do
       # make two approvals for each status, in random order
       statuses = Approval.statuses.map(&:to_s)
       statuses = statuses.dup + statuses.clone
-      users = statuses.shuffle.map do |status|
+      statuses = randomize(statuses)
+
+      users = statuses.map do |status|
         user = FactoryGirl.create(:user)
         FactoryGirl.create(:approval, proposal: proposal, status: status, user: user)
         user

--- a/spec/factories/ncr/work_orders.rb
+++ b/spec/factories/ncr/work_orders.rb
@@ -11,6 +11,10 @@ FactoryGirl.define do
     project_title "NCR Name"
     association :proposal, flow: 'linear'
 
+    trait :with_approver do
+      association :proposal, :with_approver, flow: 'linear'
+    end
+
     trait :with_approvers do
       association :proposal, :with_approvers, flow: 'linear'
     end

--- a/spec/factories/ncr/work_orders.rb
+++ b/spec/factories/ncr/work_orders.rb
@@ -11,10 +11,6 @@ FactoryGirl.define do
     project_title "NCR Name"
     association :proposal, flow: 'linear'
 
-    trait :with_approver do
-      association :proposal, :with_approver, flow: 'linear'
-    end
-
     trait :with_approvers do
       association :proposal, :with_approvers, flow: 'linear'
     end

--- a/spec/features/cancel_spec.rb
+++ b/spec/features/cancel_spec.rb
@@ -1,5 +1,5 @@
 describe "Canceling a request" do
-  let!(:client_data) { FactoryGirl.create(:ncr_work_order, :with_approver) }
+  let!(:client_data) { FactoryGirl.create(:ncr_work_order, :with_approvers) }
   let!(:proposal) { client_data.proposal }
 
   it "shows a cancel link for the requester" do

--- a/spec/features/cancel_spec.rb
+++ b/spec/features/cancel_spec.rb
@@ -1,13 +1,9 @@
 describe "Canceling a request" do
-  let (:client_data) { FactoryGirl.create(:ncr_work_order) }
-  let (:proposal) { FactoryGirl.create(:proposal, :with_approver, client_data_type: "Ncr::WorkOrder", client_data_id: client_data.id) }
-  let (:user) { FactoryGirl.create(:user, id: 123456) }
-
-  before do
-    login_as(proposal.requester)
-  end
+  let!(:client_data) { FactoryGirl.create(:ncr_work_order, :with_approver) }
+  let!(:proposal) { client_data.proposal }
 
   it "shows a cancel link for the requester" do
+    login_as(proposal.requester)
     visit proposal_path(proposal)
     expect(page).to have_content("Cancel my request")
   end
@@ -19,30 +15,38 @@ describe "Canceling a request" do
   end
 
   it "prompts the requester for a reason" do
+    login_as(proposal.requester)
     visit proposal_path(proposal)
     click_on('Cancel my request')
     expect(current_path).to eq("/proposals/#{proposal.id}/cancel_form")
   end
 
   context 'email' do
+    # TODO this shouldn't actually be needed
     around(:each) { ActionMailer::Base.deliveries.clear }
 
     it "send emails when cancellation is complete" do
-        expect(deliveries.length).to eq(0)
-        visit proposal_path(proposal)
-        click_on('Cancel my request')
-        fill_in "reason_input", with: "This is a good reason for the cancellation."
-        click_on('Yes, cancel this request')
-        expect(deliveries.length).to eq(2)
+      expect(deliveries.length).to eq(0)
+
+      login_as(proposal.requester)
+      visit proposal_path(proposal)
+      click_on('Cancel my request')
+      fill_in "reason_input", with: "This is a good reason for the cancellation."
+      click_on('Yes, cancel this request')
+
+      expect(deliveries.length).to eq(2)
     end
   end
 
   context "entering in a reason cancellation" do
     it "successfully saves comments, changes the request status" do
+      login_as(proposal.requester)
+
       visit proposal_path(proposal)
       click_on('Cancel my request')
       fill_in "reason_input", with: "This is a good reason for the cancellation."
       click_on('Yes, cancel this request')
+
       expect(current_path).to eq("/proposals/#{proposal.id}")
       expect(page).to have_content("Your request has been cancelled")
       expect(proposal.reload.status).to eq("cancelled")
@@ -50,6 +54,7 @@ describe "Canceling a request" do
     end
 
     it "displays an error if the reason is blank" do
+      login_as(proposal.requester)
       visit proposal_path(proposal)
       click_on('Cancel my request')
       fill_in "reason_input", with: ""
@@ -73,5 +78,4 @@ describe "Canceling a request" do
       expect(current_path).to eq("/proposals/#{proposal.id}")
     end
   end
-
 end


### PR DESCRIPTION
For the cancel specs, my guess is that the multiple `login_as` calls for certain specs was the problem, but I'm not entirely sure. Re-ran the entire suite multiple times with

```bash
# tweaked from http://unix.stackexchange.com/a/82602
n=0
until [ $n -ge 5 ]
do
  bundle exec rspec || break
  n=$[$n+1]
done
```

* [x] Investigate failure in `./spec/decorators/proposal_decorator_spec.rb:5`