### PR TITLE
move API token creation into the mailer

### DIFF
--- a/app/mailers/communicart_mailer.rb
+++ b/app/mailers/communicart_mailer.rb
@@ -8,8 +8,9 @@ class CommunicartMailer < ActionMailer::Base
   add_template_helper MarkdownHelper
 
   # Approver can approve/take other action
-  def actions_for_approver(to_email, approval, alert_partial = nil)
+  def actions_for_approver(approval, alert_partial = nil)
     @show_approval_actions = true
+    to_email = approval.user_email_address
     proposal = approval.proposal
 
     self.notification_for_subscriber(to_email, proposal, alert_partial, approval)

--- a/app/mailers/communicart_mailer.rb
+++ b/app/mailers/communicart_mailer.rb
@@ -13,6 +13,10 @@ class CommunicartMailer < ActionMailer::Base
     to_email = approval.user_email_address
     proposal = approval.proposal
 
+    unless approval.api_token
+      approval.create_api_token!
+    end
+
     self.notification_for_subscriber(to_email, proposal, alert_partial, approval)
   end
 

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -73,7 +73,6 @@ class Dispatcher
   private
 
   def send_notification_email(approval)
-    email = approval.user_email_address
-    CommunicartMailer.actions_for_approver(email, approval).deliver_later
+    CommunicartMailer.actions_for_approver(approval).deliver_later
   end
 end

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -2,7 +2,6 @@ class Dispatcher
   include ClassMethodsMixin
 
   def email_approver(approval)
-    approval.create_api_token!
     send_notification_email(approval)
   end
 

--- a/lib/mail_preview.rb
+++ b/lib/mail_preview.rb
@@ -1,6 +1,5 @@
 class MailPreview < MailView
   def actions_for_approver
-    # TODO mock access token, if one isn't present
     mail = CommunicartMailer.actions_for_approver(pending_approval)
     inline_styles(mail)
   end

--- a/lib/mail_preview.rb
+++ b/lib/mail_preview.rb
@@ -1,7 +1,7 @@
 class MailPreview < MailView
   def actions_for_approver
     # TODO mock access token, if one isn't present
-    mail = CommunicartMailer.actions_for_approver(email, pending_approval)
+    mail = CommunicartMailer.actions_for_approver(pending_approval)
     inline_styles(mail)
   end
 

--- a/lib/ncr_dispatcher.rb
+++ b/lib/ncr_dispatcher.rb
@@ -23,7 +23,6 @@ class NcrDispatcher < LinearDispatcher
       if approval.api_token   # Approver's been notified through some other means
         CommunicartMailer.actions_for_approver(approval, "updated").deliver_later
       else
-        approval.create_api_token!
         CommunicartMailer.actions_for_approver(approval).deliver_later
       end
     }

--- a/lib/ncr_dispatcher.rb
+++ b/lib/ncr_dispatcher.rb
@@ -21,10 +21,10 @@ class NcrDispatcher < LinearDispatcher
 
     proposal.currently_awaiting_approvals.each{|approval|
       if approval.api_token   # Approver's been notified through some other means
-        CommunicartMailer.actions_for_approver(approval.user_email_address, approval, "updated").deliver_later
+        CommunicartMailer.actions_for_approver(approval, "updated").deliver_later
       else
         approval.create_api_token!
-        CommunicartMailer.actions_for_approver(approval.user_email_address, approval).deliver_later
+        CommunicartMailer.actions_for_approver(approval).deliver_later
       end
     }
 

--- a/spec/lib/dispatcher_spec.rb
+++ b/spec/lib/dispatcher_spec.rb
@@ -10,19 +10,6 @@ describe Dispatcher do
     end
   end
 
-  describe '#email_approver' do
-    let(:dispatcher) { Dispatcher.new }
-
-    it 'creates a new token for the approver' do
-      proposal.approvers = [FactoryGirl.create(:user)]
-      approval = proposal.individual_approvals.first
-      expect(CommunicartMailer).to receive_message_chain(:actions_for_approver, :deliver_later)
-      expect(approval).to receive(:create_api_token!).once
-
-      dispatcher.email_approver(approval)
-    end
-  end
-
   let(:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers) }
   let(:dispatcher) { Dispatcher.new }
 
@@ -34,18 +21,6 @@ describe Dispatcher do
         proposal.approvers.second.email_address,
         proposal.requester.email_address
       ].sort)
