### PR TITLE
[Delivers #104981410] fix broken budget email report

### DIFF
--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -119,7 +119,7 @@ module Ncr
       if self.pending?
         self.currently_awaiting_approvers.first.email_address
       else
-        self.approving_official.email_address
+        self.approving_official ? self.approving_official.email_address : self.system_approver_emails.first
       end
     end
 

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -118,8 +118,10 @@ module Ncr
     def current_approver_email_address
       if self.pending?
         self.currently_awaiting_approvers.first.email_address
+      elsif self.approving_official
+        self.approving_official.email_address
       else
-        self.approving_official ? self.approving_official.email_address : self.system_approver_emails.first
+        self.system_approver_emails.first
       end
     end
 


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/n/projects/1149728/stories/104981410

resurrect the not-nil check for approving_official and default to system_approver_emails when nil (not sure in what legit biz case it would be undefined)