### PR TITLE
Add materialized "approved_at" field to approvals

### DIFF
--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -37,17 +37,9 @@ class Approval < ActiveRecord::Base
   scope :with_users, -> { includes :user }
 
 
-  # TODO we should probably store this value
-  def approved_at
-    if self.approved?
-      self.updated_at
-    else
-      nil
-    end
-  end
-
   # Used by the state machine
   def on_approved_entry(new_state, event)
+    self.update(approved_at: Time.now)
     self.proposal.partial_approve!
     Dispatcher.on_approval_approved(self)
   end

--- a/db/migrate/20150721205524_add_approved_at_to_approvals.rb
+++ b/db/migrate/20150721205524_add_approved_at_to_approvals.rb
@@ -1,0 +1,13 @@
+class AddApprovedAtToApprovals < ActiveRecord::Migration
+  def up
+    add_column :approvals, :approved_at, :datetime
+    execute <<-SQL
+      UPDATE approvals SET approved_at = updated_at
+      WHERE status = 'approved';
+    SQL
+  end
+
+  def down
+    remove_column :approvals, :approved_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150718164818) do
+ActiveRecord::Schema.define(version: 20150721205524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 20150718164818) do
     t.datetime "updated_at"
     t.integer  "position"
     t.integer  "proposal_id"
+    t.datetime "approved_at"
   end
 
   create_table "attachments", force: :cascade do |t|

--- a/spec/factories/approvals.rb
+++ b/spec/factories/approvals.rb
@@ -1,15 +1,7 @@
 FactoryGirl.define do
   factory :approval do
-    proposal_id 1
-    user_id 1
+    proposal
+    user
     status 'pending'
-
-    trait :with_proposal do
-      proposal
-    end
-
-    trait :with_user do
-      user
-    end
   end
 end

--- a/spec/helpers/communicart_mailer_helper_spec.rb
+++ b/spec/helpers/communicart_mailer_helper_spec.rb
@@ -1,7 +1,7 @@
 describe CommunicartMailerHelper do
   describe '#generate_approve_url' do
     it "returns a URL" do
-      approval = FactoryGirl.create(:approval, :with_proposal, :with_user)
+      approval = FactoryGirl.create(:approval)
       token = approval.create_api_token!
       proposal = approval.proposal
 

--- a/spec/lib/linear_dispatcher_spec.rb
+++ b/spec/lib/linear_dispatcher_spec.rb
@@ -68,10 +68,9 @@ describe LinearDispatcher do
 
   describe '#on_approval_approved' do
     it "sends to the requester and the next approver" do
-      proposal = FactoryGirl.create(:proposal, :with_approvers)
+      proposal = FactoryGirl.create(:proposal, :with_approvers, flow: 'linear')
       approval = proposal.approvals.first
-      approval.update_attribute(:status, 'approved')  # avoiding state machine
-      dispatcher.on_approval_approved(approval)
+      approval.approve!   # calls on_approval_approved
       expect(email_recipients).to eq([
         'approver2@some-dot-gov.gov',
         proposal.requester.email_address

--- a/spec/models/approval_spec.rb
+++ b/spec/models/approval_spec.rb
@@ -35,6 +35,8 @@ describe Approval do
       approval.make_actionable!
       approval.approve!
       expect(approval.approved_at).not_to be_nil
+      approval.reload
+      expect(approval.approved_at).not_to be_nil
     end
   end
 end

--- a/spec/models/approval_spec.rb
+++ b/spec/models/approval_spec.rb
@@ -20,4 +20,21 @@ describe Approval do
       expect(approval.api_token).to eq(nil)
     end
   end
+
+  describe '#approved_at' do
+    it 'is nil when pending' do
+      expect(approval.approved_at).to be_nil
+    end
+
+    it 'is nil when actionable' do
+      approval.make_actionable!
+      expect(approval.approved_at).to be_nil
+    end
+
+    it 'is set when approved' do
+      approval.make_actionable!
+      approval.approve!
+      expect(approval.approved_at).not_to be_nil
+    end
+  end
 end

--- a/spec/views/communicart_mailer/_email_reply.html.erb_spec.rb
+++ b/spec/views/communicart_mailer/_email_reply.html.erb_spec.rb
@@ -1,6 +1,6 @@
 describe "communicart_mailer/_email_reply.html.erb" do
   it "renders 'Send a Comment' link with approve button" do
-    approval = FactoryGirl.create(:approval, :with_proposal, :with_user)
+    approval = FactoryGirl.create(:approval)
     approval.create_api_token!
     render partial: "communicart_mailer/email_reply", locals: {show_approval_actions: true, approval: approval}
 
@@ -9,7 +9,7 @@ describe "communicart_mailer/_email_reply.html.erb" do
     expect(rendered).to_not include "View this request"
   end
   it "renders 'View This Request' link without approve button" do
-    approval = FactoryGirl.create(:approval, :with_proposal, :with_user)
+    approval = FactoryGirl.create(:approval)
     approval.create_api_token!
     render partial: "communicart_mailer/email_reply", locals: {show_approval_actions: false, approval: approval}
 


### PR DESCRIPTION
Split from #454, this creates an `approved_at` field for approvals. The field is set when the approval enters the approved state. Also backfills existing data.

Also simplifies options on the approval factory (rather than setting non-useful defaults).