### PR TITLE
Edits to Help content

### DIFF
--- a/app/views/help/approver_out_of_office.md
+++ b/app/views/help/approver_out_of_office.md
@@ -1,0 +1,3 @@
+<% title "What happens if someone in the approval chain is out of office?" %>
+
+If you've submitted your request and the approving official is on leave, access the request under My Requests, select Modify, change the name of the approving official, and click Submit.

--- a/app/views/help/delegated-request.md
+++ b/app/views/help/delegated-request.md
@@ -1,0 +1,5 @@
+<% title "How do I submit a delegated request on behalf of a card holder?" %>
+
+1. If you are making a request on behalf of a card holder, first, make sure you have authority to do so.
+1. When you make the request, include the following note in the Description section: “This request is for [FirstName LastName]’s card.”
+1. Once you submit the request be sure to use the Add Observer feature to notify the card holder that you’ve made this request on their behalf.

--- a/app/views/help/index.html.haml
+++ b/app/views/help/index.html.haml
@@ -11,4 +11,4 @@
         - else
           = page
 - # this needs to be at the bottom of the template
-- title "FAQ"
+- title "Help"

--- a/app/views/help/modifiying_requests.md
+++ b/app/views/help/modifiying_requests.md
@@ -1,28 +1,27 @@
-<% title "What if there's something wrong with the request?" %>
+<% title "What if I need to modify a request?" %>
 
-A request may need to be modified after it is submitted. These situations include:
-
-* There was a typo.
-* A different RWA number needs to be used. (BA80)
-* The original request had a Not-To-Exceed amount, which needs to be changed to Exact once it's complete.
+You may need to modify a request after it is submitted for a number of reasons:
+  - To correct a typo or other error
+  - To update a Not-To-Exceed amount to a final purchase price
+  - To change approval information or provide a new RWA number
 
 ## Approver
 
-If you are one of the approvers and notice an issue:
+Approvers cannot modify requests, but they can ask the requester to do so. If you are one of the approvers and notice an issue:
 
-1. Go to the detail page for a request.
+1. Go to the detail page for the request.
 1. Scroll down to the comment area.
-1. Leave a comment, saying what needs to be changed.
+1. Leave a comment that explains what needs to change. Click “Submit.”
 
-Everyone involved in the request will get a notification with the comment.
+Everyone involved in the request will receive a notification email with the comment.
 
 ## Requester
 
 If you are a requester, follow these steps to modify the request:
 
-1. Go to the detail page for a request.
-1. Scroll down to click the "Modify Request" button.
-1. Modify the values in the form.
-1. Submit the changes but clicking the button at the bottom.
+1. Go to the detail page for the request.
+1. Scroll down to click the “Modify Request” button.
+1. Modify the information in the form.
+1. Submit the changes by clicking the “Update” button at the bottom.
 
-At this point, everyone involved will be notified, so you don't need to send any additional message.
+Everyone involved will receive a notification email, so you don't need to send an additional message.

--- a/app/views/help/modifiying_requests.md
+++ b/app/views/help/modifiying_requests.md
@@ -5,9 +5,9 @@ You may need to modify a request after it is submitted for a number of reasons:
   - To update a Not-To-Exceed amount to a final purchase price
   - To change approval information or provide a new RWA number
 
-## Approver
+## To ask for a modification
 
-Approvers cannot modify requests, but they can ask the requester to do so. If you are one of the approvers and notice an issue:
+Who is eligible to modify a request depends on the rules of your region or organization. But anyone involved in a request can ask for a modification:
 
 1. Go to the detail page for the request.
 1. Scroll down to the comment area.
@@ -16,9 +16,7 @@ Approvers cannot modify requests, but they can ask the requester to do so. If yo
 
 Everyone involved in the request will receive a notification email with the comment.
 
-## Requester
-
-If you are a requester, follow these steps to modify the request:
+## To modify a request directly
 
 1. Go to the detail page for the request.
 1. Scroll down to click the “Modify Request” button.

--- a/app/views/help/modifiying_requests.md
+++ b/app/views/help/modifiying_requests.md
@@ -11,7 +11,8 @@ Approvers cannot modify requests, but they can ask the requester to do so. If yo
 
 1. Go to the detail page for the request.
 1. Scroll down to the comment area.
-1. Leave a comment that explains what needs to change. Click “Submit.”
+1. Leave a comment that explains what needs to change.
+1. Click “Submit.”
 
 Everyone involved in the request will receive a notification email with the comment.
 

--- a/app/views/help/new_work_order.md
+++ b/app/views/help/new_work_order.md
@@ -4,7 +4,7 @@ If you are a credit card holder, follow these steps:
 
 1. [Sign in](/auth/myusa), if you aren't already.
     * If you are logged in, your email will appear in the top right.
