### PR TITLE
[Delivers #98787550] sort gsa18f procurements by urgency

### DIFF
--- a/app/models/gsa18f/procurement.rb
+++ b/app/models/gsa18f/procurement.rb
@@ -69,6 +69,10 @@ module Gsa18f
       self.product_name_and_description
     end
 
+    def urgency_string
+      URGENCY[urgency]
+    end
+
     def self.approver_email
       ENV.fetch('GSA18F_APPROVER_EMAIL')
     end

--- a/app/views/gsa18f/procurements/form.html.erb
+++ b/app/views/gsa18f/procurements/form.html.erb
@@ -80,7 +80,7 @@
      <div class="form-group">
       <%= f.label :urgency %>
       <%= f.collection_select(
-            :urgency, Gsa18f::Procurement::URGENCY, :to_s, :to_s,
+            :urgency, Gsa18f::Procurement::URGENCY, :first, :last,
             {include_blank: true}, {class: 'form-control'}) %>
     </div>
     <!-- Additional Info -->

--- a/config/data/18f.yaml
+++ b/config/data/18f.yaml
@@ -1,7 +1,7 @@
 URGENCY:
-  - 'I need it yesterday'
-  - "I'm patient but would like w/in a week"
-  - 'Whenever'
+  10: 'I need it yesterday'
+  20: "I'm patient but would like w/in a week"
+  30: 'Whenever'
 OFFICES:
   - 'DC'
   - 'Chicago'

--- a/config/tables/proposals.yml
+++ b/config/tables/proposals.yml
@@ -37,6 +37,10 @@ default: &DEFAULT
       db: COALESCE(ncr_work_orders.amount, gsa18f_procurements.cost_per_unit * gsa18f_procurements.quantity, 0)
       display: client_data.total_price
       formatter: currency
+    urgency:
+      header: Urgency
+      db: gsa18f_procurements.urgency
+      display: client_data.urgency_string
   columns:
     - public_id
     - name
@@ -63,3 +67,4 @@ gsa18f:
     - total_price
     - status
     - created_at
+    - urgency

--- a/db/migrate/20150924162801_change_procurement_urgency_to_integer.rb
+++ b/db/migrate/20150924162801_change_procurement_urgency_to_integer.rb
@@ -1,0 +1,51 @@
+class ChangeProcurementUrgencyToInteger < ActiveRecord::Migration
+  def up
+    add_column :gsa18f_procurements, :tmp_urgency, :integer
+
+    execute <<-SQL
+      UPDATE gsa18f_procurements
+      SET tmp_urgency = 10
+      WHERE urgency = 'I need it yesterday';
+    SQL
+
+    execute <<-SQL
+      UPDATE gsa18f_procurements
+      SET tmp_urgency = 20
+      WHERE urgency = 'I''m patient but would like w/in a week';
+    SQL
+
+    execute <<-SQL
+      UPDATE gsa18f_procurements
+      SET tmp_urgency = 30
+      WHERE urgency = 'Whenever';
+    SQL
+
+    remove_column :gsa18f_procurements, :urgency
+    rename_column :gsa18f_procurements, :tmp_urgency, :urgency
+  end
+
+  def down
+    add_column :gsa18f_procurements, :tmp_urgency, :string
+
+    execute <<-SQL
+      UPDATE gsa18f_procurements
+      SET tmp_urgency = 'I need it yesterday'
+      WHERE urgency = 10;
+    SQL
+
+    execute <<-SQL
+      UPDATE gsa18f_procurements
+      SET tmp_urgency = 'I''m patient but would like w/in a week'
+      WHERE urgency = 20;
+    SQL
+
+    execute <<-SQL
+      UPDATE gsa18f_procurements
+      SET tmp_urgency = 'Whenever'
+      WHERE urgency = 30;
+    SQL
+
+    remove_column :gsa18f_procurements, :urgency
+    rename_column :gsa18f_procurements, :tmp_urgency, :urgency
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150901190853) do
+ActiveRecord::Schema.define(version: 20150924162801) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,9 +103,9 @@ ActiveRecord::Schema.define(version: 20150901190853) do
     t.boolean  "recurring"
     t.string   "recurring_interval",           limit: 255
     t.integer  "recurring_length"
-    t.string   "urgency",                      limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "urgency"
   end
 
   create_table "ncr_work_orders", force: :cascade do |t|

--- a/spec/factories/gsa18f/procurements.rb
+++ b/spec/factories/gsa18f/procurements.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
     additional_info "none"
     sequence(:product_name_and_description) {|n| "Proposal #{n}" }
     office Gsa18f::Procurement::OFFICES[0]
-    urgency Gsa18f::Procurement::URGENCY[0]
+    urgency Gsa18f::Procurement::URGENCY[10]
     association :proposal, flow: 'linear'
 
     #todo: Probably shouldn't be required, remove once #98376564 is fixed

