### PR TITLE
Correcting the formatting of the .about.yml file.

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -63,7 +63,6 @@ partners:
 
 # Brief descriptions of significant project developments
 milestones:
-- 
 
 # Technologies used to build the project
 stack:
@@ -105,7 +104,6 @@ licenses:
 
 # Blogs or websites associated with project development
 blog:
-- 
 
 # Links to project artifacts
 # Items:


### PR DESCRIPTION
Currently, the .about.yml file parsing is breaking on the empty dash records for`milestones` and `blog`. Removing the records, i.e. going from this state:
```
milestones:
-
...
blog:
-
```

to:
```
milestones:
...
blog:
```

corrects the issue.