### PR TITLE
Remove 'rejected' state completely

### DIFF
--- a/app/assets/stylesheets/common/communicarts.scss
+++ b/app/assets/stylesheets/common/communicarts.scss
@@ -389,10 +389,6 @@ p.approved {
   padding-left: 21px;
 }
 
-p.rejected {
-  background-color: #fcc;
-}
-
 .needs-auth {
   left: 50%;
   top: 50%;
@@ -508,10 +504,6 @@ header {
     margin-top: .8em;
     margin-bottom: .2em;
   }
-}
-
-.reject-link {
-  margin-left: 15px;
 }
 
 ul#request-actions {

--- a/app/assets/stylesheets/modules/shared/email_status.scss
+++ b/app/assets/stylesheets/modules/shared/email_status.scss
@@ -46,7 +46,7 @@
     padding: 0 60px 0 0;
 
     &.last {
-      img.approved.linear, img.pending.linear, img.rejected.linear {
+      img.approved.linear, img.pending.linear {
         background-image: none;
       }
 

--- a/app/controllers/concerns/token_auth.rb
+++ b/app/controllers/concerns/token_auth.rb
@@ -38,7 +38,7 @@ module TokenAuth
       user_id: current_user, proposal_id: self.proposal})
     tokens.where(used_at: nil).update_all(used_at: Time.now)
 
-    authorize(self.proposal, :can_approve_or_reject!)
+    authorize(self.proposal, :can_approve!)
     if params[:version] && params[:version] != self.proposal.version.to_s
       raise Pundit::NotAuthorizedError.new(
         "This request has recently changed. Please review the modified request before approving.")

--- a/app/mailers/communicart_mailer.rb
+++ b/app/mailers/communicart_mailer.rb
@@ -8,7 +8,7 @@ class CommunicartMailer < ActionMailer::Base
   add_template_helper MarkdownHelper
 
 
-  # Approver can approve/reject/take other action
+  # Approver can approve/take other action
   def actions_for_approver(to_email, approval, alert_partial=nil)
     @show_approval_actions = true
     self.notification_for_approver(to_email, approval, alert_partial)

--- a/app/policies/proposal_policy.rb
+++ b/app/policies/proposal_policy.rb
@@ -57,10 +57,9 @@ class ProposalPolicy
           "A response has already been logged a response for this proposal")
   end
 
-  def can_approve_or_reject!
+  def can_approve!
     approver! && pending_approval! && not_cancelled!
   end
-  alias_method :can_approve!, :can_approve_or_reject!
 
   def can_edit!
     requester! && not_approved! && not_cancelled!

--- a/app/views/help/proposal_process.md
+++ b/app/views/help/proposal_process.md
@@ -2,4 +2,4 @@
 
 1. The approving official (AO) that the requester specified in the form will be sent an email notification with details of the request.
 1. If the approving official approves, it goes to the one or two budget mailboxes, depending on the type of request (BA61 vs. BA80, etc.).
-1. Once all approvers have approved (or any one of them reject) the request, the requester gets a notification.
+1. Once all approvers have approved the request, the requester gets a notification.

--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -186,7 +186,7 @@
   </div>
 <%- end %>
 
-<% if policy(@proposal).can_approve_or_reject? %>
+<% if policy(@proposal).can_approve? %>
   <div class="centered">
     <%= form_tag(approve_proposal_path(@proposal, method: "POST")) do %>
       <%= hidden_field_tag(:version, @proposal.version) %>

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -1,6 +1,6 @@
 # Technical overview
 
-C2 is, at its core, a state machine wrapped in email notifications. The system centers around Proposals, which are submitted by a "requester" and sent out to the "approvers" via email. Approvers can either ask questions or leave comments, then approve" or reject the request. The requester (and any "observers") get notifications about the overall progress. Aside from receiving email notifications for updates, users can log in at any time and see the details for outstanding and past Proposals they were involved with.
+C2 is, at its core, a state machine wrapped in email notifications. The system centers around Proposals, which are submitted by a "requester" and sent out to the "approvers" via email. Approvers can either ask questions or leave comments, then approve" the request. The requester (and any "observers") get notifications about the overall progress. Aside from receiving email notifications for updates, users can log in at any time and see the details for outstanding and past Proposals they were involved with.
 
 Note: You will see references to "Carts" throughout the interface and the code...this is a legacy term, which is in the middle of being split into Proposals and their associated domain-(a.k.a. "use case")-specific models. The name "Communicart" is a reference to this initial use case as well.
 