-    end
-
-    it 'creates a new token for each approver' do
-      Timecop.freeze do
-        expect(dispatcher).to receive(:send_notification_email).twice
-        dispatcher.deliver_new_proposal_emails(proposal)
-
-        proposal.individual_approvals.each do |approval|
-          # handle float comparison
-          expect(approval.api_token.expires_at).to be_within(1.second).of(7.days.from_now)
-        end
-      end
     end
 
     it 'sends a proposal notification email to observers' do

--- a/spec/mailers/communicart_mailer_spec.rb
+++ b/spec/mailers/communicart_mailer_spec.rb
@@ -37,7 +37,7 @@ describe CommunicartMailer do
 
   describe 'notification_for_approver' do
     let!(:token) { approval.create_api_token! }
-    let(:mail) { CommunicartMailer.actions_for_approver('email.to.email@testing.com', approval) }
+    let(:mail) { CommunicartMailer.actions_for_approver(approval) }
     let(:body) { mail.body.encoded }
     let(:approval_uri) do
       doc = Capybara.string(body)
@@ -50,7 +50,7 @@ describe CommunicartMailer do
     it_behaves_like "a Proposal email"
 
     it 'renders the receiver email' do
-      expect(mail.to).to eq(["email.to.email@testing.com"])
+      expect(mail.to).to eq([approver.email_address])
     end
 
     it "sets the sender name" do
@@ -67,7 +67,7 @@ describe CommunicartMailer do
     end
 
     it 'alerts subscribers that they have been removed' do
-      mail = CommunicartMailer.actions_for_approver('abc@example.com', approval, 'removed')
+      mail = CommunicartMailer.actions_for_approver(approval, 'removed')
       expect(mail.body.encoded).to include('You have been removed from this request.')
     end
 
@@ -109,19 +109,19 @@ describe CommunicartMailer do
 
     context 'alert templates' do
       it 'defaults to no specific header' do
-        mail = CommunicartMailer.actions_for_approver('abc@example.com', approval)
+        mail = CommunicartMailer.actions_for_approver(approval)
         expect(mail.body.encoded).not_to include('updated')
         expect(mail.body.encoded).not_to include('already approved')
       end
 
       it 'uses already_approved as a particular template' do
-        mail = CommunicartMailer.actions_for_approver('abc@example.com', approval, 'already_approved')
+        mail = CommunicartMailer.actions_for_approver(approval, 'already_approved')
         expect(mail.body.encoded).to include('updated')
         expect(mail.body.encoded).to include('already approved')
       end
 
       it 'uses updated as a particular template' do
-        mail = CommunicartMailer.actions_for_approver('abc@example.com', approval, 'updated')
+        mail = CommunicartMailer.actions_for_approver(approval, 'updated')
         expect(mail.body.encoded).to include('updated')
         expect(mail.body.encoded).not_to include('already approved')
       end
@@ -133,7 +133,7 @@ describe CommunicartMailer do
     end
 
     it "does include action buttons when actions_for_approver is used" do
-        mail = CommunicartMailer.actions_for_approver('abc@example.com', approval)
+        mail = CommunicartMailer.actions_for_approver(approval)
         expect(mail.body.encoded).to include('Approve')
     end
   end

--- a/spec/mailers/communicart_mailer_spec.rb
+++ b/spec/mailers/communicart_mailer_spec.rb
@@ -262,6 +262,22 @@ describe CommunicartMailer do
     end
   end
 
+  describe 'actions_for_approver' do
+    let(:mail) { CommunicartMailer.actions_for_approver(approval) }
+
+    it_behaves_like "a Proposal email"
+
+    it "creates a new token" do
+      expect(proposal.api_tokens).to eq([])
+
+      Timecop.freeze do
+        mail.deliver_now
+        approval.reload
+        expect(approval.api_token.expires_at).to be_within(1.second).of(7.days.from_now)
+      end
+    end
+  end
+
   describe '#proposal_subject' do
     it 'defaults when no client_data is present' do
       proposal = FactoryGirl.create(:proposal)


### PR DESCRIPTION
Don't _love_ the idea of the mailer being responsible for this, but it centralizes the logic that's needed for the mail to be sent successfully.

Came up because the delayed email sends are failing on staging because they don't have a token (which should have been created before, but is now missing for whatever reason). This sidesteps the issue of creating the token if it doesn't exist right before the email is sent.