### PR TITLE
fix client admins not being able to see all Proposals they are involved with

### DIFF
--- a/app/decorators/proposal_decorator.rb
+++ b/app/decorators/proposal_decorator.rb
@@ -40,7 +40,7 @@ class ProposalDecorator < Draper::Decorator
   end
 
   def generate_status_message
-    if object.approvals.where.not(status: 'pending').empty?
+    if object.approvals.non_pending.empty?
       progress_status_message
     else
       completed_status_message

--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -23,6 +23,7 @@ class Approval < ActiveRecord::Base
   self.statuses.each do |status|
     scope status, -> { where(status: status) }
   end
+  scope :non_pending, -> { where.not(status: 'pending') }
 
   default_scope { order('position ASC') }
 

--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -9,9 +9,6 @@ class Approval < ActiveRecord::Base
   end
 
   belongs_to :proposal
-  belongs_to :user
-  has_many :delegations, through: :user, source: :outgoing_delegates
-  has_many :delegates, through: :delegations, source: :assignee
   acts_as_list scope: :proposal
 
   belongs_to :parent, class_name: 'Approval'

--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -9,6 +9,9 @@ class Approval < ActiveRecord::Base
   end
 
   belongs_to :proposal
+  belongs_to :user
+  has_many :delegations, through: :user, source: :outgoing_delegates
+  has_many :delegates, through: :delegations, source: :assignee
   acts_as_list scope: :proposal
 
   belongs_to :parent, class_name: 'Approval'

--- a/app/models/approvals/individual.rb
+++ b/app/models/approvals/individual.rb
@@ -3,11 +3,13 @@
 module Approvals
   class Individual < Approval
     belongs_to :user
+    has_one :api_token, -> { fresh }, foreign_key: 'approval_id'
+    has_many :delegations, through: :user, source: :outgoing_delegates
+    has_many :delegates, through: :delegations, source: :assignee
+
     validates :user, presence: true
     delegate :full_name, :email_address, :to => :user, :prefix => true
     scope :with_users, -> { includes :user }
-
-    has_one :api_token, -> { fresh }, foreign_key: "approval_id"
 
     workflow do
       on_transition { self.touch } # sets updated_at; https://github.com/geekq/workflow/issues/96

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -231,8 +231,7 @@ class Proposal < ActiveRecord::Base
 
   # Returns True if the user is an approver and has acted on the proposal
   def is_active_approver? user
-    current_approver = self.approvals.find_by user_id: user.id
-    current_approver && current_approver.status != "pending"
+    self.approvals.non_pending.exists?(user_id: user.id)
   end
 
   def self.client_model_names

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ActiveRecord::Base
   has_many :observations
   has_many :comments
 
+  # TODO rename to _delegations, and add relations for the Users
   has_many :outgoing_delegates, class_name: 'ApprovalDelegate', foreign_key: 'assigner_id'
   has_many :incoming_delegates, class_name: 'ApprovalDelegate', foreign_key: 'assignee_id'
 

--- a/app/policies/proposal_policy/scope.rb
+++ b/app/policies/proposal_policy/scope.rb
@@ -11,9 +11,9 @@ class ProposalPolicy
         @scope.all
       elsif @user.client_admin?
         # TODO include all Proposals that the user is involved in
-        Query::Proposals.new(@scope).for_client_slug(@user.client_slug)
+        @scope.where(Query::Proposals.for_client_slug(@user.client_slug))
       else
-        Query::Proposals.new(@scope).which_involve(@user)
+        @scope.where(Query::Proposals.which_involve(@user))
       end
     end
   end

--- a/app/policies/proposal_policy/scope.rb
+++ b/app/policies/proposal_policy/scope.rb
@@ -10,14 +10,20 @@ class ProposalPolicy
       if @user.admin?
         @scope.all
       elsif @user.client_admin?
-        @scope.where(
-          Query::Proposals.for_client_slug(@user.client_slug).or(
-            Query::Proposals.which_involve(@user)
-          )
-        )
+        self.for_client_admin
       else
         @scope.where(Query::Proposals.which_involve(@user))
       end
+    end
+
+    protected
+
+    def for_client_admin
+      @scope.where(
+        Query::Proposals.for_client_slug(@user.client_slug).or(
+          Query::Proposals.which_involve(@user)
+        )
+      )
     end
   end
 end

