### PR TITLE
run `rake db:seed` on deploy

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,1 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+# any commands in this file should be idempotent

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -37,11 +37,9 @@ Per [the Twelve-Factor guidelines](http://12factor.net/config), all necessary co
 ## Starting the application
 
 ```bash
-./bin/rails s
+PORT=3000 ./script/start
 open http://localhost:3000
 ```
-
-To include the background jobs (which include sending emails), run using `foreman start -p 3000`.
 
 ### Viewing the mailers
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@
 # NOTE: any changes to this file require running `cf push <appname>` directly, rather than `cf-blue-green <appname>`.
 
 # general configuration
-command: script/server_start
+command: script/start
 domain: 18f.gov
 instances: 1
 memory: 1G

--- a/script/server_start
+++ b/script/server_start
@@ -5,5 +5,5 @@
 set -e
 set -x
 
-bin/rake cf:on_first_instance db:migrate
+bin/rake cf:on_first_instance db:migrate db:seed
 foreman start -p $PORT

--- a/script/start
+++ b/script/start
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-# Script for starting the application in a server environment (rather than local development).
-
 set -e
 set -x
 


### PR DESCRIPTION
Addressing an issue raised in #602.

For any changes to `seeds.rb`, we want to ensure that those records are created on our various environments, without needing to duplicate the seeding in a migration. This change makes a `start` script, which should be used on development machines or servers, which

* Runs migrations
* Runs seeds
* Starts the server with the background workers