### PR TITLE
have CircleCI run migrations

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,8 +2,6 @@
 # https://github.com/testdouble/feedback/issues/7
 database:
   override:
-    - export RAILS_ENV="test"
-    - export RACK_ENV="test"
     - bundle exec rake db:create db:migrate --trace
 dependencies:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,10 @@
+# run all migrations
+# https://github.com/testdouble/feedback/issues/7
+database:
+  override:
+    - export RAILS_ENV="test"
+    - export RACK_ENV="test"
+    - bundle exec rake db:create db:migrate --trace
 dependencies:
   pre:
     - cp .env.example .env
-


### PR DESCRIPTION
This pull request intentionally raises a question: do we want to ensure all past migrations continue to work indefinitely? If they are broken (such as referencing a class name that is removed), tests will fail, as seen here. See discussion in https://github.com/testdouble/feedback/issues/7 for more background.

/cc @cmc333333 