### PR TITLE
[Delivers #100901060, Possibly #100944736] Interaction b/w TabularData and ProposalSearch

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -63,6 +63,7 @@ class ProposalsController < ApplicationController
   # @todo - this is acting more like an index; rename existing #index to #mine
   # or similar, then rename #query to #index
   def query
+    @text = params[:text]
     if @text
       # only sort by the match priority if searching
       @proposals_data = self.proposals_container(:query, frozen_sort: true)
@@ -73,7 +74,6 @@ class ProposalsController < ApplicationController
     # @todo - move all of this filtering into the TabularData::Container object
     @start_date = self.param_date(:start_date)
     @end_date = self.param_date(:end_date)
-    @text = params[:text]
 
     if @start_date
       @proposals_data.alter_query{ |p| p.where('proposals.created_at >= ?', @start_date) }

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -77,6 +77,7 @@ class ProposalsController < ApplicationController
       @proposals_data.alter_query{ |p| p.where('proposals.created_at < ?', @end_date) }
     end
     if @text
+      @proposals_data.freeze_sort!  # we will always sort by search
       @proposals_data.alter_query do |p|
         ProposalSearch.new(p).execute(@text)
       end

--- a/app/views/shared/_table.html.haml
+++ b/app/views/shared/_table.html.haml
@@ -7,7 +7,7 @@
         %th{class: column.sort_dir}
           - # @todo: why are there h5s in our table headers?
           %h5
-            - if column.can_sort?
+            - if !container.frozen_sort && column.can_sort?
               = link_to(column.header, container.sort_params(request.query_parameters, column))
             - else
               = column.header

--- a/lib/proposal_search.rb
+++ b/lib/proposal_search.rb
@@ -46,24 +46,10 @@ class ProposalSearch
     self.relation.joins(join)
   end
 
-  def with_rank(query)
-    sanitized_query = ActiveRecord::Base::sanitize(query)
-    rank = <<-SQL
-      ts_rank(p_search.document, plainto_tsquery(#{sanitized_query})) AS rank
-    SQL
-
-    self.joined.select('*', rank)
-  end
-
-  def filtered(query)
-    self.with_rank(query).where('p_search.document @@ plainto_tsquery(?)', query)
-  end
-
-  def ordered(query)
-    self.filtered(query).order('rank DESC')
-  end
-
   def execute(query)
-    self.ordered(query)
+    sanitized = ActiveRecord::Base::sanitize(query)
+    self.joined.
+      where('p_search.document @@ plainto_tsquery(?)', query).
+      order("ts_rank(p_search.document, plainto_tsquery(#{sanitized})) DESC")
   end
 end

--- a/lib/proposal_search.rb
+++ b/lib/proposal_search.rb
@@ -1,3 +1,5 @@
+# @todo - materialize the tsvector and remove this in favor of a simpler
+# `where` + `order`
 # Query logic modified from
 #
 #   http://blog.lostpropertyhq.com/postgres-full-text-search-is-good-enough/#ranking

--- a/lib/tabular_data/container.rb
+++ b/lib/tabular_data/container.rb
@@ -1,9 +1,10 @@
 module TabularData
   class Container
-    attr_reader :columns
+    attr_reader :columns, :frozen_sort
 
     def initialize(name, config)
       @name = name
+      @frozen_sort = false
       self.init_query(config[:engine].constantize, config.fetch(:joins, []))
       self.init_columns(config.fetch(:column_configs, {}), config.fetch(:columns, {}))
       self.set_sort(config[:sort])
@@ -16,7 +17,11 @@ module TabularData
 
     # @todo filtering, paging, etc.
     def rows
-      @query.order(@sort)
+      results = @query
+      if @sort && !@frozen_sort
+        results = results.order(@sort)
+      end
+      results
     end
 
     def set_state_from_params(params)
@@ -44,6 +49,10 @@ module TabularData
         key = client_name
       end
       container_yaml[key].deep_symbolize_keys
+    end
+
+    def freeze_sort!
+      @frozen_sort = true
     end
 
     protected

--- a/lib/tabular_data/container.rb
+++ b/lib/tabular_data/container.rb
@@ -4,7 +4,7 @@ module TabularData
 
     def initialize(name, config)
       @name = name
-      @frozen_sort = false
+      @frozen_sort = config.fetch(:frozen_sort, false)
       self.init_query(config[:engine].constantize, config.fetch(:joins, []))
       self.init_columns(config.fetch(:column_configs, {}), config.fetch(:columns, {}))
       self.set_sort(config[:sort])
@@ -51,11 +51,6 @@ module TabularData
       container_yaml[key].deep_symbolize_keys
     end
 
-    def freeze_sort!
-      @frozen_sort = true
-      @columns.each{|c| c.sort(nil)}
-    end
-
     protected
 
     def set_sort(field)
@@ -64,7 +59,7 @@ module TabularData
       field = field.gsub(/\A-/, '')
 
       @columns.each do |column|
-        if column.name == field
+        if column.name == field && !@frozen_sort
           @sort = column.sort(dir)
         else
           column.sort(nil)

--- a/lib/tabular_data/container.rb
+++ b/lib/tabular_data/container.rb
@@ -4,6 +4,7 @@ module TabularData
 
     def initialize(name, config)
       @name = name
+      # useful if the sort is set via alter_query
       @frozen_sort = config.fetch(:frozen_sort, false)
       self.init_query(config[:engine].constantize, config.fetch(:joins, []))
       self.init_columns(config.fetch(:column_configs, {}), config.fetch(:columns, {}))

--- a/lib/tabular_data/container.rb
+++ b/lib/tabular_data/container.rb
@@ -53,6 +53,7 @@ module TabularData
 
     def freeze_sort!
       @frozen_sort = true
+      @columns.each{|c| c.sort(nil)}
     end
 
     protected

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -142,6 +142,23 @@ describe ProposalsController do
         expect(response.body).to include("2012-05-02 - 2012-06-02")
       end
     end
+
+    context 'search' do
+      it 'plays nicely with TabularData' do
+        double, single, triple = 3.times.map { FactoryGirl.create(:proposal, requester: user) }
+        double.update(public_id: 'AAA AAA')
+        single.update(public_id: 'AAA')
+        triple.update(public_id: 'AAA AAA AAA')
+
+        get :query, text: "AAA"
+        query = assigns(:proposals_data).rows
+
+        expect(query.length).to be(3)
+        expect(query[0].id).to be(triple.id)
+        expect(query[1].id).to be(double.id)
+        expect(query[2].id).to be(single.id)
+      end
+    end
   end
 
   describe '#cancel_form' do

--- a/spec/features/tabular_data_spec.rb
+++ b/spec/features/tabular_data_spec.rb
@@ -73,4 +73,13 @@ describe "Tabular data sorting" do
       expect_order(tables[1], cancelled.reverse)
     end
   end
+
+  context 'search' do
+    it 'does not allows titles to be clicked to re-sort' do
+      visit '/proposals/query?text=1'
+      within(tables[0]) do
+        expect(page).not_to have_selector("th a")
+      end
+    end
+  end
 end

--- a/spec/lib/tabular_data/container_spec.rb
+++ b/spec/lib/tabular_data/container_spec.rb
@@ -26,6 +26,31 @@ describe TabularData::Container do
 
       container.rows.count  # smoke test
     end
+
+    it 'sets sort' do
+      config = {engine: 'Proposal',
+                column_configs: {a: true, b: true},
+                columns: ['a', 'b'],
+                sort: '-a'}
+      container = TabularData::Container.new(:a_name, config)
+      expect(container.rows.to_sql).to include('ORDER BY (proposals.a) DESC')
+      expect(container.frozen_sort).to be(false)
+      expect(container.columns[0].sort_dir).to be(:desc)
+      expect(container.columns[1].sort_dir).to be_nil
+    end
+
+    it 'allows the sort to be frozen' do
+      config = {engine: 'Proposal',
+                column_configs: {a: true, b: true},
+                columns: ['a', 'b'],
+                sort: '-a',
+                frozen_sort: true}
+      container = TabularData::Container.new(:a_name, config)
+      expect(container.rows.to_sql).not_to include('ORDER BY (proposals.a) DESC')
+      expect(container.frozen_sort).to be(true)
+      expect(container.columns[0].sort_dir).to be_nil
+      expect(container.columns[1].sort_dir).to be_nil
+    end
   end
 
   describe '#alter_query' do


### PR DESCRIPTION
* Remove the ability to sort on the search page; we can rely on the search ranking
* Simplify `ProposalSearch` so that it doesn't have a separate projection (and hence doesn't need to `select *`)

The latter resolves an explosion when searching.

~~This needs tests.~~ @annalee I _think_ this might resolve #100944736 too but I'm not positive.