### PR TITLE
[Delivers #100957216] notify requester on proposal change

### DIFF
--- a/lib/ncr_dispatcher.rb
+++ b/lib/ncr_dispatcher.rb
@@ -18,9 +18,14 @@ class NcrDispatcher < LinearDispatcher
     notify_approvers(proposal, modifier)
     notify_pending_approvers(proposal, modifier)
     notify_observers(proposal, modifier)
+    notify_requester(proposal, modifier) unless proposal.requester == modifier
   end
 
   private
+
+  def notify_requester(proposal, modifier)
+    CommunicartMailer.notification_for_subscriber(proposal.requester.email_address, proposal, "updated").deliver_later
+  end
 
   def notify_approvers(proposal, modifier)
     proposal.individual_approvals.approved.each do |approval|

--- a/lib/ncr_dispatcher.rb
+++ b/lib/ncr_dispatcher.rb
@@ -18,12 +18,13 @@ class NcrDispatcher < LinearDispatcher
     notify_approvers(proposal, modifier)
     notify_pending_approvers(proposal, modifier)
     notify_observers(proposal, modifier)
-    notify_requester(proposal, modifier) unless proposal.requester == modifier
+    notify_requester(proposal, modifier)
   end
 
   private
 
   def notify_requester(proposal, modifier)
+    return if proposal.requester == modifier
     CommunicartMailer.notification_for_subscriber(proposal.requester.email_address, proposal, "updated").deliver_later
   end
 

--- a/spec/lib/ncr_dispatcher_spec.rb
+++ b/spec/lib/ncr_dispatcher_spec.rb
@@ -73,5 +73,13 @@ describe NcrDispatcher do
       ncr_dispatcher.on_proposal_update(proposal, approval_1.user)
       expect(email_recipients).to_not include(email)
     end
+
+    it "does notify requester if they are not the one making the update" do
+      deliveries.clear
+      email = proposal.requester.email_address
+      ncr_dispatcher.on_proposal_update(proposal, approval_1.user)
+      expect(approval_1.user.email_address).to_not eq(proposal.requester.email_address)
+      expect(email_recipients).to include(email)
+    end
   end
 end


### PR DESCRIPTION
It appears that requesters were only getting notified on comments, not changes, to a proposal. This PR adds code + test to verify requesters are getting notified when a proposal changes.