--- a/spec/features/18f_procurement_spec.rb
+++ b/spec/features/18f_procurement_spec.rb
@@ -34,7 +34,7 @@ describe "GSA 18f Purchase Request Form" do
       fill_in 'Quantity', with: 6
       fill_in 'gsa18f_procurement_date_requested', with: '12/12/2999'
       fill_in 'gsa18f_procurement_additional_info', with: 'none'
-      select Gsa18f::Procurement::URGENCY[0], :from => 'gsa18f_procurement_urgency'
+      select Gsa18f::Procurement::URGENCY[10], :from => 'gsa18f_procurement_urgency'
       select Gsa18f::Procurement::OFFICES[0], :from => 'gsa18f_procurement_office'
       expect {
         click_on 'Submit for approval'
@@ -57,7 +57,7 @@ describe "GSA 18f Purchase Request Form" do
       expect(procurement.cost_per_unit).to eq(123.45)
       expect(procurement.quantity).to eq(6)
       expect(procurement.office).to eq(Gsa18f::Procurement::OFFICES[0])
-      expect(procurement.urgency).to eq(Gsa18f::Procurement::URGENCY[0])
+      expect(procurement.urgency).to eq(10)
     end
 
     it "sets an observer" do
@@ -142,7 +142,7 @@ describe "GSA 18f Purchase Request Form" do
       fill_in 'Quantity', with: 6
       fill_in 'gsa18f_procurement_date_requested', with: '12/12/2999'
       fill_in 'gsa18f_procurement_additional_info', with: 'none'
-      select Gsa18f::Procurement::URGENCY[0], :from => 'gsa18f_procurement_urgency'
+      select Gsa18f::Procurement::URGENCY[10], :from => 'gsa18f_procurement_urgency'
       select Gsa18f::Procurement::OFFICES[0], :from => 'gsa18f_procurement_office'
 
       click_on 'Submit for approval'
@@ -167,7 +167,7 @@ describe "GSA 18f Purchase Request Form" do
       expect(procurement.cost_per_unit).to eq(123.45)
       expect(procurement.quantity).to eq(6)
       expect(procurement.office).to eq(Gsa18f::Procurement::OFFICES[0])
-      expect(procurement.urgency).to eq(Gsa18f::Procurement::URGENCY[0])
+      expect(procurement.urgency).to eq(10)
 
       expect(proposal.requester).to eq(requester)
       expect(proposal.approvers.map(&:email_address)).to eq(%w(test_approver@some-dot-gov.gov))

--- a/spec/features/tabular_data_spec.rb
+++ b/spec/features/tabular_data_spec.rb
@@ -22,6 +22,10 @@ describe "Tabular data sorting" do
   end
 
   context 'home page' do
+    before do
+      user.update(client_slug: nil)
+    end
+
     it 'begins sorted by -created_at' do
       visit '/proposals'
 
@@ -71,6 +75,29 @@ describe "Tabular data sorting" do
       end
 
       expect_order(tables[1], cancelled.reverse)
+    end
+  end
+
+  context '18F home page' do
+    let!(:proposals) { 3.times.map { FactoryGirl.create(:gsa18f_procurement) } }
+
+    before do
+      user.update(client_slug: "gsa18f")
+      proposals[0].update(urgency: 20)
+      proposals[1].update(urgency: 30)
+      proposals[2].update(urgency: 10)
+    end
+
+    it 'can be sorted by urgency' do
+      visit '/proposals'
+      expect_order(tables[0], proposals.reverse.map { |p| p.proposal })
+
+      within(tables[0]) do
+        click_on 'Urgency'
+      end
+
+      expect_order(tables[0], [proposals[2], proposals[0], proposals[1]]
+        .map { |p| p.proposal })
     end
   end
 


### PR DESCRIPTION
Allows gsa18F `Procurement`s to be sorted by `urgency`in the table at /proposals, and changes the type of `urgency` from `:string` to `:integer` to support sorting. 

:warning: Includes a migration to update existing urgency values to integers, but only for the 3 urgency strings currently in 18f.yaml. Please confirm that only these 3 values exist before running the migration in production. Happy to update the migration if there are other values.

*Context/notes to self:*
- If a user can have multiple clients (i.e. work w/ multiple orgs/agencies), /proposals should probably become a tabbed view. Sorting by urgency is unlikely to make sense across clients. 
- Spacing out the integer values (10/20/30 vs 1/2/3) is so folks can add new urgency levels later w/o a data migration.
- With shorter, more symbol-like labels this would be a candidate for ActiveRecord enums.
- `Procurement#urgency_string` should be moved to a decorator if there are more than 1 or 2 similar methods