### PR TITLE
use #each instead of #each_row in migration

### DIFF
--- a/db/migrate/20150831193037_move_observations_to_roles.rb
+++ b/db/migrate/20150831193037_move_observations_to_roles.rb
@@ -4,7 +4,7 @@ class MoveObservationsToRoles < ActiveRecord::Migration
 
     # We have to use raw sql because we've subclassed the observation class. Also, use `GROUP_BY` to find DISTINCT pairs.
     pgres = ProposalRole.connection.execute("SELECT proposal_id, user_id FROM observations WHERE user_id IN (SELECT id FROM users) GROUP BY proposal_id, user_id")
-    pgres.each_row do |row|
+    pgres.each do |row|
       ProposalRole.create(proposal_id: row['proposal_id'], user_id: row['user_id'], role_id: role.id)
     end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -123,9 +123,9 @@ ActiveRecord::Schema.define(version: 20150901190853) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "direct_pay"
-    t.string   "cl_number"
-    t.string   "function_code"
-    t.string   "soc_code"
+    t.string   "cl_number",       limit: 255
+    t.string   "function_code",   limit: 255
+    t.string   "soc_code",        limit: 255
   end
 
   create_table "properties", force: :cascade do |t|


### PR DESCRIPTION
Follow-up to #581.

`#each_row` returns each row as an array, whereas `#each` returns them as a Hash :facepalm: This migration is getting on my nerves.