### PR TITLE
do not notify user with email when they update a request

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,5 @@ Style/RedundantSelf:
   Enabled: false
 Style/StringLiterals:
   Enabled: false
+Style/AndOr:
+  Enabled: false

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -118,7 +118,7 @@ module Ncr
     end
 
     def email_approvers
-      Dispatcher.on_proposal_update(self.proposal)
+      Dispatcher.on_proposal_update(self.proposal, self.modifier)
     end
 
     # Ignore values in certain fields if they aren't relevant. May want to

--- a/lib/dispatcher/class_methods_mixin.rb
+++ b/lib/dispatcher/class_methods_mixin.rb
@@ -40,9 +40,9 @@ class Dispatcher
         dispatcher.email_approver(approval)
       end
 
-      def on_proposal_update(proposal)
+      def on_proposal_update(proposal, modifier=nil)
         dispatcher = self.initialize_dispatcher(proposal)
-        dispatcher.on_proposal_update(proposal)
+        dispatcher.on_proposal_update(proposal, modifier)
       end
 
       def on_approver_removal(proposal, approvers)

--- a/lib/dispatcher/class_methods_mixin.rb
+++ b/lib/dispatcher/class_methods_mixin.rb
@@ -40,7 +40,7 @@ class Dispatcher
         dispatcher.email_approver(approval)
       end
 
-      def on_proposal_update(proposal, modifier=nil)
+      def on_proposal_update(proposal, modifier = nil)
         dispatcher = self.initialize_dispatcher(proposal)
         dispatcher.on_proposal_update(proposal, modifier)
       end

--- a/lib/ncr_dispatcher.rb
+++ b/lib/ncr_dispatcher.rb
@@ -28,7 +28,10 @@ class NcrDispatcher < LinearDispatcher
     }
 
     proposal.observers.each{|observer|
-      next if modifier and observer.id == modifier.id # https://www.pivotaltracker.com/story/show/100957216
+      # don't notify the person who triggered the notification
+      # https://www.pivotaltracker.com/story/show/100957216
+      next if modifier and observer.id == modifier.id
+
       if observer.role_on(proposal).active_observer?
         CommunicartMailer.notification_for_subscriber(observer.email_address, proposal, "updated").deliver_later
       end

--- a/lib/ncr_dispatcher.rb
+++ b/lib/ncr_dispatcher.rb
@@ -14,13 +14,13 @@ class NcrDispatcher < LinearDispatcher
 
   # Notify approvers who have already approved that this proposal has been
   # modified. Also notify current approvers that the proposal has been updated
-  def on_proposal_update(proposal, modifier=nil)
+  def on_proposal_update(proposal, modifier = nil)
     proposal.individual_approvals.approved.each{|approval|
       CommunicartMailer.notification_for_subscriber(approval.user_email_address, proposal, "already_approved", approval).deliver_later
     }
 
     proposal.currently_awaiting_approvals.each{|approval|
-      if approval.api_token   # Approver's been notified through some other means
+      if approval.api_token # Approver's been notified through some other means
         CommunicartMailer.actions_for_approver(approval, "updated").deliver_later
       else
         CommunicartMailer.actions_for_approver(approval).deliver_later
@@ -28,7 +28,7 @@ class NcrDispatcher < LinearDispatcher
     }
 
     proposal.observers.each{|observer|
-      next if modifier and observer.id == modifier.id  # https://www.pivotaltracker.com/story/show/100957216
+      next if modifier and observer.id == modifier.id # https://www.pivotaltracker.com/story/show/100957216
       if observer.role_on(proposal).active_observer?
         CommunicartMailer.notification_for_subscriber(observer.email_address, proposal, "updated").deliver_later
       end

--- a/lib/ncr_dispatcher.rb
+++ b/lib/ncr_dispatcher.rb
@@ -14,7 +14,7 @@ class NcrDispatcher < LinearDispatcher
 
   # Notify approvers who have already approved that this proposal has been
   # modified. Also notify current approvers that the proposal has been updated
-  def on_proposal_update(proposal)
+  def on_proposal_update(proposal, modifier=nil)
     proposal.individual_approvals.approved.each{|approval|
       CommunicartMailer.notification_for_subscriber(approval.user_email_address, proposal, "already_approved", approval).deliver_later
     }
@@ -28,6 +28,7 @@ class NcrDispatcher < LinearDispatcher
     }
 
     proposal.observers.each{|observer|
+      next if modifier and observer.id == modifier.id  # https://www.pivotaltracker.com/story/show/100957216
       if observer.role_on(proposal).active_observer?
         CommunicartMailer.notification_for_subscriber(observer.email_address, proposal, "updated").deliver_later
       end

--- a/spec/lib/ncr_dispatcher_spec.rb
+++ b/spec/lib/ncr_dispatcher_spec.rb
@@ -58,5 +58,13 @@ describe NcrDispatcher do
       expect(email.html_part.body.to_s).not_to include("already approved")
       expect(email.html_part.body.to_s).to include("updated")
     end
+
+    it 'does not notify observer if they are the one making the update' do
+      deliveries.clear
+      email = 'requester@some-dot-gov.gov'
+      proposal.add_observer(email)
+      ncr_dispatcher.on_proposal_update(proposal, proposal.observers.first)
+      expect(email_recipients).to_not include(email)
+    end
   end
 end

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -67,7 +67,7 @@ describe Ncr::WorkOrder do
       form = FactoryGirl.create(:ncr_work_order, expense_type: 'BA61',
                                emergency: true)
       form.setup_approvals_and_observers('bob@example.com')
-      expect(form.observers.map(&:email_address)).to eq([
+      expect(form.observers.map(&:email_address)).to match_array([
         'bob@example.com',
         Ncr::WorkOrder.ba61_tier1_budget_mailbox,
         Ncr::WorkOrder.ba61_tier2_budget_mailbox


### PR DESCRIPTION
Relevant story: https://www.pivotaltracker.com/story/show/100957216

I'm not convinced that this doesn't affect *too many* notification cases, despite that tests are passing (including new test).