### PR TITLE
keep track of deployments in New Relic

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,7 +4,7 @@
 # NOTE: any changes to this file require running `cf push <appname>` directly, rather than `cf-blue-green <appname>`.
 
 # general configuration
-command: script/start
+command: script/server_start
 domain: 18f.gov
 instances: 1
 memory: 1G

--- a/script/server_start
+++ b/script/server_start
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+set -x
+
+
+# record the deployment in New Relic
+# https://docs.newrelic.com/docs/agents/ruby-agent/features/recording-deployments-ruby-agent#Manual
+# TODO track who deployed, and what revision
+bundle exec newrelic deployments
+
+./script/start


### PR DESCRIPTION
Tested on dev:

![screen shot 2015-09-23 at 2 05 39 am](https://cloud.githubusercontent.com/assets/86842/10038730/a93d370c-6197-11e5-873b-42221986e818.png)

It's particularly helpful in the graph views, where the deployments show up as vertical lines:

![screen shot 2015-09-23 at 2 08 09 am](https://cloud.githubusercontent.com/assets/86842/10038756/134ab46c-6198-11e5-8f1a-3b9f8795e55f.png)

Not that interesting here since there's no real traffic to dev in the middle of the night, but you get the idea.