### PR TITLE
use existing logic to retrieve the current approver on a WorkOrder

### DIFF
--- a/app/models/concerns/proposal_delegate.rb
+++ b/app/models/concerns/proposal_delegate.rb
@@ -20,7 +20,7 @@ module ProposalDelegate
     validates :proposal, presence: true
 
 
-    delegate :add_observer, :add_requester, :set_requester, to: :proposal
+    delegate :add_observer, :add_requester, :set_requester, :currently_awaiting_approvers, to: :proposal
 
     ### delegate the workflow actions/scopes/states ###
 

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -117,7 +117,7 @@ module Ncr
     # the highest approver on the stack, pending preferred if status indicates
     def current_approver_email_address
       if self.pending?
-        self.individual_approvals.where(status: 'actionable').first.user.email_address
+        self.currently_awaiting_approvers.first.email_address
       else
         self.approving_official.email_address
       end


### PR DESCRIPTION
Stumbled across while reviewing #666.