### PR TITLE
102087948 timezone coercion

### DIFF
--- a/app/helpers/value_helper.rb
+++ b/app/helpers/value_helper.rb
@@ -8,7 +8,8 @@ module ValueHelper
     end
 
     # timezone adjustment is handled via browser-timezone-rails gem
-    adjusted_time = time.strftime("%b %-d, %Y at %l:%M%P")
+    # so coerce into Time.zone explicitly
+    adjusted_time = time.in_time_zone.strftime("%b %-d, %Y at %l:%M%P")
 
     if ago
       content_tag('span', time_ago_in_words(adjusted_time) + " ago", title: adjusted_time)

--- a/app/helpers/value_helper.rb
+++ b/app/helpers/value_helper.rb
@@ -9,12 +9,13 @@ module ValueHelper
 
     # timezone adjustment is handled via browser-timezone-rails gem
     # so coerce into Time.zone explicitly
-    adjusted_time = time.in_time_zone.strftime("%b %-d, %Y at %l:%M%P")
+    adjusted_time     = time.in_time_zone
+    adjusted_time_str = adjusted_time.strftime("%b %-d, %Y at %l:%M%P")
 
     if ago
-      content_tag('span', time_ago_in_words(adjusted_time) + " ago", title: adjusted_time)
+      content_tag('span', time_ago_in_words(adjusted_time) + " ago", title: adjusted_time_str)
     else
-      content_tag('span', adjusted_time, title: adjusted_time)
+      content_tag('span', adjusted_time_str, title: adjusted_time_str)
     end
   end
 


### PR DESCRIPTION
The helper method that humanizes the timestamp was operating on a string which lacked the timezone, so it assumed UTC. Passing it a Time object instead, with proper localized timezone, should help it Do The Right thing in its date math.