### PR TITLE
re-enable zero-downtime deployment

### DIFF
--- a/doc/production.md
+++ b/doc/production.md
@@ -26,13 +26,15 @@ organization: cap
 1. Run `git status` and ensure that you have a clean working directory.
 1. If your deploy has a destructive migration,
     * [Take a snapshot](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateSnapshot.html) of [the database](https://console.aws.amazon.com/rds/home?region=us-east-1#dbinstances:).
+    * Note that you may see exceptions if doing a zero-downtime deployment, as the old copies of the application are expecting the old data format.
+1. Install [cf-blue-green](https://github.com/18F/cf-blue-green) v0.2.1+.
 1. Run `cf target -o cap -s general`.
 1. Deploy the application
     * If you want to do an official "release" to production, run [`./script/release`](../script/release), which will:
         1. Tag the release.
-        1. Do a deployment to the `c2-prod` application in Cloud Foundry.
+        1. Do a zero-downtime deployment to the `c2-prod` application in Cloud Foundry.
         1. Push the tag to the repository on GitHub.
-    * If you want to do a deployment to another environment, run `./script/deploy <appname>`.
+    * If you want to do a zero-downtime deployment to another environment, run `./script/deploy <appname>`.
 
 ## [Mandrill](https://mandrillapp.com)
 

--- a/script/deploy
+++ b/script/deploy
@@ -9,4 +9,4 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 
-cf push $1
+cf-blue-green $1

--- a/script/deploy
+++ b/script/deploy
@@ -9,4 +9,9 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 
+# http://stackoverflow.com/a/677212/358804
+if ! hash cf-blue-green 2>/dev/null; then
+  npm install -g cf-blue-green
+fi
+
 cf-blue-green $1

--- a/script/release
+++ b/script/release
@@ -3,6 +3,10 @@
 set -e
 set -x
 
+# http://stackoverflow.com/a/677212/358804
+if ! hash cf-blue-green 2>/dev/null; then
+  npm install -g cf-blue-green
+fi
 
 TAG=$(date -u +"%Y-%m-%dT%H%M%S")
 

--- a/script/release
+++ b/script/release
@@ -3,10 +3,6 @@
 set -e
 set -x
 
-# http://stackoverflow.com/a/677212/358804
-if ! hash cf-blue-green 2>/dev/null; then
-  npm install -g cf-blue-green
-fi
 
 TAG=$(date -u +"%Y-%m-%dT%H%M%S")
 


### PR DESCRIPTION
:zero: :clock10: :rocket: :zap: :tada: 

Everyone please run the following before we merge this:

```bash
brew update
brew upgrade cloudfoundry-cli
cf --version
# should print `cf version 6.12.4-...`

npm update -g cf-blue-green
npm list -g --depth=0 2>&1 | grep cf-blue-green
# should print `├── cf-blue-green@0.2.1`
```

Check the box next to your name below once you're all good.

* [x] @annalee 
* [x] @phirefly 
* [x] @pkarman 
* [x] @yozlet 

Thanks!

* [x] *Note to self: update instructions once https://github.com/pivotal/homebrew-tap/pull/52 is merged.*

/cc https://github.com/18F/cf-blue-green/pull/22