### PR TITLE
[#98024644] Approvals::Individual and a single approval chain entry point

### DIFF
--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -2,21 +2,10 @@ class Approval < ActiveRecord::Base
   include WorkflowModel
   has_paper_trail
 
-  workflow do
-    state :pending do
-      event :make_actionable, transitions_to: :actionable
-    end
-    state :actionable do
-      event :approve, transitions_to: :approved
-    end
+  workflow do   # overwritten in child classes
+    state :pending
+    state :actionable
     state :approved
-
-    # workflow doesn't touch active record
-    # manually updating 'updated_at'
-    # https://github.com/geekq/workflow/issues/96
-    on_transition do |from, to, triggering_event, *event_args|
-      self.touch
-    end
   end
 
   belongs_to :proposal

--- a/app/models/approvals/individual.rb
+++ b/app/models/approvals/individual.rb
@@ -14,9 +14,5 @@ module Approvals
       end
       state :approved
     end
-
-    def self.for_email(email)
-      Approvals::Individual.new(user: User.for_email(email))
-    end
   end
 end

--- a/app/models/approvals/individual.rb
+++ b/app/models/approvals/individual.rb
@@ -1,6 +1,8 @@
 # Represents a single user's ability to approve, the "leaves" in an approval chain
 module Approvals
   class Individual < Approval
+    validates :user, presence: true
+
     workflow do
       on_transition { self.touch } # https://github.com/geekq/workflow/issues/96
 

--- a/app/models/approvals/individual.rb
+++ b/app/models/approvals/individual.rb
@@ -12,5 +12,9 @@ module Approvals
       end
       state :approved
     end
+
+    def self.for_email(email)
+      Approvals::Individual.new(user: User.for_email(email))
+    end
   end
 end

--- a/app/models/approvals/individual.rb
+++ b/app/models/approvals/individual.rb
@@ -1,0 +1,16 @@
+# Represents a single user's ability to approve, the "leaves" in an approval chain
+module Approvals
+  class Individual < Approval
+    workflow do
+      on_transition { self.touch } # https://github.com/geekq/workflow/issues/96
+
+      state :pending do
+        event :make_actionable, transitions_to: :actionable
+      end
+      state :actionable do
+        event :approve, transitions_to: :approved
+      end
+      state :approved
+    end
+  end
+end

--- a/app/models/concerns/proposal_delegate.rb
+++ b/app/models/concerns/proposal_delegate.rb
@@ -15,7 +15,7 @@ module ProposalDelegate
     validates :proposal, presence: true
 
 
-    delegate :add_approver, :remove_approver, :add_observer, :add_requester, :set_requester, to: :proposal
+    delegate :add_approver, :add_observer, :add_requester, :set_requester, to: :proposal
 
     ### delegate the workflow actions/scopes/states ###
 

--- a/app/models/concerns/proposal_delegate.rb
+++ b/app/models/concerns/proposal_delegate.rb
@@ -15,7 +15,7 @@ module ProposalDelegate
     validates :proposal, presence: true
 
 
-    delegate :add_approver, :add_observer, :add_requester, :set_requester, to: :proposal
+    delegate :add_observer, :add_requester, :set_requester, to: :proposal
 
     ### delegate the workflow actions/scopes/states ###
 

--- a/app/models/gsa18f/procurement.rb
+++ b/app/models/gsa18f/procurement.rb
@@ -27,7 +27,9 @@ module Gsa18f
 
 
     def add_approvals
-      self.add_approver(Gsa18f::Procurement.approver_email)
+      self.proposal.approvers = [
+        User.for_email(Gsa18f::Procurement.approver_email)
+      ]
       self.proposal.kickstart_approvals()
     end
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -99,12 +99,6 @@ class Proposal < ActiveRecord::Base
     approval
   end
 
-  def remove_approver(email)
-    user = User.for_email(email)
-    approval = self.existing_approval_for(user)
-    approval.destroy
-  end
-
   # Set the approver list, from any start state
   # This overrides the `through` relation but provides parity to the accessor
   def approvers=(approver_list)

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -94,8 +94,8 @@ class Proposal < ActiveRecord::Base
 
   # returns the Approval
   def add_approver(email)
-    user = User.for_email(email)
-    approval = self.approvals.create!(user_id: user.id)
+    approval = Approvals::Individual.for_email(email)
+    self.approvals << approval
     approval
   end
 
@@ -104,7 +104,7 @@ class Proposal < ActiveRecord::Base
   def approvers=(approver_list)
     approvals = approver_list.each_with_index.map do |approver, idx|
       approval = self.existing_approval_for(approver)
-      approval ||= Approval.new(user: approver, proposal: self)
+      approval ||= Approvals::Individual.new(user: approver, proposal: self)
       approval.position = idx + 1   # start with 1
       approval
     end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -92,13 +92,6 @@ class Proposal < ActiveRecord::Base
     results.compact
   end
 
-  # returns the Approval
-  def add_approver(email)
-    approval = Approvals::Individual.for_email(email)
-    self.approvals << approval
-    approval
-  end
-
   # Set the approver list, from any start state
   # This overrides the `through` relation but provides parity to the accessor
   def approvers=(approver_list)
@@ -110,7 +103,7 @@ class Proposal < ActiveRecord::Base
     end
     self.approvals = approvals
     self.kickstart_approvals()
-    self.approvals.reload   # include the changes in kickstart_approvals
+    self.reload   # include the changes in kickstart_approvals
     self.reset_status()
   end
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -110,6 +110,7 @@ class Proposal < ActiveRecord::Base
     end
     self.approvals = approvals
     self.kickstart_approvals()
+    self.approvals.reload   # include the changes in kickstart_approvals
     self.reset_status()
   end
 

--- a/app/serializers/approvals/individual_serializer.rb
+++ b/app/serializers/approvals/individual_serializer.rb
@@ -1,0 +1,6 @@
+# @todo: Replace with `serializer_class` once
+# https://github.com/rails-api/active_model_serializers/pull/813 is available
+module Approvals
+  class IndividualSerializer < ApprovalSerializer
+  end
+end

--- a/db/migrate/20150724144605_add_type_to_approvals.rb
+++ b/db/migrate/20150724144605_add_type_to_approvals.rb
@@ -1,0 +1,13 @@
+class AddTypeToApprovals < ActiveRecord::Migration
+  def up
+    add_column :approvals, :type, :string
+    execute <<-SQL
+      UPDATE approvals
+      SET type = 'Approvals::Individual';
+    SQL
+  end
+
+  def down
+    remove_column :approvals, :type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150721205524) do
+ActiveRecord::Schema.define(version: 20150724144605) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,7 @@ ActiveRecord::Schema.define(version: 20150721205524) do
     t.integer  "position"
     t.integer  "proposal_id"
     t.datetime "approved_at"
