### PR TITLE
require appname on deploy, to avoid deploying everywhere

### DIFF
--- a/script/deploy
+++ b/script/deploy
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+USAGE="$0: appname"
+if [ $# -lt 1 ]; then echo "Error: appname is required.\n$USAGE" >&2; exit 1; fi
+
 set -e
 set -x
 

--- a/script/deploy
+++ b/script/deploy
@@ -1,9 +1,12 @@
 #!/bin/sh
 
-USAGE="$0: appname"
-if [ $# -lt 1 ]; then echo "Error: appname is required.\n$USAGE" >&2; exit 1; fi
-
 set -e
 set -x
+
+USAGE="$0: appname"
+if [ $# -lt 1 ]; then
+  echo "Error: appname is required.\n$USAGE" >&2
+  exit 1
+fi
 
 cf push $1


### PR DESCRIPTION
Per anecdote from recent deploy mishap, require explicit appname in `script/deploy`.