### PR TITLE
ensure that GET /api/v1/users.json is sorted by ID

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,7 +1,7 @@
 module Api
   class UsersController < BaseController
     def index
-      users = User.all
+      users = User.order('id ASC')
 
       if params[:limit]
         users = users.limit(params[:limit].to_i)


### PR DESCRIPTION
This should fix a flaky test, which appeared in https://circleci.com/gh/18F/C2/1693.