### PR TITLE
[Delivers #99002900] only display Proposals a user is involved with on /proposals

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -18,8 +18,9 @@ class ProposalsController < ApplicationController
 
   def index
     @CLOSED_PROPOSAL_LIMIT = 10
+
     @pending_data = self.listing.pending
-    @approved_data = self.listing.approved(@CLOSED_PROPOSAL_LIMIT)
+    @approved_data = self.listing.approved.alter_query{ |rel| rel.limit(@CLOSED_PROPOSAL_LIMIT) }
     @cancelled_data = self.listing.cancelled
   end
 

--- a/lib/query/proposal/listing.rb
+++ b/lib/query/proposal/listing.rb
@@ -13,8 +13,8 @@ module Query
         self.proposals_container(:pending).alter_query(&:pending)
       end
 
-      def approved(limit)
-        self.proposals_container(:approved).alter_query { |p| p.approved.limit(limit) }
+      def approved
+        self.proposals_container(:approved).alter_query(&:approved)
       end
 
       def cancelled

--- a/lib/query/proposal/listing.rb
+++ b/lib/query/proposal/listing.rb
@@ -59,7 +59,7 @@ module Query
         container
       end
 
-      # returns a Container that is limited to what the user should see on /proposals
+      # returns a Container that is limited to what the user should see on /proposals, even if the ProposalPolicy::Scope allows them to see more
       def index_visible_container(name)
         container = self.proposals_container(name)
         container.alter_query do |rel|

--- a/lib/query/proposal/listing.rb
+++ b/lib/query/proposal/listing.rb
@@ -10,15 +10,15 @@ module Query
       end
 
       def pending
-        self.proposals_container(:pending).alter_query(&:pending)
+        self.index_visible_container(:pending).alter_query(&:pending)
       end
 
       def approved
-        self.proposals_container(:approved).alter_query(&:approved)
+        self.index_visible_container(:approved).alter_query(&:approved)
       end
 
       def cancelled
-        self.proposals_container(:cancelled).alter_query(&:cancelled)
+        self.index_visible_container(:cancelled).alter_query(&:cancelled)
       end
 
       def closed
@@ -57,6 +57,15 @@ module Query
         container.set_state_from_params(self.params)
 
         container
+      end
+
+      # returns a Container that is limited to what the user should see on /proposals
+      def index_visible_container(name)
+        container = self.proposals_container(name)
+        container.alter_query do |rel|
+          condition = Query::Proposal::Clauses.which_involve(self.user)
+          rel.where(condition)
+        end
       end
 
       def param_date(sym)

--- a/spec/lib/query/proposal/listing_spec.rb
+++ b/spec/lib/query/proposal/listing_spec.rb
@@ -2,29 +2,33 @@ describe Query::Proposal::Listing do
   let(:params) { ActionController::Parameters.new }
   let(:user) { FactoryGirl.create(:user) }
 
-  describe '#pending' do
-    it "only returns that user's Proposals when they are an app admin" do
-      FactoryGirl.create(:proposal)
-      proposal = FactoryGirl.create(:proposal, requester: user)
+  [:pending, :approved, :cancelled].each do |status|
+    describe "##{status}" do
+      it "only returns that user's Proposals when they are an app admin" do
+        FactoryGirl.create(:proposal, status: status)
+        proposal = FactoryGirl.create(:proposal, requester: user, status: status)
 
-      with_env_var('ADMIN_EMAILS', user.email_address) do
-        listing = Query::Proposal::Listing.new(user, params)
-        expect(listing.pending.rows).to eq([proposal])
-      end
-    end
-
-    context "with an arbitrary client" do
-      before do
-        user.update_attribute(:client_slug, 'ncr')
-      end
-
-      it "only displays that user's Proposals when they are a client admin" do
-        proposal = FactoryGirl.create(:proposal, requester: user)
-        FactoryGirl.create(:ncr_work_order)
-
-        with_env_var('CLIENT_ADMIN_EMAILS', user.email_address) do
+        with_env_var('ADMIN_EMAILS', user.email_address) do
           listing = Query::Proposal::Listing.new(user, params)
-          expect(listing.pending.rows).to eq([proposal])
+          expect(listing.send(status).rows).to eq([proposal])
+        end
+      end
+
+      context "with an arbitrary client" do
+        before do
+          user.update_attribute(:client_slug, 'ncr')
+        end
+
+        it "only displays that user's Proposals when they are a client admin" do
+          proposal = FactoryGirl.create(:proposal, requester: user, status: status)
+
+          other_proposal = FactoryGirl.create(:proposal, status: status)
+          FactoryGirl.create(:ncr_work_order, proposal: other_proposal)
+
+          with_env_var('CLIENT_ADMIN_EMAILS', user.email_address) do
+            listing = Query::Proposal::Listing.new(user, params)
+            expect(listing.send(status).rows).to eq([proposal])
+          end
         end
       end
     end

--- a/spec/lib/query/proposal/listing_spec.rb
+++ b/spec/lib/query/proposal/listing_spec.rb
@@ -1,0 +1,32 @@
+describe Query::Proposal::Listing do
+  let(:params) { ActionController::Parameters.new }
+  let(:user) { FactoryGirl.create(:user) }
+
+  describe '#pending' do
+    it "only returns that user's Proposals when they are an app admin" do
+      FactoryGirl.create(:proposal)
+      proposal = FactoryGirl.create(:proposal, requester: user)
+
+      with_env_var('ADMIN_EMAILS', user.email_address) do
+        listing = Query::Proposal::Listing.new(user, params)
+        expect(listing.pending.rows).to eq([proposal])
+      end
+    end
+
+    context "with an arbitrary client" do
+      before do
+        user.update_attribute(:client_slug, 'ncr')
+      end
+
+      it "only displays that user's Proposals when they are a client admin" do
+        proposal = FactoryGirl.create(:proposal, requester: user)
+        FactoryGirl.create(:ncr_work_order)
+
+        with_env_var('CLIENT_ADMIN_EMAILS', user.email_address) do
+          listing = Query::Proposal::Listing.new(user, params)
+          expect(listing.pending.rows).to eq([proposal])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In other words, app/client admins won't see _all_ Proposals on that page.