### PR TITLE
[Delivers #104013748] add c2.18f.gov as a production domain

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -20,7 +20,9 @@ applications:
   env:
     DEFAULT_URL_HOST: c2-staging.18f.gov
 - name: c2-prod
-  host: cap
+  hosts:
+  - cap
+  - c2
   env:
     DEFAULT_URL_HOST: cap.18f.gov
     DISABLE_SANDBOX_WARNING: true


### PR DESCRIPTION
The impetus here is that we are setting up Mandrill in #640, which requires us to pick a domain for our transactional emails to send to/from. I didn't want to set it up with @cap.18f.gov and have to re-configure everything when we switch the site from https://cap.18f.gov to https://c2.18f.gov, so went with the latter. Because users will see this new domain in their inboxes, I'm afraid of them typing it in the browser and getting a 404.

## Changes

This PR simply makes https://c2.18f.gov point `c2-prod`, though we don't need to advertise this fact.

## Testing notes

Since this is a production-only change, we can't _really_ QA it beforehand, but I tested the equivalent change for `c2-staging`:

```yaml
hosts:
- c2-staging
- c2-staging-2
```

then ran

```
$ cf push c2-staging
...
$ curl -I https://c2-staging-2.18f.gov
HTTP/1.1 200 OK
```