### PR TITLE
temporarily remove use of cf-blue-green

### DIFF
--- a/doc/production.md
+++ b/doc/production.md
@@ -33,5 +33,5 @@ organization: cap
         1. Tag the release.
         1. Do a zero-downtime deployment to the `c2-prod` application in Cloud Foundry.
         1. Push the tag to the repository on GitHub.
-    * If you want to do a zero-downtime deployment to another environment, run `cf-blue-green <appname>`.
+    * If you want to do a zero-downtime deployment to another environment, run `./script/deploy <appname>`.
     * If you want to do a simple deployment, you can use `cf push <appname>`.

--- a/doc/production.md
+++ b/doc/production.md
@@ -26,12 +26,10 @@ organization: cap
 1. Run `git status` and ensure that you have a clean working directory.
 1. If your deploy has a destructive migration,
     * [Take a snapshot](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateSnapshot.html) of [the database](https://console.aws.amazon.com/rds/home?region=us-east-1#dbinstances:).
-    * Note that you may see exceptions if doing a zero-downtime deployment, as the old copies of the application are expecting the old data format.
 1. Install [cf-blue-green](https://github.com/18F/cf-blue-green).
 1. Deploy the application
     * If you want to do an official "release" to production, run [`./script/release`](../script/release), which will:
         1. Tag the release.
-        1. Do a zero-downtime deployment to the `c2-prod` application in Cloud Foundry.
+        1. Do a deployment to the `c2-prod` application in Cloud Foundry.
         1. Push the tag to the repository on GitHub.
-    * If you want to do a zero-downtime deployment to another environment, run `./script/deploy <appname>`.
-    * If you want to do a simple deployment, you can use `cf push <appname>`.
+    * If you want to do a deployment to another environment, run `./script/deploy <appname>`.

--- a/script/deploy
+++ b/script/deploy
@@ -3,4 +3,4 @@
 set -e
 set -x
 
-cf-blue-green $1
+cf push $1

--- a/script/deploy
+++ b/script/deploy
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+set -x
+
+cf-blue-green $1

--- a/script/release
+++ b/script/release
@@ -3,10 +3,6 @@
 set -e
 set -x
 
-# http://stackoverflow.com/a/677212/358804
-if ! hash cf-blue-green 2>/dev/null; then
-  npm install -g cf-blue-green
-fi
 
 TAG=$(date -u +"%Y-%m-%dT%H%M%S")
 

--- a/script/release
+++ b/script/release
@@ -11,5 +11,5 @@ fi
 TAG=$(date -u +"%Y-%m-%dT%H%M%S")
 
 git tag $TAG
-cf-blue-green c2-prod
+./script/deploy c2-prod
 git push origin $TAG


### PR DESCRIPTION
As discussed in Slack, `cf-blue-green` doesn't work for C2 at the moment: it doesn't start the scheduler and worker processes the way it should, due to https://github.com/18F/cf-blue-green/issues/18.

Also adds a `./script/deploy` command, so that the deployer shouldn't have to think about the underlying deploy command(s).