### PR TITLE
[Delivers #99298112] show submitted date

### DIFF
--- a/app/views/proposals/show.html.erb
+++ b/app/views/proposals/show.html.erb
@@ -16,6 +16,10 @@
           Requested by:
           <strong><%= @proposal.requester.full_name %></strong>
         </p>
+        <p>
+          Submitted:
+          <strong><%= date_with_tooltip(@proposal.created_at) %></strong>
+        </p>
       </div>
     </div>
 


### PR DESCRIPTION
Displays the requested date on the request detail page.
<img width="337" alt="screen shot 2015-07-27 at 1 30 05 pm" src="https://cloud.githubusercontent.com/assets/1122643/8912892/a595c9d6-3463-11e5-8830-f2a6ce223143.png">
