### PR TITLE
Split parallel and serial proposal approvers

### DIFF
--- a/lib/populator.rb
+++ b/lib/populator.rb
@@ -21,7 +21,7 @@ module Populator
 
       # TODO all of these things should have the same created_at/updated_at... use Timecop
       proposal = FactoryGirl.create(:proposal,
-        :with_approvers,
+        :with_serial_approvers,
         :with_observers,
         created_at: requested_at,
         updated_at: requested_at

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -1,6 +1,6 @@
 describe AttachmentsController do
   describe 'permission checking' do
-    let (:proposal) { FactoryGirl.create(:proposal, :with_approvers, :with_observers) }
+    let (:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers, :with_observers) }
     let (:params) {{
       proposal_id: proposal.id,
       attachment: { file: fixture_file_upload('icon-user.png', 'image/png') }
@@ -56,7 +56,7 @@ describe AttachmentsController do
   end
 
   describe '#show' do
-    let (:proposal) { FactoryGirl.create(:proposal, :with_approvers, :with_observers) }
+    let (:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers, :with_observers) }
     let (:attachment) { FactoryGirl.create(:attachment, proposal: proposal, user: proposal.requester) }
 
     it "allows the requester to view attachment" do

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,6 +1,6 @@
 describe CommentsController do
   describe 'permission checking' do
-    let (:proposal) { FactoryGirl.create(:proposal, :with_approvers, :with_observers) }
+    let (:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers, :with_observers) }
     let (:params) { {proposal_id: proposal.id,
                      comment: {comment_text: 'Some comment'}} }
 

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -272,7 +272,7 @@ describe ProposalsController do
     end
 
     it "allows a delegate to approve via the web UI" do
-      proposal = FactoryGirl.create(:proposal, :with_approvers, flow: "linear")
+      proposal = FactoryGirl.create(:proposal, :with_serial_approvers)
       mailbox = proposal.approvers.second
       delegate = FactoryGirl.create(:user)
       mailbox.add_delegate(delegate)

--- a/spec/factories/gsa18f/procurements.rb
+++ b/spec/factories/gsa18f/procurements.rb
@@ -7,9 +7,5 @@ FactoryGirl.define do
     office Gsa18f::Procurement::OFFICES[0]
     urgency Gsa18f::Procurement::URGENCY[0]
     association :proposal, flow: 'linear'
-
-    trait :with_approvers do
-      association :proposal, :with_approvers
-    end
   end
 end

--- a/spec/factories/ncr/work_orders.rb
+++ b/spec/factories/ncr/work_orders.rb
@@ -12,7 +12,7 @@ FactoryGirl.define do
     association :proposal, flow: 'linear'
 
     trait :with_approvers do
-      association :proposal, :with_approvers, flow: 'linear'
+      association :proposal, :with_serial_approvers, flow: 'linear'
     end
 
     trait :is_emergency do

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -11,10 +11,20 @@ FactoryGirl.define do
       end
     end
 
-    trait :with_approvers do
-      with_approver
 
+    trait :with_serial_approvers do
+      flow 'linear'
       after :create do |proposal|
+        proposal.add_approver('approver1@some-dot-gov.gov')
+        proposal.add_approver('approver2@some-dot-gov.gov')
+        proposal.kickstart_approvals()
+      end
+    end
+
+    trait :with_parallel_approvers do
+      flow 'parallel'
+      after :create do |proposal|
+        proposal.add_approver('approver1@some-dot-gov.gov')
         proposal.add_approver('approver2@some-dot-gov.gov')
         proposal.kickstart_approvals()
       end

--- a/spec/features/attachment_spec.rb
+++ b/spec/features/attachment_spec.rb
@@ -1,7 +1,5 @@
 describe "Add attachments" do
-  let (:proposal) {
-    FactoryGirl.create(:proposal, :with_approvers)
-  }
+  let (:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers) }
   let! (:attachment) {
     FactoryGirl.create(:attachment, proposal: proposal,
                        user: proposal.requester) }

--- a/spec/features/comment_spec.rb
+++ b/spec/features/comment_spec.rb
@@ -1,5 +1,5 @@
 describe "commenting" do
-  let(:proposal) { FactoryGirl.create(:proposal, :with_approvers) }
+  let(:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers) }
 
   before do
     login_as(proposal.requester)

--- a/spec/features/display_status_spec.rb
+++ b/spec/features/display_status_spec.rb
@@ -1,5 +1,5 @@
 describe "Display status text" do
-  let(:proposal) { FactoryGirl.create(:proposal, :with_approvers) }
+  let(:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers) }
   before do
     login_as(proposal.requester)
   end
@@ -29,7 +29,7 @@ describe "Display status text" do
   end
 
   context "linear" do
