### PR TITLE
improve availability of production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,6 @@ MYUSA_SECRET: consumer_secret_key
 # DEFAULT_URL_SCHEME
 # FORCE_USER_ID=123456
 # GA_TRACKING_ID
-# MAX_THREADS
 # MYUSA_URL
 # NCR_BA61_TIER1_BUDGET_MAILBOX
 # NCR_BA61_TIER2_BUDGET_MAILBOX
@@ -33,7 +32,6 @@ MYUSA_SECRET: consumer_secret_key
 # RESTRICT_ACCESS=true
 # SUPPORT_EMAIL=tickets@18f.uservoice.com
 # TEST_DATABASE_URL=postgresql://localhost/c2_test
-# WEB_CONCURRENCY
 
 # production only
 #

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,7 +6,7 @@ default: &default
 
   # should match puma.rb
   # https://devcenter.heroku.com/articles/concurrency-and-database-connections#threaded-servers
-  pool: <%= ENV["MAX_THREADS"] || 3 %>
+  pool: 3
 
 development:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,7 +6,7 @@ default: &default
 
   # should match puma.rb
   # https://devcenter.heroku.com/articles/concurrency-and-database-connections#threaded-servers
-  pool: <%= ENV["MAX_THREADS"] || 5 %>
+  pool: <%= ENV['MAX_THREADS'] || 3 %>
 
 development:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,7 +6,7 @@ default: &default
 
   # should match puma.rb
   # https://devcenter.heroku.com/articles/concurrency-and-database-connections#threaded-servers
-  pool: <%= ENV['MAX_THREADS'] || 3 %>
+  pool: <%= ENV["MAX_THREADS"] || 3 %>
 
 development:
   <<: *default

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,7 +1,7 @@
 # https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server
 
-workers Integer(ENV['WEB_CONCURRENCY'] || 1)
-threads_count = Integer(ENV['MAX_THREADS'] || 3) # should match database.yml
+workers 1
+threads_count = 3
 threads threads_count, threads_count
 
 preload_app!

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,7 +1,7 @@
 # https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server
 
 workers Integer(ENV['WEB_CONCURRENCY'] || 1)
-threads_count = Integer(ENV['MAX_THREADS'] || 5) # should match database.yml
+threads_count = Integer(ENV['MAX_THREADS'] || 3) # should match database.yml
 threads threads_count, threads_count
 
 preload_app!

--- a/doc/envvars.md
+++ b/doc/envvars.md
@@ -29,7 +29,6 @@ In this example, the current_user for every request would be User `123` regardle
 ```
 
 ## GA_TRACKING_ID
-## MAX_THREADS
 ## MYUSA_URL
 ## NCR_BA61_TIER1_BUDGET_MAILBOX
 ## NCR_BA61_TIER2_BUDGET_MAILBOX
@@ -50,8 +49,6 @@ Defaults to communicart.sender@gsa.gov
 ## SUPPORT_EMAIL
 
 The email address where all feedback and user support questions are sent.
-
-## WEB_CONCURRENCY
 
 ## SECRET_TOKEN
 ## SMTP_DOMAIN

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,7 +7,7 @@
 command: script/server_start
 domain: 18f.gov
 instances: 1
-memory: 1G
+memory: 1.5G
 # we point upstream because 18F buildpacks sometimes lag behind newer Ruby versions.
 buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,7 +7,7 @@
 command: script/server_start
 domain: 18f.gov
 instances: 1
-memory: 1.5G
+memory: 1536MB
 # we point upstream because 18F buildpacks sometimes lag behind newer Ruby versions.
 buildpack: https://github.com/cloudfoundry/ruby-buildpack.git
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -29,6 +29,7 @@ applications:
   hosts:
   - cap
   - c2
+  instances: 2
   env:
     DEFAULT_URL_HOST: cap.18f.gov
     DISABLE_SANDBOX_WARNING: true


### PR DESCRIPTION
I've been seeing the app hanging and `502 Bad Gateway` errors when trying to load the site a few times recently, and yesterday at 5pm ET the app was `down` for no particular reason. After looking at the top graph in New Relic, I believe the problem is a memory constraint during garbage collection.

![screen shot 2015-10-15 at 5 37 56 pm](https://cloud.githubusercontent.com/assets/86842/10551780/0c526ea6-741d-11e5-9a8b-70d277ad0810.png)

There may be other issues that are causing us to consume that much memory, but increasing the instance capacity and having a backup instance in production should at least keep it from crashing. See the individual commits for more explanation of the changes.