+    t.string   "type"
   end
 
   create_table "attachments", force: :cascade do |t|

--- a/spec/factories/approvals.rb
+++ b/spec/factories/approvals.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :approval do
+  factory :approval, class: Approvals::Individual do
     proposal
     user
     status 'pending'

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -6,8 +6,7 @@ FactoryGirl.define do
 
     trait :with_approver do
       after :create do |proposal|
-        proposal.add_approver('approver1@some-dot-gov.gov')
-        proposal.kickstart_approvals()
+        proposal.approvers = [FactoryGirl.create(:user)]
       end
     end
 
@@ -15,18 +14,14 @@ FactoryGirl.define do
     trait :with_serial_approvers do
       flow 'linear'
       after :create do |proposal|
-        proposal.add_approver('approver1@some-dot-gov.gov')
-        proposal.add_approver('approver2@some-dot-gov.gov')
-        proposal.kickstart_approvals()
+        proposal.approvers = 2.times.map{ FactoryGirl.create(:user) }
       end
     end
 
     trait :with_parallel_approvers do
       flow 'parallel'
       after :create do |proposal|
-        proposal.add_approver('approver1@some-dot-gov.gov')
-        proposal.add_approver('approver2@some-dot-gov.gov')
-        proposal.kickstart_approvals()
+        proposal.approvers = 2.times.map{ FactoryGirl.create(:user) }
       end
     end
 

