### PR TITLE
tweak CoffeeLint config

### DIFF
--- a/app/assets/javascripts/filter.js.coffee
+++ b/app/assets/javascripts/filter.js.coffee
@@ -18,20 +18,20 @@ class Filter
 
   filter: ($el) ->
     value = $el.val()
-    if !$el.is(":checked")
+    unless $el.is(":checked")
       value = "!" + value
     @$("[data-filter-key=#{ @key }]").each (idx, el) ->
-      hidden = el.getAttribute("data-filter-value") != value
+      hidden = el.getAttribute("data-filter-value") isnt value
       el.setAttribute("aria-hidden", hidden.toString())
 
   hideAll: () ->
     @$("[data-filter-key=#{ @key }]").attr("aria-hidden", true)
 
-  this.generateIn = ($scope) ->
+  @generateIn = ($scope) ->
     filters = {}
     $scope.find("[data-filter-control]").each (idx, el) ->
       key = el.getAttribute('data-filter-control')
-      if !filters.hasOwnProperty(key)
+      unless filters.hasOwnProperty(key)
         filters[key] = new Filter($scope, key)
     filters
 

--- a/app/assets/javascripts/filter.js.coffee
+++ b/app/assets/javascripts/filter.js.coffee
@@ -18,10 +18,10 @@ class Filter
 
   filter: ($el) ->
     value = $el.val()
-    unless $el.is(":checked")
+    if !$el.is(":checked")
       value = "!" + value
     @$("[data-filter-key=#{ @key }]").each (idx, el) ->
-      hidden = el.getAttribute("data-filter-value") isnt value
+      hidden = el.getAttribute("data-filter-value") != value
       el.setAttribute("aria-hidden", hidden.toString())
 
   hideAll: () ->
@@ -31,7 +31,7 @@ class Filter
     filters = {}
     $scope.find("[data-filter-control]").each (idx, el) ->
       key = el.getAttribute('data-filter-control')
-      unless filters.hasOwnProperty(key)
+      if !filters.hasOwnProperty(key)
         filters[key] = new Filter($scope, key)
     filters
 

--- a/app/assets/javascripts/flash_errors.js.coffee
+++ b/app/assets/javascripts/flash_errors.js.coffee
@@ -1,2 +1,2 @@
 $ ->
-  $('div.alert:first').attr('tabindex','-1').focus()
+  $('div.alert:first').attr('tabindex', '-1').focus()

--- a/app/assets/javascripts/required_for_submit.js.coffee
+++ b/app/assets/javascripts/required_for_submit.js.coffee
@@ -7,7 +7,7 @@ class RequiredForSubmit
     @checkDisable()
 
   checkDisable: ->
-    @$submit.prop 'disabled', (@$controller.val() == '')
+    @$submit.prop 'disabled', !@$controller.val()
 
 $ ->
   # @todo - better scope

--- a/app/assets/javascripts/selectizer.js.coffee
+++ b/app/assets/javascripts/selectizer.js.coffee
@@ -7,10 +7,11 @@ class Selectizer
     @$el.is('input')
 
   form_label: ->
-    $('label[for="'+@$el.attr('id')+'"]').text()
+    id = @$el.attr('id')
+    $("label[for=\"#{id}\"]").text()
 
   add_label: ->
-    @selectizeObj().$control_input.attr('aria-label',@form_label())
+    @selectizeObj().$control_input.attr('aria-label', @form_label())
 
   initialChoices: ->
     initial = @$el.data('initial') || []

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -1,9 +1,9 @@
 {
   "arrow_spacing": {
-    "level": "ignore"
+    "level": "error"
   },
   "braces_spacing": {
-    "level": "ignore",
+    "level": "error",
     "spaces": 0,
     "empty_object_spaces": 0
   },
@@ -14,39 +14,39 @@
     "level": "error"
   },
   "colon_assignment_spacing": {
-    "level": "ignore",
+    "level": "error",
     "spacing": {
       "left": 0,
-      "right": 0
+      "right": 1
     }
   },
   "cyclomatic_complexity": {
     "value": 10,
-    "level": "ignore"
+    "level": "error"
   },
   "duplicate_key": {
     "level": "error"
   },
   "empty_constructor_needs_parens": {
-    "level": "ignore"
+    "level": "error"
   },
   "ensure_comprehensions": {
     "level": "warn"
   },
   "eol_last": {
-    "level": "ignore"
+    "level": "error"
   },
   "indentation": {
     "value": 2,
     "level": "error"
   },
   "line_endings": {
-    "level": "ignore",
+    "level": "error",
     "value": "unix"
   },
   "max_line_length": {
     "value": 80,
-    "level": "ignore",
+    "level": "error",
     "limitComments": true
   },
   "missing_fat_arrows": {
@@ -65,13 +65,13 @@
     "console": false
   },
   "no_empty_functions": {
-    "level": "ignore"
+    "level": "error"
   },
   "no_empty_param_list": {
     "level": "ignore"
   },
   "no_implicit_braces": {
-    "level": "ignore",
+    "level": "error",
     "strict": true
   },
   "no_implicit_parens": {
@@ -79,25 +79,25 @@
     "level": "ignore"
   },
   "no_interpolation_in_single_quotes": {
-    "level": "ignore"
+    "level": "error"
   },
   "no_nested_string_interpolation": {
     "level": "warn"
   },
   "no_plusplus": {
-    "level": "ignore"
+    "level": "error"
   },
   "no_private_function_fat_arrows": {
     "level": "warn"
   },
   "no_stand_alone_at": {
-    "level": "ignore"
+    "level": "error"
   },
   "no_tabs": {
     "level": "error"
   },
   "no_this": {
-    "level": "ignore"
+    "level": "error"
   },
   "no_throwing_strings": {
     "level": "error"
@@ -117,17 +117,17 @@
     "level": "warn"
   },
   "non_empty_constructor_needs_parens": {
-    "level": "ignore"
+    "level": "error"
   },
   "prefer_english_operator": {
     "level": "ignore",
-    "doubleNotLevel": "ignore"
+    "doubleNotLevel": "error"
   },
   "space_operators": {
-    "level": "ignore"
+    "level": "error"
   },
   "spacing_after_comma": {
-    "level": "ignore"
+    "level": "error"
   },
   "transform_messes_up_line_numbers": {
     "level": "warn"

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -3,14 +3,9 @@
     "level": "error"
   },
   "braces_spacing": {
-    "level": "error",
-    "spaces": 0,
-    "empty_object_spaces": 0
-  },
-  "camel_case_classes": {
     "level": "error"
   },
-  "coffeescript_error": {
+  "line_endings": {
     "level": "error"
   },
   "colon_assignment_spacing": {
@@ -20,116 +15,40 @@
       "right": 1
     }
   },
-  "cyclomatic_complexity": {
-    "value": 10,
+  "no_implicit_braces": {
     "level": "error"
   },
-  "duplicate_key": {
+  "no_plusplus": {
+    "level": "error"
+  },
+  "no_stand_alone_at": {
+    "level": "error"
+  },
+  "space_operators": {
     "level": "error"
   },
   "empty_constructor_needs_parens": {
     "level": "error"
   },
-  "ensure_comprehensions": {
-    "level": "warn"
-  },
-  "eol_last": {
+  "cyclomatic_complexity": {
     "level": "error"
-  },
-  "indentation": {
-    "value": 2,
-    "level": "error"
-  },
-  "line_endings": {
-    "level": "error",
-    "value": "unix"
-  },
-  "max_line_length": {
-    "value": 80,
-    "level": "error",
-    "limitComments": true
-  },
-  "missing_fat_arrows": {
-    "level": "ignore",
-    "is_strict": false
-  },
-  "newlines_after_classes": {
-    "value": 3,
-    "level": "ignore"
-  },
-  "no_backticks": {
-    "level": "error"
-  },
-  "no_debugger": {
-    "level": "warn",
-    "console": false
-  },
-  "no_empty_functions": {
-    "level": "error"
-  },
-  "no_empty_param_list": {
-    "level": "ignore"
-  },
-  "no_implicit_braces": {
-    "level": "error",
-    "strict": true
-  },
-  "no_implicit_parens": {
-    "strict": true,
-    "level": "ignore"
-  },
-  "no_interpolation_in_single_quotes": {
-    "level": "error"
-  },
-  "no_nested_string_interpolation": {
-    "level": "warn"
-  },
-  "no_plusplus": {
-    "level": "error"
-  },
-  "no_private_function_fat_arrows": {
-    "level": "warn"
-  },
-  "no_stand_alone_at": {
-    "level": "error"
-  },
-  "no_tabs": {
-    "level": "error"
-  },
-  "no_this": {
-    "level": "error"
-  },
-  "no_throwing_strings": {
-    "level": "error"
-  },
-  "no_trailing_semicolons": {
-    "level": "error"
-  },
-  "no_trailing_whitespace": {
-    "level": "error",
-    "allowed_in_comments": false,
-    "allowed_in_empty_lines": true
-  },
-  "no_unnecessary_double_quotes": {
-    "level": "ignore"
-  },
-  "no_unnecessary_fat_arrows": {
-    "level": "warn"
   },
   "non_empty_constructor_needs_parens": {
     "level": "error"
   },
-  "prefer_english_operator": {
-    "level": "ignore",
-    "doubleNotLevel": "error"
+  "no_interpolation_in_single_quotes": {
+    "level": "error"
   },
-  "space_operators": {
+  "no_empty_functions": {
     "level": "error"
   },
   "spacing_after_comma": {
     "level": "error"
   },
-  "transform_messes_up_line_numbers": {
-    "level": "warn"
+  "no_this": {
+    "level": "error"
+  },
+  "eol_last": {
+    "level": "error"
   }
 }

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -50,5 +50,10 @@
   },
   "eol_last": {
     "level": "error"
+  },
+  "no_trailing_whitespace": {
+    "level": "error",
+    "allowed_in_comments": false,
+    "allowed_in_empty_lines": false
   }
 }


### PR DESCRIPTION
Building on https://github.com/18F/C2/pull/695.

Easiest way for me to figure out which rules I do/don't agree with is to run it locally. My process:

1. Changed all of the `level`s to `error` (i.e. enabled all of the rules).
1. Ran `coffeelint app/assets/javascripts/`.
1. For lint errors I agreed with, made the appropriate fix(es). For those I didn't, changed the config value to `ignore`.
1. Committed as 65124c3
1. Removed the config options that matched the defaults (044a329)

`coffeelint app/assets/javascripts/` passes locally.