### PR TITLE
102087948 timestamps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'autoprefixer-rails'
 gem 'awesome_print'
 gem 'aws-sdk-v1'    # remaining on v1 due to https://github.com/thoughtbot/paperclip/issues/1764
 gem 'bootstrap-sass'
+gem 'browser-timezone-rails'
 gem 'clockwork', require: false
 gem 'daemons' # for delayed_job
 gem 'delayed_job_active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,9 @@ GEM
     bootstrap-sass (3.3.5.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.3.0)
+    browser-timezone-rails (0.0.8)
+      jquery-rails
+      rails (>= 3.1)
     builder (3.2.2)
     bullet (4.14.7)
       activesupport (>= 3.0.0)
@@ -389,6 +392,7 @@ DEPENDENCIES
   awesome_print
   aws-sdk-v1
   bootstrap-sass
+  browser-timezone-rails
   bullet
   capybara
   clockwork

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,9 @@
 // about supported directives.
 //
 //= require jquery
+//= require jquery.cookie
+//= require jstz
+//= require browser_timezone_rails/set_time_zone
 //= require jquery.turbolinks
 //= require jquery_ujs
 //= require turbolinks

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -1,6 +1,6 @@
 module ReportHelper
   def pretty_date(date)
-    date.strftime("%a %m/%d/%y (%Z)")
+    date.utc.strftime("%a %m/%d/%y (%Z)")
   end
 
   def budget_proposals(type, timespan)

--- a/app/helpers/report_helper.rb
+++ b/app/helpers/report_helper.rb
@@ -1,6 +1,6 @@
 module ReportHelper
   def pretty_date(date)
-    date.in_time_zone('Eastern Time (US & Canada)').strftime("%a %m/%d/%y")
+    date.strftime("%a %m/%d/%y (%Z)")
   end
 
   def budget_proposals(type, timespan)

--- a/app/helpers/value_helper.rb
+++ b/app/helpers/value_helper.rb
@@ -2,7 +2,13 @@ module ValueHelper
   include ActionView::Helpers::NumberHelper
 
   def date_with_tooltip(time, ago = false)
-    adjusted_time = time.in_time_zone("Eastern Time (US & Canada)").strftime("%b %-d, %Y at %l:%M%P")
+    # make sure we are dealing with a Time object
+    if !time.is_a?(Time)
+      time = Time.parse(time)
+    end
+
+    # timezone adjustment is handled via browser-timezone-rails gem
+    adjusted_time = time.strftime("%b %-d, %Y at %l:%M%P")
 
     if ago
       content_tag('span', time_ago_in_words(adjusted_time) + " ago", title: adjusted_time)

--- a/app/helpers/value_helper.rb
+++ b/app/helpers/value_helper.rb
@@ -3,8 +3,8 @@ module ValueHelper
 
   def date_with_tooltip(time, ago = false)
     # make sure we are dealing with a Time object
-    if !time.is_a?(Time)
-      time = Time.parse(time)
+    unless time.is_a?(Time)
+      time = Time.zone.parse(time)
     end
 
     # timezone adjustment is handled via browser-timezone-rails gem

--- a/app/mailers/report_mailer.rb
+++ b/app/mailers/report_mailer.rb
@@ -3,7 +3,7 @@ class ReportMailer < ApplicationMailer
 
   def budget_status
     to_email = ENV.fetch('BUDGET_REPORT_RECIPIENT')
-    date = Time.now.in_time_zone('Eastern Time (US & Canada)').strftime("%a %m/%d/%y")
+    date = Time.now.utc.strftime("%a %m/%d/%y (%Z)")
 
     mail(
       to: to_email,


### PR DESCRIPTION
Use the browser's timezone for displaying timestamps in the browser. Use UTC for dates and times in emails, and make the timezone explicit.

https://www.pivotaltracker.com/story/show/102087948