### PR TITLE
[Delivers #101217754] Adding tests for the work_order.fiscal_year method

### DIFF
--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -225,6 +225,15 @@ module Ncr
       super.merge(org_id: self.org_id, building_id: self.building_id)
     end
 
+    def fiscal_year
+      year = self.created_at.nil? ? Time.now.year : self.created_at.year
+      month = self.created_at.nil? ? Time.now.month : self.created_at.month
+      if month >= 10
+        year += 1
+      end
+      year % 100   # convert to two-digit
+    end
+
     protected
 
     # TODO move to Proposal model
@@ -254,15 +263,6 @@ module Ncr
     def self.update_comment_format key, value, bullet, former=nil
       from = former ? "from #{former} " : ''
       "#{bullet}*#{key}* was changed " + from + "to #{value}"
-    end
-
-    def fiscal_year
-      year = self.created_at.nil? ? Time.now.year : self.created_at.year
-      month = self.created_at.nil? ? Time.now.month : self.created_at.month
-      if month >= 10
-        year += 1
-      end
-      year % 100   # convert to two-digit
     end
 
     # Generally shouldn't be called directly as it doesn't account for

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -230,6 +230,18 @@ describe Ncr::WorkOrder do
     end
   end
 
+  describe '#fiscal_year' do
+    it 'ends the fiscal year on September 30th' do
+      work_order = FactoryGirl.create(:ncr_work_order, created_at: Date.new(2014, 9, 30))
+      expect(work_order.fiscal_year).to eq 14
+    end
+
+    it 'starts a new fiscal year on October first' do
+      work_order = FactoryGirl.create(:ncr_work_order, created_at: Date.new(2014, 10, 1))
+      expect(work_order.fiscal_year).to eq 15
+    end
+  end
+
   describe 'validations' do
     describe 'cl_number' do
       let (:work_order) { FactoryGirl.build(:ncr_work_order) }


### PR DESCRIPTION
The public ID field already uses the fiscal_year method to set the work order's id based on the current fiscal year. Added tests to the method and we should be good to go.

Paired with @afeld. 