### PR TITLE
[Delivers #89433396] add rake task for sending reminder emails

### DIFF
--- a/lib/tasks/reminder.rake
+++ b/lib/tasks/reminder.rake
@@ -1,0 +1,21 @@
+namespace :reminder do
+  desc "Send actionable approver reminder email for pending requests"
+  task actionable_approvers: :environment do
+    props = Proposal.pending.where(client_data_type: "Ncr::WorkOrder")
+    props.each do |proposal|
+      send_reminder_email(proposal)
+    end
+  end
+
+  private
+
+  def send_reminder_email(proposal)
+    user = proposal.client_data.current_approver or return
+    approval = proposal.individual_approvals.find_by(user: user)
+    if ENV['SEND_OK']
+      Dispatcher.on_approval_approved(approval)
+    else
+      puts "Remind #{user.email_address} #{proposal.id} #{proposal.created_at} #{approval.id} #{approval.created_at}"
+    end
+  end
+end

--- a/lib/tasks/reminder.rake
+++ b/lib/tasks/reminder.rake
@@ -11,7 +11,7 @@ namespace :reminder do
 
   def send_reminder_email(proposal)
     user = proposal.client_data.current_approver
-    if !user
+    unless user
       return # legit for there to be no user, but then no reminder needed.
     end
     approval = proposal.individual_approvals.find_by(user: user)

--- a/lib/tasks/reminder.rake
+++ b/lib/tasks/reminder.rake
@@ -1,8 +1,8 @@
 namespace :reminder do
   desc "Send actionable approver reminder email for pending requests"
   task actionable_approvers: :environment do
-    props = Proposal.pending.where(client_data_type: "Ncr::WorkOrder")
-    props.each do |proposal|
+    proposals = Proposal.pending.where(client_data_type: "Ncr::WorkOrder")
+    proposals.each do |proposal|
       send_reminder_email(proposal)
     end
   end
@@ -10,7 +10,10 @@ namespace :reminder do
   private
 
   def send_reminder_email(proposal)
-    user = proposal.client_data.current_approver or return
+    user = proposal.client_data.current_approver
+    if !user
+      return # legit for there to be no user, but then no reminder needed.
+    end
     approval = proposal.individual_approvals.find_by(user: user)
     if ENV['SEND_OK']
       Dispatcher.on_approval_approved(approval)


### PR DESCRIPTION
This PR refers to this story: https://www.pivotaltracker.com/n/projects/1149728/stories/89433396

It carves out a namespace for reminding users to take actions, starting with approvers of pending requests.