-    let(:proposal) { FactoryGirl.create(:proposal, :with_approvers, flow: 'linear') }
+    let(:proposal) { FactoryGirl.create(:proposal, :with_serial_approvers) }
 
     it "displays the first approver" do
       visit proposals_path

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -109,8 +109,7 @@ describe "National Capital Region proposals" do
       end
 
       it "defaults to the approver from the last request" do
-        proposal = FactoryGirl.create(:proposal, :with_approvers,
-                                      requester: requester)
+        proposal = FactoryGirl.create(:proposal, :with_serial_approvers, requester: requester)
         visit '/ncr/work_orders/new'
         expect(find_field("Approving official's email address").value).to eq(
           proposal.approvers.first.email_address)

--- a/spec/features/version_check_spec.rb
+++ b/spec/features/version_check_spec.rb
@@ -1,5 +1,5 @@
 describe "Version check" do
-  let(:proposal) { FactoryGirl.create(:proposal, :with_approvers) }
+  let(:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers) }
 
   it "occurs if the proposal is modified in after seeing the profile page" do
     login_as(proposal.approvers.first)

--- a/spec/lib/dispatcher_spec.rb
+++ b/spec/lib/dispatcher_spec.rb
@@ -23,7 +23,7 @@ describe Dispatcher do
     end
   end
 
-  let(:proposal) { FactoryGirl.create(:proposal, :with_approvers) }
+  let(:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers) }
   let(:dispatcher) { Dispatcher.new }
 
   describe '#deliver_new_proposal_emails' do

--- a/spec/lib/linear_dispatcher_spec.rb
+++ b/spec/lib/linear_dispatcher_spec.rb
@@ -68,7 +68,7 @@ describe LinearDispatcher do
 
   describe '#on_approval_approved' do
     it "sends to the requester and the next approver" do
-      proposal = FactoryGirl.create(:proposal, :with_approvers)
+      proposal = FactoryGirl.create(:proposal, :with_parallel_approvers)
       approval = proposal.approvals.first
       approval.update_attribute(:status, 'approved')  # avoiding state machine
       dispatcher.on_approval_approved(approval)

--- a/spec/mailers/communicart_mailer_spec.rb
+++ b/spec/mailers/communicart_mailer_spec.rb
@@ -13,7 +13,7 @@ describe CommunicartMailer do
     ENV['NOTIFICATION_FROM_EMAIL'] = old_val
   end
 
-  let(:proposal) { FactoryGirl.create(:proposal, :with_approvers) }
+  let(:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers) }
   let(:approval) { proposal.approvals.first }
   let(:approver) { approval.user }
   let(:requester) { proposal.requester }

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1,5 +1,5 @@
 describe Attachment do
-  let (:proposal) { FactoryGirl.create(:proposal, :with_approvers) }
+  let (:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers) }
   let (:attachment) { FactoryGirl.create(:attachment, proposal: proposal, user: proposal.requester) }
 
   context "aws" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,7 +1,6 @@
 describe Comment do
   describe "#listeners" do
-    let (:proposal) { FactoryGirl.create(
-      :proposal, :with_approvers, :with_observers, flow: "linear") }
+    let (:proposal) { FactoryGirl.create(:proposal, :with_serial_approvers, :with_observers) }
     let (:comment) { FactoryGirl.create(:comment, proposal: proposal) }
 
     it "includes the requester" do

--- a/spec/models/gsa18f/procurement_spec.rb
+++ b/spec/models/gsa18f/procurement_spec.rb
@@ -9,12 +9,10 @@ describe Gsa18f::Procurement do
     end
 
     it "adds 18fapprover@gsa.gov as approver email" do
-      procurement = FactoryGirl.create(:gsa18f_procurement, :with_approvers)
+      procurement = FactoryGirl.create(:gsa18f_procurement)
       expect(procurement).to be_valid
 
       expect(approver_emails(procurement)).to eq([
-        'approver1@some-dot-gov.gov',
-        'approver2@some-dot-gov.gov',
         Gsa18f::Procurement.approver_email
       ])
     end

--- a/spec/models/gsa18f/procurement_spec.rb
+++ b/spec/models/gsa18f/procurement_spec.rb
@@ -1,20 +1,11 @@
 describe Gsa18f::Procurement do
-  around(:each) do |example|
-    with_18f_procurement_env_variables(&example)
-  end
-
-  describe '#create_cart' do
-    def approver_emails(procurement)
-      procurement.approvals.map {|a| a.user.email_address }
-    end
-
-    it "adds 18fapprover@gsa.gov as approver email" do
+  with_env_vars(GSA18F_APPROVER_EMAIL: 'approver@gsa.gov',
+                GSA18F_PURCHASER_EMAIL: 'purchaser@gsa.gov') do
+    it 'sets up initial approvers and observers' do
       procurement = FactoryGirl.create(:gsa18f_procurement)
-      expect(procurement).to be_valid
 
