### PR TITLE
Test database config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,7 @@ MYUSA_SECRET: consumer_secret_key
 # NOTIFICATION_FROM_EMAIL
 # PORT
 # RESTRICT_ACCESS=true
+# TEST_DATABASE_URL=postgresql://localhost/c2_test
 # WEB_CONCURRENCY
 
 # production only

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,5 +13,7 @@ development:
   database: c2_development
 test:
   <<: *default
-  url: postgresql://localhost/c2_test
+# use 'url' rather than 'database' so that DATABASE_URL env var is not merged in.
+# see URL at top of this file for docs.
+  url: <% ENV['TEST_DATABASE_URL'] || 'postgresql://localhost/c2_test' %>
 production: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,5 +13,5 @@ development:
   database: c2_development
 test:
   <<: *default
-  database: c2_test
+  url: postgresql://localhost/c2_test
 production: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,5 +15,5 @@ test:
   <<: *default
 # use 'url' rather than 'database' so that DATABASE_URL env var is not merged in.
 # see URL at top of this file for docs.
-  url: <% ENV['TEST_DATABASE_URL'] || 'postgresql://localhost/c2_test' %>
+  url: <%= ENV['TEST_DATABASE_URL'] || 'postgresql://localhost/c2_test' %>
 production: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,5 +15,5 @@ test:
   <<: *default
 # use 'url' rather than 'database' so that DATABASE_URL env var is not merged in.
 # see URL at top of this file for docs.
-  url: <%= ENV['TEST_DATABASE_URL'] || 'postgresql://localhost/c2_test' %>
+  url: <%= (ENV["TEST_DATABASE_URL"] || "postgresql://localhost/c2_test") %>
 production: *default


### PR DESCRIPTION
add new TEST_DATABASE_URL env variable, and default to explicit 'url' syntax to avoid clearing db when DATABASE_URL is set explicitly.