### PR TITLE
[Delivers #101210264] background email sending

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem 'awesome_print'
 gem 'aws-sdk-v1'    # remaining on v1 due to https://github.com/thoughtbot/paperclip/issues/1764
 gem 'bootstrap-sass'
 gem 'clockwork', require: false
+gem 'daemons' # for delayed_job
+gem 'delayed_job_active_record'
 gem 'dotenv-rails', require: 'dotenv/rails-now'
 gem 'draper'
 gem 'factory_girl_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
       activerecord (>= 3.2)
     arel (6.0.3)
     atomic (1.1.99)
-    autoprefixer-rails (5.2.1.1)
+    autoprefixer-rails (5.2.1.2)
       execjs
       json
     awesome_print (1.6.1)
@@ -96,7 +96,13 @@ GEM
     columnize (0.9.0)
     css_parser (1.3.6)
       addressable
+    daemons (1.2.3)
     database_cleaner (1.4.1)
+    delayed_job (4.0.6)
+      activesupport (>= 3.0, < 5.0)
+    delayed_job_active_record (4.0.3)
+      activerecord (>= 3.0, < 5.0)
+      delayed_job (>= 3.0, < 4.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
     dotenv (2.0.2)
@@ -109,25 +115,25 @@ GEM
       activesupport (>= 3.0)
       request_store (~> 1.0)
     erubis (2.7.0)
-    execjs (2.5.2)
+    execjs (2.6.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
-    faker (1.4.3)
+    faker (1.5.0)
       i18n (~> 0.5)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
-    font-awesome-sass (4.3.2.1)
-      sass (~> 3.2)
+    font-awesome-sass (4.4.0)
+      sass (>= 3.2)
     foreman (0.78.0)
       thor (~> 0.19.1)
     formatador (0.2.5)
     gherkin (2.12.2)
       multi_json (~> 1.3)
-    github-markdown (0.6.8)
+    github-markdown (0.6.9)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     guard (2.13.0)
@@ -174,7 +180,7 @@ GEM
     listen (3.0.3)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
-    loofah (2.0.2)
+    loofah (2.0.3)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.9)
     mail (2.6.3)
@@ -190,7 +196,7 @@ GEM
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     nenv (0.2.0)
-    newrelic_rpm (3.12.1.298)
+    newrelic_rpm (3.13.0.299)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
     notiffany (0.0.7)
@@ -242,7 +248,7 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
-    puma (2.12.3)
+    puma (2.13.4)
     pundit (1.0.1)
       activesupport (>= 3.0.0)
     rack (1.6.4)
@@ -266,7 +272,7 @@ GEM
       sprockets-rails
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.6)
+    rails-dom-testing (1.0.7)
       activesupport (>= 4.2.0.beta, < 5.0)
       nokogiri (~> 1.6.0)
       rails-deprecated_sanitizer (>= 1.0.1)
@@ -338,7 +344,7 @@ GEM
     spring (1.3.6)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
-    sprockets (3.2.0)
+    sprockets (3.3.2)
       rack (~> 1.0)
     sprockets-rails (2.3.2)
       actionpack (>= 3.0)
@@ -384,7 +390,9 @@ DEPENDENCIES
   capybara
   clockwork
   codeclimate-test-reporter
+  daemons
   database_cleaner
+  delayed_job_active_record
   dotenv-rails
   draper
   factory_girl_rails

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bin/rake cf:on_first_instance db:migrate && bundle exec puma
+worker: bin/delayed_job run
 clock: bundle exec clockwork config/clock.rb

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -4,12 +4,25 @@ class FeedbackController < ApplicationController
   end
 
   def create
-    fields = [:email, :bug, :context, :expected, :actually, :comments, :satisfaction, :referral]
-    fields = fields.select {|key| !params[key].blank?}
-    form_values = fields.map {|key| [key, params[key]]}
+    form_values = self.feedback_params
     unless form_values.empty?
       CommunicartMailer.feedback(current_user, form_values).deliver_later
     end
     # @todo - redirect somewhere to avoid back/refresh button issues
+  end
+
+  protected
+
+  def feedback_params
+    params.permit(
+      :email,
+      :bug,
+      :context,
+      :expected,
+      :actually,
+      :comments,
+      :satisfaction,
+      :referral
+    ).reject { |_key, val| val.blank? }
   end
 end

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -8,7 +8,7 @@ class FeedbackController < ApplicationController
     fields = fields.select {|key| !params[key].blank?}
     form_values = fields.map {|key| [key, params[key]]}
     unless form_values.empty?
-      CommunicartMailer.feedback(current_user, form_values).deliver_now
+      CommunicartMailer.feedback(current_user, form_values).deliver_later
     end
     # @todo - redirect somewhere to avoid back/refresh button issues
   end

--- a/app/mailers/communicart_mailer.rb
+++ b/app/mailers/communicart_mailer.rb
@@ -92,7 +92,7 @@ class CommunicartMailer < ActionMailer::Base
   end
 
   def feedback(sending_user, form_values)
-    form_strings = form_values.map { |pair| "#{pair[0]}: #{pair[1]}" }
+    form_strings = form_values.map { |key, val| "#{key}: #{val}" }
     message = form_strings.join("\n")
     mail(
       to: CommunicartMailer.support_email,

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,5 +42,7 @@ module C2
 
     # remove for Rails 4.3+(?)
     config.active_record.raise_in_transactional_callbacks = true
+
+    config.active_job.queue_adapter = :delayed_job
   end
 end

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,1 @@
+Delayed::Worker.delay_jobs = !Rails.env.test?

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,1 +1,7 @@
+# https://github.com/collectiveidea/delayed_job#gory-details
+
 Delayed::Worker.delay_jobs = !Rails.env.test?
+Delayed::Worker.destroy_failed_jobs = false
+Delayed::Worker.logger = Logger.new(STDOUT)
+Delayed::Worker.max_run_time = 5.minutes
+Delayed::Worker.raise_signal_exceptions = :term

--- a/db/migrate/20150819172749_create_delayed_jobs.rb
+++ b/db/migrate/20150819172749_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150730161938) do
+ActiveRecord::Schema.define(version: 20150819172749) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,6 +87,22 @@ ActiveRecord::Schema.define(version: 20150730161938) do
   end
 
   add_index "comments", ["proposal_id"], name: "index_comments_on_proposal_id", using: :btree
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer  "priority",   default: 0, null: false
+    t.integer  "attempts",   default: 0, null: false
+    t.text     "handler",                null: false
+    t.text     "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string   "locked_by"
+    t.string   "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "delayed_jobs", ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
 
   create_table "gsa18f_procurements", force: :cascade do |t|
     t.string   "office",                       limit: 255

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -41,7 +41,7 @@ Per [the Twelve-Factor guidelines](http://12factor.net/config), all necessary co
 open http://localhost:3000
 ```
 
-To include the [clock process](../config/clock.rb) (which is used for background jobs), run using `foreman start -p 3000`.
+To include the background jobs (which include sending emails), run using `foreman start -p 3000`.
 
 ### Viewing the mailers
 

--- a/lib/clock_tasks.rb
+++ b/lib/clock_tasks.rb
@@ -3,7 +3,7 @@
 class ClockTasks
   def self.send_ncr_budget_report
     puts "SENDING BUDGET REPORT..."
-    ReportMailer.budget_status.deliver_now
+    ReportMailer.budget_status.deliver_later
     puts "...DONE"
   end
 

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -1,5 +1,5 @@
 class Dispatcher
-  include ClassMethods
+  include ClassMethodsMixin
 
   def email_approver(approval)
     approval.create_api_token!

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -8,7 +8,7 @@ class Dispatcher
 
   def email_observer(observation)
     proposal = observation.proposal
-    CommunicartMailer.proposal_observer_email(observation.user_email_address, proposal).deliver_now
+    CommunicartMailer.proposal_observer_email(observation.user_email_address, proposal).deliver_later
   end
 
   def email_observers(proposal)
@@ -21,11 +21,11 @@ class Dispatcher
   end
 
   def on_observer_added(observation)
-    CommunicartMailer.on_observer_added(observation).deliver_now
+    CommunicartMailer.on_observer_added(observation).deliver_later
   end
 
   def email_sent_confirmation(proposal)
-    CommunicartMailer.proposal_created_confirmation(proposal).deliver_now
+    CommunicartMailer.proposal_created_confirmation(proposal).deliver_later
   end
 
   def deliver_new_proposal_emails(proposal)
@@ -38,9 +38,9 @@ class Dispatcher
 
   def deliver_cancellation_emails(proposal)
     proposal.approvers.each do |approver|
-      CommunicartMailer.cancellation_email(proposal, approver.email_address).deliver_now
+      CommunicartMailer.cancellation_email(proposal, approver.email_address).deliver_later
     end
-    CommunicartMailer.cancellation_confirmation(proposal).deliver_now
+    CommunicartMailer.cancellation_confirmation(proposal).deliver_later
   end
 
   def requires_approval_notice?(_approval)
@@ -49,7 +49,7 @@ class Dispatcher
 
   def on_approval_approved(approval)
     if self.requires_approval_notice?(approval)
-      CommunicartMailer.approval_reply_received_email(approval).deliver_now
+      CommunicartMailer.approval_reply_received_email(approval).deliver_later
     end
 
     self.email_observers(approval.proposal)
@@ -57,7 +57,7 @@ class Dispatcher
 
   def on_comment_created(comment)
     comment.listeners.each do |user|
-      CommunicartMailer.comment_added_email(comment, user.email_address).deliver_now
+      CommunicartMailer.comment_added_email(comment, user.email_address).deliver_later
     end
   end
 
@@ -66,7 +66,7 @@ class Dispatcher
 
   def on_approver_removal(proposal, removed_approvers)
     removed_approvers.each do|approver|
-      CommunicartMailer.notification_for_subscriber(approver.email_address, proposal, "removed").deliver_now
+      CommunicartMailer.notification_for_subscriber(approver.email_address, proposal, "removed").deliver_later
     end
   end
 
@@ -74,6 +74,6 @@ class Dispatcher
 
   def send_notification_email(approval)
     email = approval.user_email_address
-    CommunicartMailer.actions_for_approver(email, approval).deliver_now
+    CommunicartMailer.actions_for_approver(email, approval).deliver_later
   end
 end

--- a/lib/dispatcher/class_methods_mixin.rb
+++ b/lib/dispatcher/class_methods_mixin.rb
@@ -1,5 +1,5 @@
 class Dispatcher
-  module ClassMethods
+  module ClassMethodsMixin
     extend ActiveSupport::Concern
 
     class_methods do

--- a/lib/ncr_dispatcher.rb
+++ b/lib/ncr_dispatcher.rb
@@ -16,21 +16,21 @@ class NcrDispatcher < LinearDispatcher
   # modified. Also notify current approvers that the proposal has been updated
   def on_proposal_update(proposal)
     proposal.individual_approvals.approved.each{|approval|
-      CommunicartMailer.notification_for_subscriber(approval.user_email_address, proposal, "already_approved", approval).deliver_now
+      CommunicartMailer.notification_for_subscriber(approval.user_email_address, proposal, "already_approved", approval).deliver_later
     }
 
     proposal.currently_awaiting_approvals.each{|approval|
       if approval.api_token   # Approver's been notified through some other means
-        CommunicartMailer.actions_for_approver(approval.user_email_address, approval, "updated").deliver_now
+        CommunicartMailer.actions_for_approver(approval.user_email_address, approval, "updated").deliver_later
       else
         approval.create_api_token!
-        CommunicartMailer.actions_for_approver(approval.user_email_address, approval).deliver_now
+        CommunicartMailer.actions_for_approver(approval.user_email_address, approval).deliver_later
       end
     }
 
     proposal.observers.each{|observer|
       if observer.role_on(proposal).active_observer?
-        CommunicartMailer.notification_for_subscriber(observer.email_address, proposal, "updated").deliver_now
+        CommunicartMailer.notification_for_subscriber(observer.email_address, proposal, "updated").deliver_later
       end
     }
   end

--- a/spec/features/observer_spec.rb
+++ b/spec/features/observer_spec.rb
@@ -1,6 +1,6 @@
 describe "observers" do
   it "allows observers to be added" do
-    expect(CommunicartMailer).to receive(:on_observer_added).and_call_original
+    expect(CommunicartMailer).to receive_message_chain(:on_observer_added, :deliver_later)
 
     work_order = FactoryGirl.create(:ncr_work_order)
     observer = FactoryGirl.create(:user)

--- a/spec/lib/dispatcher_spec.rb
+++ b/spec/lib/dispatcher_spec.rb
@@ -16,7 +16,7 @@ describe Dispatcher do
     it 'creates a new token for the approver' do
       proposal.approvers = [FactoryGirl.create(:user)]
       approval = proposal.individual_approvals.first
-      expect(CommunicartMailer).to receive_message_chain(:actions_for_approver, :deliver_now)
+      expect(CommunicartMailer).to receive_message_chain(:actions_for_approver, :deliver_later)
       expect(approval).to receive(:create_api_token!).once
 
       dispatcher.email_approver(approval)
@@ -50,7 +50,7 @@ describe Dispatcher do
 
     it 'sends a proposal notification email to observers' do
       proposal.add_observer('observer1@some-dot-gov.gov')
-      expect(CommunicartMailer).to receive_message_chain(:proposal_observer_email, :deliver_now)
+      expect(CommunicartMailer).to receive_message_chain(:proposal_observer_email, :deliver_later)
       dispatcher.deliver_new_proposal_emails(proposal)
     end
   end
@@ -61,14 +61,14 @@ describe Dispatcher do
     it "sends an email to each approver" do
       allow(CommunicartMailer).to receive(:cancellation_email).and_return(mock_deliverer)
       expect(proposal.approvers.count).to eq 2
-      expect(mock_deliverer).to receive(:deliver_now).twice
+      expect(mock_deliverer).to receive(:deliver_later).twice
 
       dispatcher.deliver_cancellation_emails(proposal)
     end
 
     it "sends a confirmation email to the requester" do
       allow(CommunicartMailer).to receive(:cancellation_confirmation).and_return(mock_deliverer)
-      expect(mock_deliverer).to receive(:deliver_now).once
+      expect(mock_deliverer).to receive(:deliver_later).once
 
       dispatcher.deliver_cancellation_emails(proposal)
     end

--- a/spec/mailers/communicart_mailer_spec.rb
+++ b/spec/mailers/communicart_mailer_spec.rb
@@ -27,7 +27,7 @@ describe CommunicartMailer do
 
     it "includes the appropriate headers for threading" do
       # headers only get added when the Mail is #deliver-ed
-      mail.deliver_now
+      mail.deliver_later
 
       %w(In-Reply-To References).each do |header|
         expect(mail[header].value).to eq("<proposal-#{proposal.id}@#{DEFAULT_URL_HOST}>")

--- a/spec/mailers/report_mailer_spec.rb
+++ b/spec/mailers/report_mailer_spec.rb
@@ -3,7 +3,7 @@ describe ReportMailer do
     with_env_var('BUDGET_REPORT_RECIPIENT', 'budget@gsa.gov') do
       it "works with no data" do
         expect {
-          ReportMailer.budget_status.deliver_now
+          ReportMailer.budget_status.deliver_later
         }.to_not raise_error
       end
     end


### PR DESCRIPTION
This takes the sending of emails out of the request cycle, which has a few benefits:

* Response times will be faster
* Emails failing to send will no longer fail the overall request
* Failed email sends will be retried, and if those fail, we have a record of it

Updated gems, as well.