-    * When signing in, you will be directed to another application called [MyUSA](https://alpha.my.usa.gov/). Click the button that says "Connect with Google".
+    * If you are not logged in, clicking "Sign in" will direct you to another application called [MyUSA](https://alpha.my.usa.gov/). Click the button that says "Connect with Google".
 1. Click ["New NCR request"](/ncr/work_orders/new).
 1. Fill out the form.
 1. At the bottom of the form, click "Submit for approval".

--- a/app/views/help/printing.md
+++ b/app/views/help/printing.md
@@ -1,0 +1,9 @@
+<% title "How do I print my request or save a copy as a PDF?" %>
+
+1. Navigate to the requests page. Select the request you would like to print. Once the page loads, use any of the following options to open a print menu:
+  - Type Ctrl + P on your keyboard.
+  - Right-click with your mouse, then select “Print”
+  - In the menu of your browser, select File. From the dropdown, select Print.
+1. Any of these should open a box with printing options. To print a physical copy, press the Print button in this box. To save as a PDF:
+  - In Chrome or Internet Explorer, change the selected printer to “Print as PDF” or “Save as PDF”. Then click Print.
+  - In Firefox or Safari, click the PDF drop-down and follow the instructions.

--- a/app/views/help/proposal_process.md
+++ b/app/views/help/proposal_process.md
@@ -1,5 +1,5 @@
 <% title "What happens once a request is submitted?" %>
 
-1. The approving official (AO) that the requester specified in the form will be sent an email notification with details of the request.
-1. If the approving official approves, it goes to the one or two budget mailboxes, depending on the type of request (BA61 vs. BA80, etc.).
+1. The approving official that the requester specified in the form will receive an email notification with details of the request.
+1. If the approving official approves, the request goes to the one or two budget mailboxes, depending on the type of request (BA61 vs. BA80, etc.).
 1. Once all approvers have approved the request, the requester gets a notification.

--- a/app/views/help/requests_over_3000.md
+++ b/app/views/help/requests_over_3000.md
@@ -1,0 +1,5 @@
+<% title "How do I submit a request that exceeds $3000?" %>
+
+The C2 system will only handle credit card requests, which are capped at $3,000 per vendor per year. If you have a your request exceeding the threshold, you must go through contracts with a GSA Form 49 to complete your request.
+
+If your have a request that started as a credit card request, and then the scope increased beyond the $3,000 threshold, cancel the request and take your requirements through the contracting process.

--- a/app/views/help/verbal_ntp_requests.md
+++ b/app/views/help/verbal_ntp_requests.md
@@ -1,0 +1,5 @@
+<% title "How do I submit an verbal NTP request in case of emergency?" %>
+
+If you have an active emergency in your building (for example, a pipe burst causing major flooding), take action immediately. Just as in the past, a purchase card holder can get a verbal NTP from BA61 to take action. As soon as you are able, follow up with the paperwork.
+
+If you proceed with a verbal NTP, you will need to take an additional step when you submit your request in Communicart. When you select your billing code (BA61), a check box will appears for “Paperwork to follow up with the actual request.” You will need to check that box.

--- a/app/views/help/verbal_ntp_requests.md
+++ b/app/views/help/verbal_ntp_requests.md
@@ -1,4 +1,4 @@
-<% title "How do I submit an verbal NTP request in case of emergency?" %>
+<% title "How do I submit an verbal notice to proceed (NTP) request in case of emergency?" %>
 
 If you have an active emergency in your building (for example, a pipe burst causing major flooding), take action immediately. Just as in the past, a purchase card holder can get a verbal NTP from BA61 to take action. As soon as you are able, follow up with the paperwork.
 

--- a/app/views/layouts/help.html.haml
+++ b/app/views/layouts/help.html.haml
@@ -1,6 +1,6 @@
 - content_for :content do
   - unless params[:action] == 'index'
-    = render partial: 'shared/breadcrumb_nav', locals: {text: "Back to FAQ", href: help_index_path}
+    = render partial: 'shared/breadcrumb_nav', locals: {text: "Back to Help", href: help_index_path}
   .inset.markdown
     %h1
       = yield(:title)


### PR DESCRIPTION
## Changes
- Retitled FAQ to Help where relevant. Format-independent title that’s
consistent w/ URL may be easier to work with over the long term. Also
keeps breadcrumb, page title, and nav title consistent.
- Added some questions to cover additional issues.
- Edits to make language slightly more specific and/or active.

## Review
@phirefly 

## Comments
There are a couple other help needs, like formatting instructions for submissions, that I think are better served elsewhere. I will file those as issues instead.