### PR TITLE
Search UI modifications

### DIFF
--- a/app/views/proposals/query.html.haml
+++ b/app/views/proposals/query.html.haml
@@ -2,10 +2,9 @@
   = render partial: 'search_ui'
   %h1
     Proposals participated in
-    %h2
-    %strong Currently displaying results for: 
-    = property_to_s(@text)
-    %br
-    %a{ :href => "/proposals" } Clear search terms
-    = datespan_header(@start_date, @end_date)
+  %strong Currently displaying results for: 
+  = property_to_s(@text)
+  %br
+  %a{ :href => proposals_path } Clear search terms
+  = datespan_header(@start_date, @end_date)
   = render partial: 'shared/table', locals: {container: @proposals_data}

--- a/app/views/proposals/query.html.haml
+++ b/app/views/proposals/query.html.haml
@@ -2,5 +2,10 @@
   = render partial: 'search_ui'
   %h1
     Proposals participated in
+    %h2
+    %strong Currently displaying results for: 
+    = property_to_s(@text)
+    %br
+    %a{ :href => "/proposals" } Clear search terms
     = datespan_header(@start_date, @end_date)
   = render partial: 'shared/table', locals: {container: @proposals_data}

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -1,7 +1,6 @@
 - content_for :title, @proposal.name
 .inset
   .row
-    = render partial: 'search_ui'
     .col-md-12.col-xs-12
       %h1.communicart_header
         = @proposal.name


### PR DESCRIPTION
In response to [remove search box from `show` templates](https://www.pivotaltracker.com/story/show/95181828) and [Ability to clear out existing search results](https://www.pivotaltracker.com/story/show/95162638). 

I am not sure this an exact solution to the latter story. The "Clear search terms" link just leads back to `/proposals`, effectively clearing the search box.

I am also pretty sure my Haml can be improved. Thanks for taking a look! :)