### PR TITLE
add a Rubocop configuration file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,15 @@
+AllCops:
+  Exclude:
+    - 'bin/**/*'
+    - 'db/**/*'
+  RunRailsCops: true
+Metrics/LineLength:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/DotPosition:
+  Enabled: false
+Style/RedundantSelf:
+  Enabled: false
+Style/StringLiterals:
+  Enabled: false


### PR DESCRIPTION
Yesterday, I enabled Code Climate to run on our pull requests, which runs [Rubocop](https://github.com/bbatsov/rubocop) by default. Ruboop is aggressive, but luckily Code Climate only shows the "offsenses" on changed lines with pull requests. Example:

https://codeclimate.com/github/18F/C2/pull/538#style

Explicitly excluded some Cops (ones that I saw in the page above and don't agree with – will probably want to add more as we go), but used `--auto-gen-config` to generate the `.rubocop_todo.yml` to "zero the scale" (so to speak).

Would like to get this in before #538.