--- a/app/policies/proposal_policy/scope.rb
+++ b/app/policies/proposal_policy/scope.rb
@@ -10,8 +10,11 @@ class ProposalPolicy
       if @user.admin?
         @scope.all
       elsif @user.client_admin?
-        # TODO include all Proposals that the user is involved in
-        @scope.where(Query::Proposals.for_client_slug(@user.client_slug))
+        @scope.where(
+          Query::Proposals.for_client_slug(@user.client_slug).or(
+            Query::Proposals.which_involve(@user)
+          )
+        )
       else
         @scope.where(Query::Proposals.which_involve(@user))
       end

--- a/lib/query/proposals.rb
+++ b/lib/query/proposals.rb
@@ -23,8 +23,6 @@ module Query
     end
 
     def self.which_involve(user)
-      # use subselects instead of left joins to avoid an explicit
-      # duplication-removal step
       self.with_requester(user).or(
         self.with_approver_or_delegate(user).or(
           self.with_observer(user)
@@ -34,7 +32,9 @@ module Query
 
     protected
 
-    # subselect to be used alongside the proposals table
+    ## subselects to be used alongside the proposals table ##
+    # Subselects are used instead of left joins to avoid an explicit duplication-removal step.
+
     def self.approvals_for(user)
       approvals = Approval.arel_table
       delegates = ApprovalDelegate.arel_table
@@ -51,7 +51,6 @@ module Query
       ).ast
     end
 
-    # subselect to be used alongside the proposals table
     def self.observations_for(user)
       observations = Observation.arel_table
 
@@ -61,5 +60,7 @@ module Query
         )
       ).ast
     end
+
+    #########################################################
   end
 end

--- a/lib/query/proposals.rb
+++ b/lib/query/proposals.rb
@@ -10,6 +10,12 @@ module Query
       proposals[:requester_id].eq(user.id)
     end
 