@@ -69,7 +69,7 @@ The NCR use case was built around GSA service centers (paint shops, landscapers,
 1. The requester submits a new purchase request via the form at `/ncr/work_orders/new`.
 1. Their "approving officer" (the "AO" – their supervisor) receives an email notification with the request.
 1. If the AO approves, it goes to one or two other budget office approvers, depending on the type of request.
-1. Once all approvers have approved (or any one of them reject) the Proposal, the requester gets a notification.
+1. Once all approvers have approved the Proposal, the requester gets a notification.
 
 #### Additional resources
 

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -38,13 +38,6 @@ class Dispatcher
     true
   end
 
-  def on_proposal_rejected(proposal)
-    rejection = proposal.approvals.rejected.first
-    # @todo rewrite this email so a "rejection approval" isn't needed
-    CommunicartMailer.approval_reply_received_email(rejection).deliver_now
-    self.email_observers(proposal)
-  end
-
   def on_approval_approved(approval)
     if self.requires_approval_notice?(approval)
       CommunicartMailer.approval_reply_received_email(approval).deliver_now
@@ -82,11 +75,6 @@ class Dispatcher
   def self.deliver_new_proposal_emails(proposal)
     dispatcher = self.initialize_dispatcher(proposal)
     dispatcher.deliver_new_proposal_emails(proposal)
-  end
-
-  def self.on_proposal_rejected(proposal)
-    dispatcher = self.initialize_dispatcher(proposal)
-    dispatcher.on_proposal_rejected(proposal)
   end
 
   def self.on_approval_approved(approval)

--- a/lib/linear_dispatcher.rb
+++ b/lib/linear_dispatcher.rb
@@ -1,6 +1,6 @@
 class LinearDispatcher < Dispatcher
   def next_pending_approval(proposal)
-    # we don't care how the proposal was approved/rejected
+    # we don't care how the proposal was approved
     if proposal.pending?
       proposal.currently_awaiting_approvals.first
     else

--- a/lib/mail_preview.rb
+++ b/lib/mail_preview.rb
@@ -32,7 +32,7 @@ class MailPreview < MailView
   end
 
   def received_approval
-    Approval.where(status: ['approved', 'rejected']).last
+    Approval.approved.last
   end
 
   def proposal

--- a/spec/features/18f_procurement_spec.rb
+++ b/spec/features/18f_procurement_spec.rb
@@ -110,13 +110,6 @@ describe "GSA 18f Purchase Request Form" do
       expect(procurement.link_to_product).to eq('http://www.submitted.com')
     end
 
-    it "can be restarted if rejected" do
-      proposal.update_attributes(status: 'rejected')  # avoid workflow
-
-      visit "/gsa18f/procurements/#{procurement.id}/edit"
-      expect(current_path).to eq("/gsa18f/procurements/#{procurement.id}/edit")
-    end
-
     it "cannot be restarted if approved" do
       proposal.update_attributes(status: 'approved')  # avoid workflow
 
@@ -185,12 +178,6 @@ describe "GSA 18f Purchase Request Form" do
       expect(page).to have_content("Discard Changes")
       click_on "Discard Changes"
       expect(current_path).to eq("/proposals/#{proposal.id}")
-    end
-
-    it "shows a restart link from a rejected proposal" do
-      proposal.update_attribute(:status, 'rejected') # avoid state machine
-      visit "/proposals/#{proposal.id}"
-      expect(page).to have_content('Modify Request')
     end
 
     it "does not show a restart link for an approved proposal" do

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -317,13 +317,6 @@ describe "National Capital Region proposals" do
       expect(current_path).to eq("/ncr/work_orders/#{work_order.id}/edit")
     end
 
-    it "shows a edit link from a rejected proposal" do
-      ncr_proposal.update_attribute(:status, 'rejected') # avoid state machine
-
-      visit "/proposals/#{ncr_proposal.id}"
-      expect(page).to have_content('Modify Request')
-    end
-
     it "shows a edit link for an approved proposal" do
       ncr_proposal.update_attribute(:status, 'approved') # avoid state machine
 
@@ -451,13 +444,6 @@ describe "National Capital Region proposals" do
         # Verify it is actually saved
         work_order.reload
         expect(work_order.vendor).to eq("New ACME")
-      end
-
-      it "can be edited if rejected" do
-        ncr_proposal.update_attributes(status: 'rejected')  # avoid workflow
-
-        visit "/ncr/work_orders/#{work_order.id}/edit"
-        expect(current_path).to eq("/ncr/work_orders/#{work_order.id}/edit")
       end
 
       it "can be edited if approved" do

--- a/spec/lib/linear_dispatcher_spec.rb
+++ b/spec/lib/linear_dispatcher_spec.rb
@@ -23,13 +23,6 @@ describe LinearDispatcher do
       expect(dispatcher.next_pending_approval(proposal)).to eq(last_approval)
     end
 
-    it "returns nil if the proposal is rejected" do
-      next_app = proposal.approvals.create!(position: 5, status: 'actionable')
-      expect(dispatcher.next_pending_approval(proposal)).to eq(next_app)
-      next_app.update_attribute(:status, 'rejected')  # skip state machine
-      expect(dispatcher.next_pending_approval(proposal)).to eq(nil)
-    end
-
     it "skips approved approvals" do
       first_approval = proposal.approvals.create!(position: 6, status: 'actionable')
       proposal.approvals.create!(position: 5, status: 'approved')

--- a/spec/policies/proposal_policy_spec.rb
+++ b/spec/policies/proposal_policy_spec.rb
@@ -1,7 +1,7 @@
 describe ProposalPolicy do
   subject { described_class }
 
-  permissions :can_approve_or_reject? do
+  permissions :can_approve? do
     it "allows pending delegates" do
       proposal = FactoryGirl.create(:proposal, :with_approvers)
 
@@ -26,11 +26,6 @@ describe ProposalPolicy do
 
       it "does not allow when the user's already approved" do
         approval.update_attribute(:status, 'approved')  # skip state machine
-        expect(subject).not_to permit(approval.user, proposal)
-      end
-
-      it "does not allow when the user's already rejected" do
-        approval.update_attribute(:status, 'rejected')  # skip state machine
         expect(subject).not_to permit(approval.user, proposal)
       end
 


### PR DESCRIPTION
Split out from #454, this removes references to the rejected state from our code base.