### PR TITLE
101217598 vendor form fix

### DIFF
--- a/app/helpers/ncr/work_orders_helper.rb
+++ b/app/helpers/ncr/work_orders_helper.rb
@@ -13,13 +13,13 @@ module Ncr
       all.uniq.sort
     end
 
-    def vendor_options(vendor=nil)
+    def vendor_options(vendor = nil)
       all_vendors = Ncr::WorkOrder.where.not(vendor: nil).pluck('DISTINCT vendor')
       # merge in any passed
       if vendor
         all_vendors.push(vendor)
       end
-      all_vendors.uniq.sort_by {|v| v.downcase}
+      all_vendors.uniq.sort_by(&:downcase)
     end
   end
 end

--- a/app/helpers/ncr/work_orders_helper.rb
+++ b/app/helpers/ncr/work_orders_helper.rb
@@ -13,8 +13,13 @@ module Ncr
       all.uniq.sort
     end
 
-    def vendor_options
-      Ncr::WorkOrder.where.not(vendor: nil).pluck('DISTINCT vendor').sort
+    def vendor_options(vendor=nil)
+      all_vendors = Ncr::WorkOrder.where.not(vendor: nil).pluck('DISTINCT vendor')
+      # merge in any passed
+      if vendor
+        all_vendors.push(vendor)
+      end
+      all_vendors.uniq.sort_by {|v| v.downcase}
     end
   end
 end

--- a/app/views/ncr/work_orders/form.html.erb
+++ b/app/views/ncr/work_orders/form.html.erb
@@ -71,7 +71,7 @@
       <%= f.text_field :vendor,
             class: 'form-control js-selectize',
             placeholder: "Type here to search or add",
-            data: {initial: JSON.generate(vendor_options)} %>
+            data: {initial: JSON.generate(vendor_options(@model_instance.vendor))} %>
     </div>
     <div class="form-group">
       <%= field_set_tag "Amount", class: "required" do %>

--- a/spec/features/ncr_work_orders_spec.rb
+++ b/spec/features/ncr_work_orders_spec.rb
@@ -481,24 +481,26 @@ describe "National Capital Region proposals" do
         end
       end
 
-      it "doesn't change approving list when delegated" do
-        proposal = Proposal.last
-        approval = proposal.individual_approvals.first
-        approval.approve!
-        approval = proposal.individual_approvals.second
-        user = approval.user
-        delegate = User.new(email_address:'delegate@example.com')
-        delegate.save
-        user.add_delegate(delegate)
-        approval.update_attributes!(user: delegate)
-        visit "/ncr/work_orders/#{work_order.id}/edit"
-        fill_in 'Description', with:"New Description that shouldn't change the approver list"
-        click_on 'Update'
-
-        proposal.reload
-        second_approver = proposal.approvers.second.email_address
-        expect(second_approver).to eq('delegate@example.com')
-        expect(proposal.individual_approvals.length).to eq(3)
+      with_env_vars(NCR_BA61_TIER1_BUDGET_MAILBOX: 'foo@example.gov', NCR_BA61_TIER2_BUDGET_MAILBOX: 'bar@example.gov') do
+        it "doesn't change approving list when delegated" do
+          proposal = Proposal.last
+          approval = proposal.individual_approvals.first
+          approval.approve!
+          approval = proposal.individual_approvals.second
+          user = approval.user
+          delegate = User.new(email_address:'delegate@example.com')
+          delegate.save
+          user.add_delegate(delegate)
+          approval.update_attributes!(user: delegate)
+          visit "/ncr/work_orders/#{work_order.id}/edit"
+          fill_in 'Description', with:"New Description that shouldn't change the approver list"
+          click_on 'Update'
+  
+          proposal.reload
+          second_approver = proposal.approvers.second.email_address
+          expect(second_approver).to eq('delegate@example.com')
+          expect(proposal.individual_approvals.length).to eq(3)
+        end
       end
 
       it "has 'Discard Changes' link" do

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -62,7 +62,7 @@ describe Ncr::WorkOrder do
         'bob@example.com',
         Ncr::WorkOrder.ba61_tier1_budget_mailbox,
         Ncr::WorkOrder.ba61_tier2_budget_mailbox
-      ])
+      ].uniq)
       expect(form.approvals.length).to eq(0)
       form.clear_association_cache
       expect(form.approved?).to eq(true)


### PR DESCRIPTION
Make a new vendor string value sticky on form error.

https://www.pivotaltracker.com/story/show/101217598

NOTE there is no accompanying test for this because (a) I could find no prior art in spec/ for testing HTML responses and (b) there was no regression apparent in existing tests. I would be happy to blaze that trail (testing HTML responses) if folks think it is needed.