-      expect(approver_emails(procurement)).to eq([
-        Gsa18f::Procurement.approver_email
-      ])
+      expect(procurement.approvers.map(&:email_address)).to eq(['approver@gsa.gov'])
+      expect(procurement.observers.map(&:email_address)).to eq(['purchaser@gsa.gov'])
     end
   end
 

--- a/spec/policies/attachment_policy_spec.rb
+++ b/spec/policies/attachment_policy_spec.rb
@@ -1,8 +1,6 @@
 describe AttachmentPolicy do
   subject { described_class }
-  let(:proposal) {
-    FactoryGirl.create(:proposal, :with_approvers, :with_observers)
-  }
+  let(:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers, :with_observers) }
   let(:attachment) { FactoryGirl.create(:attachment, proposal: proposal) } 
 
   permissions :can_destroy? do

--- a/spec/policies/proposal_policy_spec.rb
+++ b/spec/policies/proposal_policy_spec.rb
@@ -3,7 +3,7 @@ describe ProposalPolicy do
 
   permissions :can_approve_or_reject? do
     it "allows pending delegates" do
-      proposal = FactoryGirl.create(:proposal, :with_approvers)
+      proposal = FactoryGirl.create(:proposal, :with_parallel_approvers)
 
       approval = proposal.approvals.first
       delegate = FactoryGirl.create(:user)
@@ -14,8 +14,7 @@ describe ProposalPolicy do
     end
 
     context "parallel proposal" do
-      let(:proposal) {FactoryGirl.create(:proposal, :with_approvers,
-                                         flow: 'parallel')}
+      let(:proposal) {FactoryGirl.create(:proposal, :with_parallel_approvers)}
       let(:approval) {proposal.approvals.first}
 
       it "allows when there's a pending approval" do
@@ -41,8 +40,7 @@ describe ProposalPolicy do
     end
 
     context "linear proposal" do
-      let(:proposal) {FactoryGirl.create(:proposal, :with_approvers,
-                                         flow: 'linear')}
+      let(:proposal) {FactoryGirl.create(:proposal, :with_serial_approvers)}
       let(:first_approval) { proposal.approvals.first }
       let(:second_approval) { proposal.approvals.last }
 
@@ -68,8 +66,7 @@ describe ProposalPolicy do
   end
 
   permissions :can_show? do
-    let(:proposal) {FactoryGirl.create(:proposal, :with_approvers,
-                                       :with_observers)}
+    let(:proposal) {FactoryGirl.create(:proposal, :with_parallel_approvers, :with_observers)}
 
     it "allows the requester to see it" do
       expect(subject).to permit(proposal.requester, proposal)
@@ -97,7 +94,7 @@ describe ProposalPolicy do
   end
 
   permissions :can_edit? do
-    let(:proposal) { FactoryGirl.create(:proposal, :with_approvers, :with_observers) }
+    let(:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers, :with_observers) }
 
     it "allows the requester to edit it" do
       expect(subject).to permit(proposal.requester, proposal)
@@ -123,7 +120,7 @@ describe ProposalPolicy do
   end
 
   permissions :can_cancel? do
-    let(:proposal) { FactoryGirl.create(:proposal, :with_approvers) }
+    let(:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers) }
 
     it "allows the requester to edit it" do
       expect(subject).to permit(proposal.requester, proposal)
@@ -140,7 +137,7 @@ describe ProposalPolicy do
   end
 
   context "testing scope" do
-    let(:proposal) { FactoryGirl.create(:proposal, :with_approvers, :with_observers) }
+    let(:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers, :with_observers) }
 
     it "allows the requester to see" do
       user = proposal.requester
@@ -203,7 +200,7 @@ describe ProposalPolicy do
         ENV['CLIENT_ADMIN_EMAILS'] = ""
       end
 
-      let(:proposal1) { FactoryGirl.create(:proposal, :with_approvers, :with_observers, requester_id: 555) }
+      let(:proposal1) { FactoryGirl.create(:proposal, :with_parallel_approvers, :with_observers, requester_id: 555) }
 
       it "allows a client admin to see unassociated requests that are inside its client scope" do
         proposal.update_attributes(client_data_type:'AbcCompany::SomethingApprovable')
@@ -234,7 +231,7 @@ describe ProposalPolicy do
     end
 
     context "ADMIN privileges" do
-      let(:proposal1) { FactoryGirl.create(:proposal, :with_approvers, :with_observers, requester_id: 555) }
+      let(:proposal1) { FactoryGirl.create(:proposal, :with_parallel_approvers, :with_observers, requester_id: 555) }
 
       after do
         ENV['ADMIN_EMAILS'] = ""


### PR DESCRIPTION
Split out from #454 , this updates the proposal factory with specific traits for parallel and serial approvals. Also fixes some cruft in the procurement spec, which wasn't testing what it should have been.