### PR TITLE
cancellation emails

### DIFF
--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -15,8 +15,6 @@ class Approval < ActiveRecord::Base
   belongs_to :parent, class_name: 'Approval'
   has_many :child_approvals, class_name: 'Approval', foreign_key: 'parent_id'
 
-  belongs_to :user
-
   scope :individual, -> { where(type: 'Approvals::Individual') }
 
 

--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -15,6 +15,8 @@ class Approval < ActiveRecord::Base
   belongs_to :parent, class_name: 'Approval'
   has_many :child_approvals, class_name: 'Approval', foreign_key: 'parent_id'
 
+  belongs_to :user
+
   scope :individual, -> { where(type: 'Approvals::Individual') }
 
 

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -37,8 +37,14 @@ class Dispatcher
 
   def deliver_cancellation_emails(proposal)
     proposal.approvals.each do |approval|
-      next if approval.pending?  # https://www.pivotaltracker.com/story/show/100733040
+      # do not send email to approvers who have not yet heard about the proposal
+      # https://www.pivotaltracker.com/story/show/100733040
+      next if approval.pending?
+
+      # since we operate on 'approvals' rather than 'approvers',
+      # must do explicit check on related User
       next unless approval.user
+
       CommunicartMailer.cancellation_email(approval.user_email_address, proposal).deliver_later
     end
     CommunicartMailer.cancellation_confirmation(proposal).deliver_later

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -36,8 +36,10 @@ class Dispatcher
   end
 
   def deliver_cancellation_emails(proposal)
-    proposal.approvers.each do |approver|
-      CommunicartMailer.cancellation_email(approver.email_address, proposal).deliver_later
+    proposal.approvals.each do |approval|
+      next if approval.pending?  # https://www.pivotaltracker.com/story/show/100733040
+      next unless approval.user
+      CommunicartMailer.cancellation_email(approval.user_email_address, proposal).deliver_later
     end
     CommunicartMailer.cancellation_confirmation(proposal).deliver_later
   end

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -36,14 +36,10 @@ class Dispatcher
   end
 
   def deliver_cancellation_emails(proposal)
-    proposal.approvals.each do |approval|
+    proposal.individual_approvals.each do |approval|
       # do not send email to approvers who have not yet heard about the proposal
       # https://www.pivotaltracker.com/story/show/100733040
       next if approval.pending?
-
-      # since we operate on 'approvals' rather than 'approvers',
-      # must do explicit check on related User
-      next unless approval.user
 
       CommunicartMailer.cancellation_email(approval.user_email_address, proposal).deliver_later
     end

--- a/spec/lib/dispatcher_spec.rb
+++ b/spec/lib/dispatcher_spec.rb
@@ -44,11 +44,7 @@ describe Dispatcher do
 
     it "sends an email to each actionable approver" do
       allow(CommunicartMailer).to receive(:cancellation_email).and_return(mock_deliverer)
-      #serial_proposal.approvals.each do |approval|
-      #  next unless approval.user
-      #  puts "approval=#{approval.user.email_address} #{approval.status}"
-      #end 
-      expect(serial_proposal.approvers.count).to eq 1
+      expect(serial_proposal.approvers.count).to eq 2
       expect(mock_deliverer).to receive(:deliver_later).once
 
       dispatcher.deliver_cancellation_emails(serial_proposal)

--- a/spec/lib/dispatcher_spec.rb
+++ b/spec/lib/dispatcher_spec.rb
@@ -11,6 +11,7 @@ describe Dispatcher do
   end
 
   let(:proposal) { FactoryGirl.create(:proposal, :with_parallel_approvers) }
+  let(:serial_proposal) { FactoryGirl.create(:proposal, :with_serial_approvers) }
   let(:dispatcher) { Dispatcher.new }
 
   describe '#deliver_new_proposal_emails' do
@@ -40,6 +41,18 @@ describe Dispatcher do
 
       dispatcher.deliver_cancellation_emails(proposal)
     end
+
+    it "sends an email to each actionable approver" do
+      allow(CommunicartMailer).to receive(:cancellation_email).and_return(mock_deliverer)
+      #serial_proposal.approvals.each do |approval|
+      #  next unless approval.user
+      #  puts "approval=#{approval.user.email_address} #{approval.status}"
+      #end 
+      expect(serial_proposal.approvers.count).to eq 1
+      expect(mock_deliverer).to receive(:deliver_later).once
+
+      dispatcher.deliver_cancellation_emails(serial_proposal)
+    end 
 
     it "sends a confirmation email to the requester" do
       allow(CommunicartMailer).to receive(:cancellation_confirmation).and_return(mock_deliverer)


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/100733040

Only send cancellation emails to non-pending approvers.