### PR TITLE
add explicit buildpack so that Ruby 2.2.3 is supported on cloud.gov

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -8,6 +8,7 @@ command: script/server_start
 domain: 18f.gov
 instances: 1
 memory: 1G
+buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
 
 # environment-specific configuration
 applications:

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,6 +8,7 @@ command: script/server_start
 domain: 18f.gov
 instances: 1
 memory: 1G
+# we point upstream because 18F buildpacks sometimes lag behind newer Ruby versions.
 buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
 
 # environment-specific configuration


### PR DESCRIPTION
this is necessary until 18F CF buildpacks are updated.