### PR TITLE
add manifest file

### DIFF
--- a/doc/production.md
+++ b/doc/production.md
@@ -2,7 +2,7 @@
 
 Live at https://cap.18f.gov.
 
-18F's [deployments](http://12factor.net/codebase) of C2 live in AWS, and are deployed via [Cloud Foundry](http://www.cloudfoundry.org). See [our Cloud Foundry documentation](https://docs.18f.gov) for more details how to inspect and configure them. Note that we are *not* currently [using manifests](http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html) to deploy.
+18F's [deployments](http://12factor.net/codebase) of C2 live in AWS, and are deployed via [Cloud Foundry](http://www.cloudfoundry.org). See [our Cloud Foundry documentation](https://docs.18f.gov) for more details on how to inspect and configure them.
 
 ## Environments
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,24 @@
+---
+# https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html
+
+# general configuration
+domain: 18f.gov
+instances: 1
+memory: 512M
+
+# environment-specific configuration
+applications:
+- name: c2-dev
+  host: c2-dev
+  env:
+    DEFAULT_URL_HOST: c2-dev.18f.gov
+- name: c2-staging
+  host: c2-staging
+  env:
+    DEFAULT_URL_HOST: c2-staging.18f.gov
+- name: c2-prod
+  host: cap
+  env:
+    DEFAULT_URL_HOST: cap.18f.gov
+    DISABLE_SANDBOX_WARNING: true
+    RESTRICT_ACCESS: true


### PR DESCRIPTION
Moves the non-sensitive Cloud Foundry configuration into a config file, meaning that it's now version controlled.