### PR TITLE
Disabled "Negated If" Rubocop style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,8 @@ Style/EmptyElse:
   Enabled: false
 Style/GuardClause:
   Enabled: false
+Style/NegatedIf:
+  Enabled: false
 Style/IfUnlessModifier:
   # inline conditionals don't get picked up by simplecov, so preferable to avoid them
   Enabled: false


### PR DESCRIPTION
* I think it is clearer to say `if !blah` than `unless blah`