+    def self.approvals_with_delegates
+      approvals.project(Arel.star).
+        join(delegates, Arel::Nodes::OuterJoin).
+        on(delegates[:assigner_id].eq(approvals[:user_id]))
+    end
+
     def self.with_approver_or_delegate(user)
       Arel::Nodes::Exists.new(
         self.approvals_for(user)
@@ -48,16 +54,30 @@ module Query
       Proposal.arel_table
     end
 
+    def self.with_matching_proposal
+      approvals[:proposal_id].eq(proposals[:id])
+    end
+
+    def self.non_pending
+      approvals[:status].not_eq('pending')
+    end
+
+    def self.where_approver(user)
+      approvals[:user_id].eq(user.id)
+    end
+
+    def self.where_delegate(user)
+      delegates[:assignee_id].eq(user.id)
+    end
+
     ## subselects to be used alongside the proposals table ##
     # Subselects are used instead of left joins to avoid an explicit duplication-removal step.
 
     def self.approvals_for(user)
-      approvals.project(Arel.star).join(delegates, Arel::Nodes::OuterJoin).on(
-        delegates[:assigner_id].eq(approvals[:user_id])
-      ).where(
-        approvals[:proposal_id].eq(proposals[:id]).and(
-          approvals[:status].not_eq('pending').and(
-            approvals[:user_id].eq(user.id).or(delegates[:assignee_id].eq(user.id))
+      self.approvals_with_delegates.where(
+        self.with_matching_proposal.and(
+          self.non_pending.and(
+            self.where_approver(user).or(self.where_delegate(user))
           )
         )
       ).ast

--- a/spec/lib/query/proposals_spec.rb
+++ b/spec/lib/query/proposals_spec.rb
@@ -1,0 +1,49 @@
+describe Query::Proposals do
+  describe '.with_requester' do
+    it "returns matches" do
+      FactoryGirl.create(:proposal)
+      proposal = FactoryGirl.create(:proposal)
+
+      condition = Query::Proposals.with_requester(proposal.requester)
+      expect(Proposal.where(condition)).to eq([proposal])
+    end
+  end
+
+  describe '.with_approver_or_delegate' do
+    it "returns approver matches" do
+      FactoryGirl.create(:proposal, :with_approver)
+      proposal = FactoryGirl.create(:proposal, :with_approver)
+      approver = proposal.approvers.first
+
+      condition = Query::Proposals.with_approver_or_delegate(approver)
+      expect(Proposal.where(condition)).to eq([proposal])
+    end
+
+    it "returns delegate matches" do
+      proposal1 = FactoryGirl.create(:proposal, :with_approver)
+      approver1 = proposal1.approvers.first
+      delegate1 = FactoryGirl.create(:user)
+      approver1.add_delegate(delegate1)
+
+      proposal2 = FactoryGirl.create(:proposal, :with_approver)
+      approver2 = proposal2.approvers.first
+      delegate2 = FactoryGirl.create(:user)
+      approver2.add_delegate(delegate2)
+
+      condition = Query::Proposals.with_approver_or_delegate(delegate2)
+      expect(Proposal.where(condition)).to eq([proposal2])
+    end
+  end
+
+  describe '.with_observer' do
+    it "returns matches" do
+      FactoryGirl.create(:proposal, :with_observer)
+
+      proposal = FactoryGirl.create(:proposal, :with_observer)
+      observer = proposal.observers.first
+
+      condition = Query::Proposals.with_observer(observer)
+      expect(Proposal.where(condition)).to eq([proposal])
+    end
+  end
+end

--- a/spec/models/approval_spec.rb
+++ b/spec/models/approval_spec.rb
@@ -40,6 +40,16 @@ describe Approval do
     end
   end
 
+  describe '#delegates' do
+    it "returns a list of users" do
+      approver = approval.user
+      delegate = FactoryGirl.create(:user)
+      approver.add_delegate(delegate)
+
+      expect(approval.delegates).to eq([delegate])
+    end
+  end
+
   describe '#on_approved_entry' do
     it "notified the proposal if the root gets approved" do
       expect(approval.proposal).to receive(:partial_approve!).once
@@ -85,7 +95,7 @@ describe Approval do
       root.child_approvals = [and_clause,
                               Approvals::Individual.new(user: carrie),
                               then_clause]
-      
+
       proposal.approvals = [root] + root.child_approvals + and_clause.child_approvals + then_clause.child_approvals
       root.initialize!
     end

--- a/spec/models/approval_spec.rb
+++ b/spec/models/approval_spec.rb
@@ -40,16 +40,6 @@ describe Approval do
     end
   end
 
-  describe '#delegates' do
-    it "returns a list of users" do
-      approver = approval.user
-      delegate = FactoryGirl.create(:user)
-      approver.add_delegate(delegate)
-
-      expect(approval.delegates).to eq([delegate])
-    end
-  end
-
   describe '#on_approved_entry' do
     it "notified the proposal if the root gets approved" do
       expect(approval.proposal).to receive(:partial_approve!).once

--- a/spec/models/approvals/individual_spec.rb
+++ b/spec/models/approvals/individual_spec.rb
@@ -1,0 +1,13 @@
+describe Approvals::Individual do
+  let(:approval) { FactoryGirl.create(:approval) }
+
+  describe '#delegates' do
+    it "returns a list of users" do
+      approver = approval.user
+      delegate = FactoryGirl.create(:user)
+      approver.add_delegate(delegate)
+
+      expect(approval.delegates).to eq([delegate])
+    end
+  end
+end

--- a/spec/policies/proposal_policy/scope_spec.rb
+++ b/spec/policies/proposal_policy/scope_spec.rb
@@ -61,10 +61,20 @@ describe ProposalPolicy::Scope do
         expect(proposals).to eq([proposal])
       end
 
-      it "prevents them from seeing requests outside its client scope" do
-        expect(Proposal).to receive(:client_model_names).and_return(['CdfCompany::SomethingApprovable'])
-        proposal.update_attributes(client_data_type:'CdfCompany::SomethingApprovable')
-        expect(proposals).to be_empty
+      context "outside of their client scope" do
+        before do
+          expect(Proposal).to receive(:client_model_names).and_return(['CdfCompany::SomethingApprovable'])
+        end
+
+        it "allows them to see Proposals they are involved with" do
+          proposal.update_attributes(client_data_type: 'CdfCompany::SomethingApprovable', requester: user)
+          expect(proposals).to eq([proposal])
+        end
+
+        it "prevents them from seeing outside requests" do
+          proposal.update_attributes(client_data_type: 'CdfCompany::SomethingApprovable')
+          expect(proposals).to be_empty
+        end
       end
     end
 


### PR DESCRIPTION
Issue introduced in #538.

More importantly, converted the queries to Arel, which makes the various conditions for the subsets of Proposals composable. http://www.scuttle.io/ was super helpful in doing the conversion. Want to play around with them more to try and make them more readable, but I think they're ok for now.

Both pull requests are in service of https://www.pivotaltracker.com/story/show/99002900.