### PR TITLE
add DelayedJob plugin for peek

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'paper_trail'
 gem 'peek'
 gem 'peek-performance_bar'
 gem 'peek-pg'
+gem 'peek-delayed_job'
 gem 'pg'
 gem 'puma'
 gem 'pundit', '>= 1.0.0'  # Interface for Pundit::NotAuthorizedError changed in this version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,9 @@ GEM
     peek (0.1.10)
       atomic (>= 1.0.0)
       railties (>= 3.0.0)
+    peek-delayed_job (0.1.0)
+      delayed_job_active_record
+      peek (>= 0.1.0)
     peek-performance_bar (1.1.6)
       peek (>= 0.1.0)
     peek-pg (1.1.0)
@@ -412,6 +415,7 @@ DEPENDENCIES
   paper_trail
   paperclip
   peek
+  peek-delayed_job
   peek-performance_bar
   peek-pg
   pg

--- a/config/initializers/peek.rb
+++ b/config/initializers/peek.rb
@@ -1,2 +1,3 @@
 Peek.into Peek::Views::PerformanceBar
 Peek.into Peek::Views::PG
+Peek.into Peek::Views::DelayedJob


### PR DESCRIPTION
...which I just made! In short, this will allow us to see the state of our background worker queue when using the app. See the repository for more info:

https://github.com/18F/peek-delayed_job