### PR TITLE
Frontpage nav css fix

### DIFF
--- a/app/assets/stylesheets/common/header.scss
+++ b/app/assets/stylesheets/common/header.scss
@@ -22,12 +22,6 @@ header {
   }
 }
 
-.header-nav {
-  display: inline-block;
-  float: right;
-  color: #fff;
-}
-
 ul#breadcrumb-nav {
   width: 800px;
   margin: 0 auto;
@@ -52,24 +46,4 @@ ul#breadcrumb-nav {
   width: 200px;
   height: 30px;
   text-indent: -2000px;
-}
-
-.header-nav li {
-  display: inline-block;
-  padding-right: 12px;
-}
-
-.mycart-link {
-  clear: all;
-  margin-top: -20px;
-}
-
-@media (max-width: 480px) {
-  .header-nav {
-    padding-start: 0px;
-    text-align: right;
-    li {
-      padding-right: 0;
-    }
-  }
 }

--- a/app/assets/stylesheets/common/sandbox_banner.scss
+++ b/app/assets/stylesheets/common/sandbox_banner.scss
@@ -6,4 +6,6 @@
   border-top: none;
   text-align: center;
   padding: 10px 10px;
+  font-size: 14px;
+  color: #333;
 }

--- a/app/assets/stylesheets/common/static.scss
+++ b/app/assets/stylesheets/common/static.scss
@@ -1,5 +1,6 @@
 @import "../modules/request_form";
 @import "../modules/search_ui";
+@import "../modules/layouts/header_nav";
 
 body {
   font-family: helvetica, verdana, arial, sans-serif;

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -12,6 +12,7 @@
  *= require common/header
  *= require common/sandbox_banner
  *= require common/button_to
+ *= require modules/layouts/header_nav
  */
 
 @import "bootstrap-sprockets";

--- a/app/assets/stylesheets/modules/layouts/header_nav.scss
+++ b/app/assets/stylesheets/modules/layouts/header_nav.scss
@@ -1,0 +1,30 @@
+.header-nav {
+  display: inline-block;
+  float: right;
+  color: #fff;
+
+  li {
+      display: inline-block;
+      padding-right: 12px;
+    }
+
+  a {
+      color: #fff;
+    }
+
+}
+
+.mycart-link {
+  clear: all;
+  margin-top: -20px;
+}
+
+@media (max-width: 480px) {
+  .header-nav {
+    padding-start: 0px;
+    text-align: right;
+    li {
+      padding-right: 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/webapp/webviews.scss
+++ b/app/assets/stylesheets/webapp/webviews.scss
@@ -252,10 +252,6 @@ body.webapp {
     margin-bottom: $webpadding;
     padding: $webpadding;
   }
-  .sandbox-banner {
-    font-size: 14px;
-    color: #333;
-  }
 }
 
 .controller-proposals {


### PR DESCRIPTION
Fixes a css bug that was causing the frontpage nav to show up an unreadable dark blue instead of white. Also moves the header nav css into its own stylesheet.

Paired with @afeld.

Before the fix:
<img width="401" alt="screen shot 2015-07-21 at 4 35 12 pm" src="https://cloud.githubusercontent.com/assets/1122643/8811846/9f1b5edc-2fc6-11e5-8e46-0d4a0294175a.png">

After:
<img width="419" alt="screen shot 2015-07-21 at 4 35 30 pm" src="https://cloud.githubusercontent.com/assets/1122643/8811848/a55c5de6-2fc6-11e5-8fd9-adf9d359efd9.png">
