### PR TITLE
Added minor css tweaks to deal with Photon overrides on the homepage

### DIFF
--- a/app/assets/stylesheets/common/sandbox_banner.scss
+++ b/app/assets/stylesheets/common/sandbox_banner.scss
@@ -1,4 +1,6 @@
 .sandbox-banner {
+  font-family: Helvetica, Arial, sans-serif;
+  font-weight: normal;
   width: 100%;
   display: block;
   background: #fff2bb;
@@ -8,4 +10,8 @@
   padding: 10px 10px;
   font-size: 14px;
   color: #333;
+
+  a, a:hover {
+    color: #006be6;
+  }
 }

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -4,8 +4,6 @@
   html5up.net | @n33co
   Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
 %html{lang: 'en'}
-  - unless ENV["DISABLE_SANDBOX_WARNING"]
-    = render 'shared/sandbox_warning'
   %head
     %title Communicart
     %meta{'http-equiv' => "content-type", content: "text/html; charset=utf-8"}
@@ -24,6 +22,8 @@
       = stylesheet_link_tag "photon/ie/v8.css"
 
   %body
+    - unless ENV["DISABLE_SANDBOX_WARNING"]
+      = render 'shared/sandbox_warning'
     / Header
     %section#header
       - flash_list.each do |key, value|


### PR DESCRIPTION
• Moved sandbox banner after the head tag
• Added some CSS to deal with some Photon overriding on the homepage. This fixes the font size problem on the homepage.

Old with small font size:
![screen shot 2015-07-22 at 3 58 36 pm](https://cloud.githubusercontent.com/assets/11333/8837750/fb0c6f2c-3095-11e5-8089-cf5907e9ba40.png)


Current font sizes on prod:
![screen shot 2015-07-22 at 5 15 46 pm](https://cloud.githubusercontent.com/assets/11333/8837763/0c8b5c90-3096-11e5-9ade-1835b6b65e7b.png)


Font sizes with these changes
![screen shot 2015-07-22 at 5 16 42 pm](https://cloud.githubusercontent.com/assets/11333/8837768/19997674-3096-11e5-9a90-b04b60d163b3.png)
:

