### PR TITLE
[Fixes #99273060] Suppress comment email on proposal cancellation

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -9,7 +9,7 @@ class AttachmentsController < ApplicationController
     attachment.user = current_user
     if attachment.save
       flash[:success] = "You successfully added a attachment"
-      Dispatcher.deliver_attachment_emails(self.proposal)
+      Dispatcher.deliver_attachment_emails(proposal)
     else
       flash[:error] = attachment.errors.full_messages
     end
@@ -20,7 +20,7 @@ class AttachmentsController < ApplicationController
   def destroy
     self.attachment.destroy
     flash[:success] = "Deleted attachment"
-    redirect_to proposal_path(self.attachment.proposal_id)
+    redirect_to proposal_path(attachment.proposal)
   end
 
   def show
@@ -41,6 +41,6 @@ class AttachmentsController < ApplicationController
   end
 
   def auth_errors(exception)
-    redirect_to proposals_path, :alert => "You are not allowed to add an attachment to that proposal"
+    redirect_to proposals_path, alert: "You are not allowed to add an attachment to that proposal"
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -7,6 +7,7 @@ class CommentsController < ApplicationController
   def create
     comment = proposal.comments.build(comment_params)
     comment.user = current_user
+
     if comment.save
       flash[:success] = "You successfully added a comment"
       Dispatcher.on_comment_created(comment)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,14 +1,15 @@
 class CommentsController < ApplicationController
   before_filter :authenticate_user!
-  before_filter ->{authorize self.proposal, :can_show!}
+  before_filter ->{authorize proposal, :can_show!}
   rescue_from Pundit::NotAuthorizedError, with: :auth_errors
 
 
   def create
-    comment = self.proposal.comments.build(self.comment_params)
+    comment = proposal.comments.build(comment_params)
     comment.user = current_user
     if comment.save
       flash[:success] = "You successfully added a comment"
+      Dispatcher.on_comment_created(comment)
     else
       flash[:error] = comment.errors.full_messages
     end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -35,19 +35,19 @@ class ProposalsController < ApplicationController
 
   def cancel
     if params[:reason_input].present?
-      proposal = Proposal.find params[:id]
+      proposal = Proposal.find(params[:id])
       comments = "Request cancelled with comments: " + params[:reason_input]
       proposal.cancel!
-      proposal.comments.create!(comment_text: comments, user_id: current_user.id)
+      proposal.comments.create!(comment_text: comments, user: current_user)
 
       flash[:success] = "Your request has been cancelled"
-      redirect_to proposal_path, id: proposal.id
+      redirect_to proposal_path(proposal)
       Dispatcher.new.deliver_cancellation_emails(proposal)
     else
-      redirect_to cancel_form_proposal_path, id: params[:id],
-                                             alert: "A reason for cancellation is required.
-                                                     Please indicate why this request needs
-                                                     to be cancelled."
+      redirect_to(
+        cancel_form_proposal_path(params[:id]),
+        alert: "A reason for cancellation is required. Please indicate why this request needs to be cancelled."
+      )
     end
   end
 

--- a/app/mailers/concerns/proposal_conversation_threading.rb
+++ b/app/mailers/concerns/proposal_conversation_threading.rb
@@ -43,6 +43,10 @@ module ProposalConversationThreading
     I18n.t(i18n_key, params.symbolize_keys)
   end
 
+  ###################
+
+  ## mixin methods ##
+
   protected
 
   def assign_threading_headers(proposal)
@@ -63,4 +67,6 @@ module ProposalConversationThreading
       template_name: template_name
     )
   end
+
+  ###################
 end

--- a/app/mailers/concerns/proposal_conversation_threading.rb
+++ b/app/mailers/concerns/proposal_conversation_threading.rb
@@ -43,10 +43,6 @@ module ProposalConversationThreading
     I18n.t(i18n_key, params.symbolize_keys)
   end
 
-  ###################
-
-  ## mixin methods ##
-
   protected
 
   def assign_threading_headers(proposal)
@@ -67,6 +63,4 @@ module ProposalConversationThreading
       template_name: template_name
     )
   end
-
-  ###################
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -12,6 +12,7 @@ class Comment < ActiveRecord::Base
   scope :normal_comments, ->{ where(update_comment: nil) } # we probably want `.where.not(update_comment: true)`, but that query isn't working as of 5bb8b4d385
   scope :update_comments, ->{ where(update_comment: true) }
 
+
   after_create :add_user_as_observer
 
   # match .attributes

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -12,7 +12,6 @@ class Comment < ActiveRecord::Base
   scope :normal_comments, ->{ where(update_comment: nil) } # we probably want `.where.not(update_comment: true)`, but that query isn't working as of 5bb8b4d385
   scope :update_comments, ->{ where(update_comment: true) }
 
-  after_create ->{ Dispatcher.on_comment_created(self) }
   after_create :add_user_as_observer
 
   # match .attributes

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -283,16 +283,15 @@ module Ncr
           comment_texts << "_Modified post-approval_"
         end
 
-        comment = proposal.comments.create(
+        proposal.comments.create(
           comment_text: comment_texts.join("\n"),
           update_comment: true,
           user: self.modifier || self.requester
         )
-        Dispatcher.on_comment_created(comment)
       end
     end
 
-    def self.update_comment_format key, value, bullet, former=nil
+    def self.update_comment_format(key, value, bullet, former=nil)
       from = former ? "from #{former} " : ''
       "#{bullet}*#{key}* was changed " + from + "to #{value}"
     end

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -282,11 +282,13 @@ module Ncr
         if self.approved?
           comment_texts << "_Modified post-approval_"
         end
-        self.proposal.comments.create(
+
+        comment = proposal.comments.create(
           comment_text: comment_texts.join("\n"),
           update_comment: true,
           user: self.modifier || self.requester
         )
+        Dispatcher.on_comment_created(comment)
       end
     end
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -203,6 +203,8 @@ class Proposal < ActiveRecord::Base
     end
   end
 
+  ## delegated methods ##
+
   def public_identifier
     self.delegate_with_default(:public_identifier) { "##{self.id}" }
   end
@@ -226,6 +228,8 @@ class Proposal < ActiveRecord::Base
       self.client_data.try(:version)
     ].compact.max
   end
+
+  #######################
 
   def restart
     # Note that none of the state machine's history is stored

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -268,8 +268,11 @@ class Proposal < ActiveRecord::Base
     # invalidate relation cache so we reload on next access
     self.observers(true)
     # when explicitly adding an observer using the form in the Proposal page...
-    if adder && reason
-      add_observation_comment(user, adder, reason)
+    if adder
+      if reason
+        add_observation_comment(user, adder, reason)
+      end
+
       Dispatcher.on_observer_added(observation, reason)
     end
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -280,13 +280,14 @@ class Proposal < ActiveRecord::Base
   end
 
   def add_observation_comment(user, adder, reason)
-    comment = comments.create(
-      comment_text: I18n.t('activerecord.attributes.observation.user_reason_comment',
-                           user: adder.full_name,
-                           observer: user.full_name,
-                           reason: reason),
+    comments.create(
+      comment_text: I18n.t(
+        'activerecord.attributes.observation.user_reason_comment',
+        user: adder.full_name,
+        observer: user.full_name,
+        reason: reason
+      ),
       user: adder
     )
-    Dispatcher.on_comment_created(comment)
   end
 end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -203,9 +203,6 @@ class Proposal < ActiveRecord::Base
     end
   end
 
-
-  ## delegated methods ##
-
   def public_identifier
     self.delegate_with_default(:public_identifier) { "##{self.id}" }
   end
@@ -229,9 +226,6 @@ class Proposal < ActiveRecord::Base
       self.client_data.try(:version)
     ].compact.max
   end
-
-  #######################
-
 
   def restart
     # Note that none of the state machine's history is stored
@@ -278,11 +272,13 @@ class Proposal < ActiveRecord::Base
   end
 
   def add_observation_comment(user, adder, reason)
-    self.comments.create(
+    comment = comments.create(
       comment_text: I18n.t('activerecord.attributes.observation.user_reason_comment',
                            user: adder.full_name,
                            observer: user.full_name,
                            reason: reason),
-      user: adder)
+      user: adder
+    )
+    Dispatcher.on_comment_created(comment)
   end
 end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -264,10 +264,11 @@ class Proposal < ActiveRecord::Base
     # invalidate relation cache so we reload on next access
     self.observers(true)
     # when explicitly adding an observer using the form in the Proposal page...
-    if adder
-      add_observation_comment(user, adder, reason) unless reason.blank?
+    if adder && reason
+      add_observation_comment(user, adder, reason)
       Dispatcher.on_observer_added(observation, reason)
     end
+
     observation
   end
 

--- a/app/views/proposals/cancel_form.html.erb
+++ b/app/views/proposals/cancel_form.html.erb
@@ -1,20 +1,15 @@
 <div class="inset">
   <div class="row centered">
-
-    <h1>
-      Cancellation: <%= @proposal.name %>
-    </h1>
-
-    <%= form_tag({controller: "proposals", action: "cancel", id: @proposal.id}, method: "post") do %>
-      <%= label_tag(:reason_input, "Reason for cancellation") %><br/>
-      <%= text_area_tag 'reason_input', nil, size: "50x10" %>
+    <h1>Cancellation: <%= @proposal.name %></h1>
+    <%= form_tag(cancel_proposal_path(@proposal), method: :post) do %>
+      <%= label_tag(:reason_input, 'Reason for cancellation') %><br/>
+      <%= text_area_tag 'reason_input', nil, size: '50x10' %>
       <p>
-        <%= submit_tag("Yes, cancel this request", class: 'form-button') %>
+        <%= submit_tag('Yes, cancel this request', class: 'form-button') %>
       </p>
       <p>
-        <%= link_to 'I made a mistake. Take me back', proposal_path, id: @proposal.id %>
+        <%= link_to 'I made a mistake. Take me back', proposal_path(@proposal) %>
       </p>
     <% end %>
-
   </div>
 </div>

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -14,7 +14,7 @@ class Dispatcher
     proposal.observations.each do |observation|
       user = observation.user
       if user.role_on(proposal).active_observer?
-       email_observer(observation)
+        email_observer(observation)
       end
     end
   end

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -39,8 +39,10 @@ class Dispatcher
   def deliver_attachment_emails(proposal)
     proposal.users.each do |user|
       approval = proposal.approvals.find_by(user_id: user.id)
-      next if approval && approval.pending?
-      CommunicartMailer.new_attachment_email(user.email_address, proposal).deliver_later
+
+      if user_is_not_approver?(approval) || approver_knows_about_proposal?(approval)
+        CommunicartMailer.new_attachment_email(user.email_address, proposal).deliver_later
+      end
     end
   end
 
@@ -84,5 +86,13 @@ class Dispatcher
 
   def send_notification_email(approval)
     CommunicartMailer.actions_for_approver(approval).deliver_later
+  end
+
+  def user_is_not_approver?(approval)
+    approval.blank?
+  end
+
+  def approver_knows_about_proposal?(approval)
+    !approval.pending?
   end
 end

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -48,8 +48,9 @@ class Dispatcher
 
   def deliver_cancellation_emails(proposal)
     proposal.individual_approvals.each do |approval|
-      next if approval.pending?
-      CommunicartMailer.cancellation_email(approval.user_email_address, proposal).deliver_later
+      if approver_knows_about_proposal?(approval)
+        CommunicartMailer.cancellation_email(approval.user_email_address, proposal).deliver_later
+      end
     end
 
     CommunicartMailer.cancellation_confirmation(proposal).deliver_later

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -15,12 +15,11 @@ describe CommentsController do
       end
 
       it 'sends a comment email to approvers and observers' do
-        ActionMailer::Base.deliveries.clear
         login_as(proposal.requester)
 
-        post :create, params
-
-        expect(deliveries.length).to eq 4
+        expect {
+          post :create, params
+        }.to chage { deliveries.length }.fromt(0).to(4)
       end
     end
 

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -19,7 +19,7 @@ describe CommentsController do
 
         expect {
           post :create, params
-        }.to chage { deliveries.length }.fromt(0).to(4)
+        }.to change { deliveries.length }.from(0).to(4)
       end
     end
 

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,18 +1,30 @@
 describe CommentsController do
   describe 'permission checking' do
     let (:proposal) { create(:proposal, :with_parallel_approvers, :with_observers) }
-    let (:params) { {proposal_id: proposal.id,
-                     comment: {comment_text: 'Some comment'}} }
+    let (:params) {
+      { proposal_id: proposal.id, comment: { comment_text: 'Some comment' }}
+    }
 
-    it "allows the requester to comment" do
-      login_as(proposal.requester)
-      post :create, params
-      expect(flash[:success]).to be_present
-      expect(flash[:error]).not_to be_present
-      expect(response).to redirect_to(proposal)
+    context 'requester comments' do
+      it 'allows the requester to comment' do
+        login_as(proposal.requester)
+        post :create, params
+        expect(flash[:success]).to be_present
+        expect(flash[:error]).not_to be_present
+        expect(response).to redirect_to(proposal)
+      end
+
+      it 'sends a comment email to approvers and observers' do
+        ActionMailer::Base.deliveries.clear
+        login_as(proposal.requester)
+
+        post :create, params
+
+        expect(deliveries.length).to eq 4
+      end
     end
 
-    it "allows an approver to comment" do
+    it 'allows an approver to comment' do
       login_as(proposal.approvers[0])
       post :create, params
       expect(flash[:success]).to be_present
@@ -20,7 +32,7 @@ describe CommentsController do
       expect(response).to redirect_to(proposal)
     end
 
-    it "allows an observer to comment" do
+    it 'allows an observer to comment' do
       login_as(proposal.observers[0])
       post :create, params
       expect(flash[:success]).to be_present
@@ -28,7 +40,7 @@ describe CommentsController do
       expect(response).to redirect_to(proposal)
     end
 
-    it "allows a delegate to comment" do
+    it 'allows a delegate to comment' do
       approver = proposal.approvers.first
       delegate = create(:user)
       approver.add_delegate(delegate)
@@ -41,7 +53,7 @@ describe CommentsController do
       expect(Comment.last.user).to eq(delegate)
     end
 
-    it "does not allow others to comment" do
+    it 'does not allow others to comment' do
       login_as(create(:user))
       post :create, params
       expect(flash[:success]).not_to be_present

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -6,14 +6,14 @@ FactoryGirl.define do
 
     trait :with_approver do
       after :create do |proposal|
-        proposal.approver = FactoryGirl.create(:user)
+        proposal.approver = create(:user)
       end
     end
 
     trait :with_serial_approvers do
       flow 'linear'
       after :create do |proposal|
-        ind = 2.times.map{ Approvals::Individual.new(user: FactoryGirl.create(:user)) }
+        ind = 2.times.map{ Approvals::Individual.new(user: create(:user)) }
         proposal.root_approval = Approvals::Serial.new(child_approvals: ind)
       end
     end
@@ -21,14 +21,14 @@ FactoryGirl.define do
     trait :with_parallel_approvers do
       flow 'parallel'
       after :create do |proposal|
-        ind = 2.times.map{ Approvals::Individual.new(user: FactoryGirl.create(:user)) }
+        ind = 2.times.map{ Approvals::Individual.new(user: create(:user)) }
         proposal.root_approval = Approvals::Parallel.new(child_approvals: ind)
       end
     end
 
     trait :with_observer do
       after :create do |proposal|
-        observer = FactoryGirl.create(:user)
+        observer = create(:user)
         proposal.add_observer(observer.email_address)
       end
     end
@@ -36,7 +36,7 @@ FactoryGirl.define do
     trait :with_observers do
       after :create do |proposal|
         2.times do
-          observer = FactoryGirl.create(:user)
+          observer = create(:user)
           proposal.add_observer(observer.email_address)
         end
       end
@@ -48,7 +48,7 @@ FactoryGirl.define do
 
     after(:create) do |proposal, evaluator|
       if evaluator.delegate
-        user = FactoryGirl.create(:user)
+        user = create(:user)
         proposal.approver = user
         user.add_delegate(evaluator.delegate)
       end

--- a/spec/features/cancel_spec.rb
+++ b/spec/features/cancel_spec.rb
@@ -30,26 +30,27 @@ describe 'Canceling a request' do
   context 'email' do
     context 'proposal without approver' do
       it 'sends cancellation email to requester' do
-        ActionMailer::Base.deliveries.clear
         proposal = create(:proposal)
 
         login_as(proposal.requester)
-        cancel_proposal(proposal)
 
-        expect(deliveries.length).to eq(1)
+        expect {
+          cancel_proposal(proposal)
+        }.to change { deliveries.length }.from(0).to(1)
       end
     end
 
     context 'proposal with pending status' do
       it 'does not send cancellation email to approver' do
-        ActionMailer::Base.deliveries.clear
         proposal = create(:proposal, :with_approver)
         proposal.individual_approvals.first.update(status: 'pending')
 
         login_as(proposal.requester)
         cancel_proposal(proposal)
 
-        expect(deliveries.length).to eq(1)
+        expect {
+          cancel_proposal(proposal)
+        }.to change { deliveries.length }.from(0).to(1)
       end
     end
 
@@ -61,7 +62,9 @@ describe 'Canceling a request' do
         login_as(proposal.requester)
         cancel_proposal(proposal)
 
-        expect(deliveries.length).to eq(2)
+        expect {
+          cancel_proposal(proposal)
+        }.to change { deliveries.length }.from(0).to(2)
       end
    end
   end

--- a/spec/features/cancel_spec.rb
+++ b/spec/features/cancel_spec.rb
@@ -46,7 +46,6 @@ describe 'Canceling a request' do
         proposal.individual_approvals.first.update(status: 'pending')
 
         login_as(proposal.requester)
-        cancel_proposal(proposal)
 
         expect {
           cancel_proposal(proposal)
@@ -56,11 +55,9 @@ describe 'Canceling a request' do
 
    context 'proposal with approver cancelled with reason' do
       it 'sends cancellation emails to requester and approver' do
-        ActionMailer::Base.deliveries.clear
         proposal = create(:proposal, :with_approver)
 
         login_as(proposal.requester)
-        cancel_proposal(proposal)
 
         expect {
           cancel_proposal(proposal)

--- a/spec/features/observer_spec.rb
+++ b/spec/features/observer_spec.rb
@@ -14,7 +14,8 @@ describe "observers" do
     expect(page).to have_content("#{observer.full_name} has been added as an observer")
 
     proposal.reload
-    expect(proposal.observers).to eq [observer]
+
+    expect(proposal.observers).to include(observer)
   end
 
   it "allows observers to be added by other observers" do
@@ -22,6 +23,7 @@ describe "observers" do
     observer1 = proposal.observers.first
     login_as(observer1)
 
+    ActionMailer::Base.deliveries.clear
     observer2 = create(:user)
 
     visit "/proposals/#{proposal.id}"

--- a/spec/features/observer_spec.rb
+++ b/spec/features/observer_spec.rb
@@ -21,10 +21,8 @@ describe "observers" do
   it "allows observers to be added by other observers" do
     proposal = create(:proposal, :with_observer)
     observer1 = proposal.observers.first
-    login_as(observer1)
-
-    ActionMailer::Base.deliveries.clear
     observer2 = create(:user)
+    login_as(observer1)
 
     visit "/proposals/#{proposal.id}"
     select observer2.email_address, from: 'observation_user_email_address'

--- a/spec/features/observer_spec.rb
+++ b/spec/features/observer_spec.rb
@@ -50,7 +50,6 @@ describe "observers" do
     expect(page).to have_content("#{observer.full_name} has been added as an observer")
     proposal.reload
 
-    expect(deliveries.first.body.encoded).to include reason   # comment notification
-    expect(deliveries.second.body.encoded).to include reason  # subscription notification
+    expect(deliveries.first.body.encoded).to include reason # subscription notification
   end
 end

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -409,19 +409,29 @@ describe Ncr::WorkOrder do
       expect(Comment.count).to be 0
     end
 
-    it "attributes the update comment to the requester by default" do
+    it 'attributes the update comment to the requester by default' do
       work_order.update(vendor: 'VenVenVen')
       comment = work_order.comments.update_comments.last
       expect(comment.user).to eq(work_order.requester)
     end
 
-    it "attributes the update comment to someone set explicitly" do
+    it 'attributes the update comment to someone set explicitly' do
       modifier = create(:user)
       work_order.modifier = modifier
       work_order.update(vendor: 'VenVenVen')
 
       comment = work_order.comments.update_comments.last
       expect(comment.user).to eq(modifier)
+    end
+
+    it 'does not send a comment email for the update comment to proposal listeners' do
+      listener = create(:user)
+      work_order.proposal.add_observer(listener)
+      ActionMailer::Base.deliveries.clear
+
+      work_order.update(vendor: 'TestVendor')
+
+      expect(deliveries.length).to eq(0)
     end
   end
 

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -427,11 +427,10 @@ describe Ncr::WorkOrder do
     it 'does not send a comment email for the update comment to proposal listeners' do
       listener = create(:user)
       work_order.proposal.add_observer(listener)
-      ActionMailer::Base.deliveries.clear
 
-      work_order.update(vendor: 'TestVendor')
-
-      expect(deliveries.length).to eq(0)
+      expect {
+       work_order.update(vendor: 'TestVendor')
+      }.to change { deliveries.length }.by(0)
     end
   end
 

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -277,17 +277,29 @@ describe Proposal do
     end
   end
 
-  describe "#add_observer" do
+  describe '#add_observer' do
     let(:proposal) { create(:proposal) }
     let(:observer) { create(:user) }
     let(:observer_email) { observer.email_address }
     let(:user) { create(:user) }
+
     it 'adds an observer to the proposal' do
       expect(proposal.observers).to be_empty
       proposal.add_observer(observer_email)
       expect(proposal.observers).to eq [observer]
     end
-    context "with an adding user" do
+
+    it 'adds a comment and sends a comment email when there is an adder and observation reason' do
+      ActionMailer::Base.deliveries.clear
+      reason = "this is required"
+
+      proposal.add_observer(observer_email, user, reason)
+
+      expect(proposal.comments.count).to eq 1
+      expect(deliveries.length).to eq 3
+    end
+
+    context 'with an adding user' do
       context 'without a reason' do
         it 'does not add a comment' do
           expect(proposal.comments).to be_empty
@@ -295,8 +307,10 @@ describe Proposal do
           expect(proposal.comments).to be_empty
         end
       end
+
       context 'with a reason' do
-        let(:reason) { "my mate, innit" }
+        let(:reason) { 'my mate, innit' }
+
         it 'adds a comment mentioning the reason' do
           expect(proposal.comments).to be_empty
           proposal.add_observer(observer_email, user, reason)

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -299,6 +299,12 @@ describe Proposal do
       expect(proposal.comments.count).to eq 1
     end
 
+    it 'sends an observer email when there is an adder but no reason' do
+      expect {
+        proposal.add_observer(observer_email, user, nil)
+      }.to change { deliveries.length }.from(0).to(1)
+    end
+
     context 'with an adding user' do
       context 'without a reason' do
         it 'does not add a comment' do

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -294,7 +294,7 @@ describe Proposal do
 
       expect {
         proposal.add_observer(observer_email, user, reason)
-      }.to change { deliveries.length }.from(0).to(3)
+      }.to change { deliveries.length }.from(0).to(1)
 
       expect(proposal.comments.count).to eq 1
     end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -290,13 +290,13 @@ describe Proposal do
     end
 
     it 'adds a comment and sends a comment email when there is an adder and observation reason' do
-      ActionMailer::Base.deliveries.clear
       reason = "this is required"
 
-      proposal.add_observer(observer_email, user, reason)
+      expect {
+        proposal.add_observer(observer_email, user, reason)
+      }.to change { deliveries.length }.from(0).to(3)
 
       expect(proposal.comments.count).to eq 1
-      expect(deliveries.length).to eq 3
     end
 
     context 'with an adding user' do


### PR DESCRIPTION
* When a proposal is cancelled, we send a cancellation email to
  requester and approvers
* Extra email about cancellation comment is repetitive
* Fixes #99273060