--- a/spec/features/comment_spec.rb
+++ b/spec/features/comment_spec.rb
@@ -34,7 +34,9 @@ describe "commenting" do
     fill_in 'comment[comment_text]', with: 'foo'
     click_on 'Send a Comment'
 
-    expect(email_recipients).to eq(['approver1@some-dot-gov.gov',
-                                    'approver2@some-dot-gov.gov'])
+    expect(email_recipients).to eq([
+      proposal.approvers.first.email_address,
+      proposal.approvers.second.email_address
+    ].sort)
   end
 end

--- a/spec/features/display_status_spec.rb
+++ b/spec/features/display_status_spec.rb
@@ -1,6 +1,7 @@
 describe "Display status text" do
   let(:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers) }
   before do
+    # ensure unique names as we'll be testing them later
     proposal.approvers.first.update(first_name: "Uniquely", last_name: "Named")
     proposal.approvers.second.update(first_name: "Onlyof", last_name: "Itskind")
     login_as(proposal.requester)
@@ -16,8 +17,9 @@ describe "Display status text" do
     visit proposals_path
     expect(page).not_to have_content('Please review')
     expect(page).to have_content('Waiting for review from:')
-    proposal.approvers.each{|approver|
-      expect(page).to have_content(approver.full_name)}
+    proposal.approvers.each do |approver|
+      expect(page).to have_content(approver.full_name)
+    end
   end
 
   it "excludes approved approvals" do
@@ -25,9 +27,10 @@ describe "Display status text" do
     visit proposals_path
     expect(page).not_to have_content('Please review')
     expect(page).to have_content('Waiting for review from:')
-    proposal.approvers[1..-1].each{|approver|
-      expect(page).to have_content(approver.full_name)}
-    expect(page).not_to have_content(proposal.approvers.first.full_name)
+    proposal.approvers[1..-1].each do |approver|
+      expect(page).to have_content(approver.full_name)
+    end
+    expect(page).not_to have_content("Uniquely Named")
   end
 
   context "linear" do
@@ -36,16 +39,17 @@ describe "Display status text" do
     it "displays the first approver" do
       visit proposals_path
       expect(page).to have_content('Waiting for review from:')
-      proposal.approvers[1..-1].each{|approver|
-        expect(page).not_to have_content(approver.full_name)}
-      expect(page).to have_content(proposal.approvers.first.full_name)
+      proposal.approvers[1..-1].each do |approver|
+        expect(page).not_to have_content(approver.full_name)
+      end
+      expect(page).to have_content("Uniquely Named")
     end
 
     it "excludes approved approvals" do
       proposal.approvals.first.approve!
       visit proposals_path
       expect(page).to have_content('Waiting for review from:')
-      expect(page).not_to have_content(proposal.approvers.first.full_name)
+      expect(page).not_to have_content("Uniquely Named")
     end
   end
 end

--- a/spec/features/display_status_spec.rb
+++ b/spec/features/display_status_spec.rb
@@ -1,6 +1,8 @@
 describe "Display status text" do
   let(:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers) }
   before do
+    proposal.approvers.first.update(first_name: "Uniquely", last_name: "Named")
+    proposal.approvers.second.update(first_name: "Onlyof", last_name: "Itskind")
     login_as(proposal.requester)
   end
 

--- a/spec/lib/dispatcher_spec.rb
+++ b/spec/lib/dispatcher_spec.rb
@@ -14,8 +14,8 @@ describe Dispatcher do
     let(:dispatcher) { Dispatcher.new }
 
     it 'creates a new token for the approver' do
-      approval = proposal.add_approver('approver1@some-dot-gov.gov')
-      proposal.kickstart_approvals()
+      proposal.approvers = [FactoryGirl.create(:user)]
+      approval = proposal.approvals.first
       expect(CommunicartMailer).to receive_message_chain(:actions_for_approver, :deliver_now)
       expect(approval).to receive(:create_api_token!).once
 
