### PR TITLE
silence logging of requests for assets in development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,6 @@ MYUSA_SECRET: consumer_secret_key
 # optional
 #
 # API_ENABLED=true
-# ASSETS_DEBUG=true
 # BULLET_ENABLED=true
 # BUDGET_REPORT_RECIPIENT
 # DATABASE_URL

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ group :development do
   gem 'railroady'
   gem 'letter_opener'
   gem 'letter_opener_web'
+  gem 'quiet_assets'
   gem 'spring'
   gem 'spring-commands-rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,6 +301,8 @@ GEM
     puma (2.14.0)
     pundit (1.0.1)
       activesupport (>= 3.0.0)
+    quiet_assets (1.1.0)
+      railties (>= 3.1, < 5.0)
     rack (1.6.4)
     rack-cors (0.4.0)
     rack-test (0.6.3)
@@ -483,6 +485,7 @@ DEPENDENCIES
   pry-rails
   puma
   pundit (>= 1.0.0)
+  quiet_assets
   rack-cors
   rack_session_access
   railroady

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,7 +25,7 @@ C2::Application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = ENV['ASSETS_DEBUG'] ? true : false
+  config.assets.debug = true
 
   # Use letter opener to avoid sending real emails. The "web" version makes
   # the emails visible at /letter_opener

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -37,7 +37,7 @@ Per [the Twelve-Factor guidelines](http://12factor.net/config), all necessary co
 ## Starting the application
 
 ```bash
-PORT=3000 ASSETS_DEBUG=true ./script/start
+PORT=3000 ./script/start
 open http://localhost:3000
 ```
 


### PR DESCRIPTION
Asset logging, e.g.

```
Started GET "/assets/icon-logout.png" for ::1 at 2015-10-08 13:18:47 -0400
```

is basically just noise, so added a gem that silences it. Also removed the now-not-really-useful `ASSETS_DEBUG` config flag, which was [apparently](https://github.com/18F/C2/pull/618/files#r41514899) added to reduce the number of asset logging messages received. Now it's a non-issue, and it makes JS debugging easier since they appear in separate files.