### PR TITLE
[Delivers #99321148] Show requester in request list for client-specific users

### DIFF
--- a/app/views/gsa18f/_proposal_list.html.erb
+++ b/app/views/gsa18f/_proposal_list.html.erb
@@ -5,7 +5,8 @@
 <table class="proposal-list">
   <tr class="header">
     <th class="sixth" scope="col"><h5>ID</h5></th>
-    <th class="first" scope="col"><h5>Request</h5></th>
+    <th class="next" scope="col"><h5>Request</h5></th>
+    <th class="sixth" scope="col"><h5>Requester</h5></th>
     <th class="sixth" scope="col"><h5>Total Price</h5></th>
     <th class="sixth" scope="col"><h5>Status</h5></th>
     <th class="sixth" scope="col"><h5>Submitted</h5></th>
@@ -18,7 +19,8 @@
   <%- proposals_list.each do |proposal| %>
     <tr>
       <td class="sixth"><a href="<%= proposal_url(proposal) %>"><%= proposal.public_identifier %></a></td>
-      <td class="first"><a href="<%= proposal_url(proposal) %>"><%= proposal.name %></a></td>
+      <td class="next"><a href="<%= proposal_url(proposal) %>"><%= proposal.name %></a></td>
+      <td class="sixth"><%= proposal.requester.email_address %></td>
       <td class="sixth"><%= number_to_currency(proposal.client_data.try(:total_price)) %></td>
       <td class="sixth">
         <%= render partial: 'proposals/review_status',

--- a/app/views/ncr/_proposal_list.html.erb
+++ b/app/views/ncr/_proposal_list.html.erb
@@ -5,7 +5,8 @@
 <table class="proposal-list">
   <tr class="header">
     <th class="sixth" scope="col"><h5>ID</h5></th>
-    <th class="first" scope="col"><h5>Request</h5></th>
+    <th class="next" scope="col"><h5>Request</h5></th>
+    <th class="sixth" scope="col"><h5>Requester</h5></th>
     <th class="sixth" scope="col"><h5>Total Price</h5></th>
     <th class="sixth" scope="col"><h5>Status</h5></th>
     <th class="sixth" scope="col"><h5>Submitted</h5></th>
@@ -18,7 +19,8 @@
   <%- proposals_list.each do |proposal| %>
     <tr>
       <td class="sixth"><a href="<%= proposal_url(proposal) %>"><%= proposal.public_identifier %></a></td>
-      <td class="first"><a href="<%= proposal_url(proposal) %>"><%= proposal.name %></a></td>
+      <td class="next"><a href="<%= proposal_url(proposal) %>"><%= proposal.name %></a></td>
+      <td class="sixth"><%= proposal.requester.email_address %></td>
       <td class="sixth"><%= number_to_currency(proposal.client_data.try(:total_price)) %></td>
       <td class="sixth">
         <%= render partial: 'proposals/review_status',

--- a/spec/features/proposal_listing_spec.rb
+++ b/spec/features/proposal_listing_spec.rb
@@ -19,26 +19,60 @@ describe "Listing Page" do
     login_as(user)
   end
 
-  it "should not explode if client is not set" do
-    visit '/proposals'
-    expect(page).to have_content(default.public_identifier)
-    expect(page).to have_content(ncr.public_identifier)
-    expect(page).to have_content(gsa18f.proposal.public_identifier)
+  context "client is not set" do
+    before do
+      user.update_attribute(:client_slug, '')
+    end
+
+    it "should not explode" do
+      visit '/proposals'
+      expect(page).to have_content(default.public_identifier)
+      expect(page).to have_content(ncr.public_identifier)
+      expect(page).to have_content(gsa18f.proposal.public_identifier)
+    end
+
+    it "should show requester" do
+      visit '/proposals'
+      expect(page).to have_content("Requester")
+      expect(page).to have_content(default.name+' '+default.requester.email_address)
+    end
   end
 
-  it "should not explode if client is ncr" do
-    user.update_attribute(:client_slug, 'ncr')
-    visit '/proposals'
-    expect(page).to have_content(default.public_identifier)
-    expect(page).to have_content(ncr.public_identifier)
-    expect(page).to have_content(gsa18f.proposal.public_identifier)
+  context "client is ncr" do
+    before do
+      user.update_attribute(:client_slug, 'ncr')
+    end
+
+    it "should not explode" do
+      visit '/proposals'
+      expect(page).to have_content(default.public_identifier)
+      expect(page).to have_content(ncr.public_identifier)
+      expect(page).to have_content(gsa18f.proposal.public_identifier)
+    end
+
+    it "should show requester" do
+      visit '/proposals'
+      expect(page).to have_content("Requester")
+      expect(page).to have_content(ncr.name+' '+ncr.requester.email_address)
+    end
   end
 
-  it "should not explode if client is gsa18f" do
-    user.update_attribute(:client_slug, 'gsa18f')
-    visit '/proposals'
-    expect(page).to have_content(default.public_identifier)
-    expect(page).to have_content(ncr.public_identifier)
-    expect(page).to have_content(gsa18f.proposal.public_identifier)
+  context "client is gsa18f" do
+    before do
+      user.update_attribute(:client_slug, 'gsa18f')
+    end
+
+    it "should not explode" do
+      visit '/proposals'
+      expect(page).to have_content(default.public_identifier)
+      expect(page).to have_content(ncr.public_identifier)
+      expect(page).to have_content(gsa18f.proposal.public_identifier)
+    end
+
+    it "should show requester" do
+      visit '/proposals'
+      expect(page).to have_content("Requester")
+      expect(page).to have_content(gsa18f.name+' '+gsa18f.requester.email_address)
+    end
   end
 end


### PR DESCRIPTION
Fixes a bug where the requester email address is hidden in the "my requests" table for users with a client slug set.