@@ -30,10 +30,10 @@ describe Dispatcher do
     it "sends emails to the requester and all approvers" do
       dispatcher.deliver_new_proposal_emails(proposal)
       expect(email_recipients).to eq([
-        'approver1@some-dot-gov.gov',
-        'approver2@some-dot-gov.gov',
+        proposal.approvers.first.email_address,
+        proposal.approvers.second.email_address,
         proposal.requester.email_address
-      ])
+      ].sort)
     end
 
     it 'creates a new token for each approver' do

--- a/spec/lib/linear_dispatcher_spec.rb
+++ b/spec/lib/linear_dispatcher_spec.rb
@@ -65,9 +65,9 @@ describe LinearDispatcher do
       approval = proposal.approvals.first
       approval.approve!   # calls on_approval_approved
       expect(email_recipients).to eq([
-        'approver2@some-dot-gov.gov',
+        proposal.approvers.second.email_address,
         proposal.requester.email_address
-      ])
+      ].sort)
     end
   end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -12,8 +12,7 @@ describe Comment do
     end
 
     it "includes approved approvers" do
-      proposal.add_approver("someone@example.com")
-      proposal.kickstart_approvals()
+      proposal.approvers = proposal.approvers + [FactoryGirl.create(:user)]
       expect(proposal.approvers.length).to eq(3)
       proposal.approvals.first.approve!
       expect(comment.listeners).to include(proposal.approvers[0])

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -153,22 +153,21 @@ describe Proposal do
 
     it 'fixes modified linear proposal approvals' do
       proposal = FactoryGirl.create(:proposal, flow: 'linear')
-      proposal.add_approver('1@example.com')
-      proposal.add_approver('2@example.com')
+      approver1, approver2, approver3 = 3.times.map{ FactoryGirl.create(:user) }
+      proposal.approvers = [approver1, approver2]
 
       proposal.kickstart_approvals()
 
       expect(proposal.approvals.count).to be 2
 
       proposal.approvals.first.approve!
-      proposal.remove_approver('2@example.com')
-      proposal.add_approver('3@example.com')
+      proposal.approvers = [approver1, approver3]
 
       proposal.kickstart_approvals()
 
       expect(proposal.approvals.approved.count).to be 1
       expect(proposal.approvals.actionable.count).to be 1
-      expect(proposal.approvals.actionable.first.user.email_address).to eq '3@example.com'
+      expect(proposal.approvals.actionable.first.user).to eq approver3
     end
 
     it 'does not modify a full approved parallel proposal' do

--- a/spec/steps/approval_steps.rb
+++ b/spec/steps/approval_steps.rb
@@ -18,9 +18,9 @@ module ApprovalSteps
   end
 
   step "the proposal has an approval for :email in position :position" do |email, position|
-    @approval = @proposal.add_approver(email)
-    @approval.update_attribute(:position, position)
-    @proposal.kickstart_approvals
+    @proposal.approvers = @proposal.approvers + [User.for_email(email)]
+    @approval = @proposal.approvals.last
+    @approval.set_list_position(position)
   end
 
   step "feature flag :flag_name is :value" do |flag, value|

--- a/spec/steps/user_steps.rb
+++ b/spec/steps/user_steps.rb
@@ -71,8 +71,7 @@ module UserSteps
 
   step 'a proposal with approver :approver_email' do |approver_email|
     @proposal = FactoryGirl.create(:proposal)
-    @proposal.add_approver(approver_email)
-    @proposal.kickstart_approvals
+    @proposal.approvers = [User.for_email(approver_email)]
     @approval = @proposal.approvals.first
   end
 


### PR DESCRIPTION
Split out from #454 

This doesn't change too much of `app` - it migrates all approvals to the `Approvals::Individual` subclass and removes all but one entry point for setting the approval chain.

Most of the code updates are to the specs, which were heavy users of `add_approver`