### PR TITLE
Updates help language to reflect increased FY 2016 limit

### DIFF
--- a/app/views/help/requests_over_3000.md
+++ b/app/views/help/requests_over_3000.md
@@ -1,5 +1,5 @@
-<% title "How do I submit a request that exceeds $3000?" %>
+<% title "How do I submit a request that exceeds $3500?" %>
 
-The C2 system will only handle credit card requests, which are capped at $3,000 per vendor per job. If you have a your request exceeding the threshold, you must go through contracts with a GSA Form 49 to complete your request.
+The C2 system will only handle credit card requests. These requests are capped at $3,500 per vendor per job for fiscal year 2016. To submit a request exceeding the threshold, you must go through contracts with a [GSA Form 49](http://www.gsa.gov/portal/forms/download/115206) to complete your request.
 
-If your have a request that started as a credit card request, and then the scope increased beyond the $3,000 threshold, cancel the request and take your requirements through the contracting process.
+If your have a request that started as a credit card request, and then the scope increased beyond the $3,500 threshold, cancel the request and take your requirements through the contracting process.


### PR DESCRIPTION
Just one question, but it needed care:
- changes limit to $3500
- specifies FY 2016 (avoids confusion re older requests)
- adds link to procurement request form
- fixes a small typo