### PR TITLE
[DO NOT MERGE] make JOIN of client models for proposal pages implicit

### DIFF
--- a/config/tables/proposals.yml
+++ b/config/tables/proposals.yml
@@ -2,14 +2,6 @@ default: &DEFAULT
   engine: Proposal
   joins:
     requester: true
-    gsa18f_procurements: >
-      LEFT JOIN gsa18f_procurements
-      ON (gsa18f_procurements.id = proposals.client_data_id
-      AND proposals.client_data_type = 'Gsa18f::Procurement')
-    ncr_work_orders: >
-      LEFT JOIN ncr_work_orders
-      ON (ncr_work_orders.id = proposals.client_data_id
-      AND proposals.client_data_type = 'Ncr::WorkOrder')
   sort: -created_at
   column_configs:
     public_id:

--- a/lib/tabular_data/container.rb
+++ b/lib/tabular_data/container.rb
@@ -71,14 +71,21 @@ module TabularData
 
     def init_query(engine, joins)
       @query = engine.all()     # convert into a query
-      joins.each do |name, config|
-        if config == true
-          join_tables = engine.joins(name).join_sources
-          join_tables[-1].left.table_alias = name   # alias the table
-          @query = @query.joins(join_tables).includes(name)
-        else  # String config
-          @query = @query.joins(config)
-        end
+
+      joins.each do |name|
+        join_tables = engine.joins(name).join_sources
+        join_tables[-1].left.table_alias = name   # alias the table
+        @query = @query.joins(join_tables).includes(name)
+      end
+
+      Proposal::CLIENT_MODELS.each do |client_model|
+        table_name = client_model.table_name
+        join = <<-SQL
+          LEFT JOIN #{table_name}
+          ON (#{table_name}.id = proposals.client_data_id
+          AND proposals.client_data_type = '#{client_model}')
+        SQL
+        @query = @query.joins(join)
       end
     end
 

--- a/spec/lib/tabular_data/container_spec.rb
+++ b/spec/lib/tabular_data/container_spec.rb
@@ -70,7 +70,7 @@ describe TabularData::Container do
   end
 
   describe '#set_state_from_params' do
-    let(:container) { 
+    let(:container) {
       config = {engine: 'Proposal',
                 column_configs: {id: true, client: {virtual: true}},
                 columns: ['id', 'client']}


### PR DESCRIPTION
This is more of an idea than code that should actually be merged, but in the past few refactoring I've been keeping an eye out for how we can make the relationships between Proposals and the client models more implicit; in other words, how we reduce the amount of code specific to each. This is an example, where the `LEFT JOIN`s between them will (presumably) be the same for all client models, so we shouldn't have to write it out by hand. Would love ideas about a better way to achieve this.