### PR TITLE
Specifies DAP agency field, adds forceSSL

### DIFF
--- a/app/views/layouts/_analytics.html.erb
+++ b/app/views/layouts/_analytics.html.erb
@@ -1,6 +1,7 @@
 <% if ENV['GA_TRACKING_ID'] %>
   <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
-  <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js"></script>
+  <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA"></script>
+  
   <!-- 18F analytics -->
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -10,6 +11,7 @@
 
     ga('create', '<%= ENV['GA_TRACKING_ID'] %>', 'auto');
     ga('set', 'anonymizeIp', true);
+    ga('set', 'forceSSL', true);
     ga('send', 'pageview');
   </script>
 <% end %>


### PR DESCRIPTION
This specifies an `agency` of `GSA` for DAP reporting, and adds a missing `forceSSL` flag to GA settings.