### PR TITLE
[#98295520] make a Step base class

### DIFF
--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -1,29 +1,18 @@
-class Approval < ActiveRecord::Base
-  include WorkflowModel
-  has_paper_trail class_name: 'C2Version'
-
+class Approval < Step
   workflow do   # overwritten in child classes
     state :pending
     state :actionable
     state :approved
   end
 
-  belongs_to :proposal
-  acts_as_list scope: :proposal
-  validates :proposal, presence: true
-
   belongs_to :parent, class_name: 'Approval'
   has_many :child_approvals, class_name: 'Approval', foreign_key: 'parent_id', dependent: :destroy
 
   scope :individual, -> { where(type: 'Approvals::Individual') }
 
-
   self.statuses.each do |status|
     scope status, -> { where(status: status) }
   end
-  scope :non_pending, -> { where.not(status: 'pending') }
-
-  default_scope { order('position ASC') }
 
   def notify_parent_approved
     if self.parent

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,0 +1,17 @@
+class Step < ActiveRecord::Base
+  include WorkflowModel
+  has_paper_trail class_name: 'C2Version'
+
+  workflow do # overwritten in child classes
+    state :pending
+    state :complete
+  end
+
+  belongs_to :proposal
+  acts_as_list scope: :proposal
+  validates :proposal, presence: true
+
+  default_scope { order('position ASC') }
+
+  scope :non_pending, -> { where.not(status: 'pending') }
+end

--- a/db/migrate/20151019045846_rename_approvals_to_steps.rb
+++ b/db/migrate/20151019045846_rename_approvals_to_steps.rb
@@ -1,0 +1,6 @@
+class RenameApprovalsToSteps < ActiveRecord::Migration
+  def change
+    rename_table :approvals, :steps
+    rename_column :api_tokens, :approval_id, :step_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151013224625) do
+ActiveRecord::Schema.define(version: 20151019045846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 20151013224625) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "used_at"
-    t.integer  "approval_id"
+    t.integer  "step_id"
   end
 
   create_table "approval_delegates", force: :cascade do |t|
@@ -46,21 +46,6 @@ ActiveRecord::Schema.define(version: 20151013224625) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
-
-  create_table "approvals", force: :cascade do |t|
-    t.integer  "user_id"
-    t.string   "status",              limit: 255
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer  "position"
-    t.integer  "proposal_id"
-    t.datetime "approved_at"
-    t.string   "type"
-    t.integer  "parent_id"
-    t.integer  "min_children_needed"
-  end
-
-  add_index "approvals", ["user_id", "proposal_id"], name: "approvals_user_proposal_idx", unique: true, using: :btree
 
   create_table "attachments", force: :cascade do |t|
     t.string   "file_file_name",    limit: 255
@@ -173,6 +158,21 @@ ActiveRecord::Schema.define(version: 20151013224625) do
 
   add_index "roles", ["name"], name: "roles_name_idx", unique: true, using: :btree
 
+  create_table "steps", force: :cascade do |t|
+    t.integer  "user_id"
+    t.string   "status",              limit: 255
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.integer  "position"
+    t.integer  "proposal_id"
+    t.datetime "approved_at"
+    t.string   "type"
+    t.integer  "parent_id"
+    t.integer  "min_children_needed"
+  end
+
+  add_index "steps", ["user_id", "proposal_id"], name: "approvals_user_proposal_idx", unique: true, using: :btree
+
   create_table "user_roles", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "role_id", null: false
@@ -202,9 +202,6 @@ ActiveRecord::Schema.define(version: 20151013224625) do
 
   add_foreign_key "approval_delegates", "users", column: "assignee_id", name: "assignee_id_fkey"
   add_foreign_key "approval_delegates", "users", column: "assigner_id", name: "assigner_id_fkey"
-  add_foreign_key "approvals", "approvals", column: "parent_id", name: "parent_id_fkey", on_delete: :cascade
-  add_foreign_key "approvals", "proposals", name: "proposal_id_fkey"
-  add_foreign_key "approvals", "users", name: "user_id_fkey"
   add_foreign_key "attachments", "proposals", name: "proposal_id_fkey"
   add_foreign_key "attachments", "users", name: "user_id_fkey"
   add_foreign_key "comments", "proposals", name: "proposal_id_fkey"
@@ -213,6 +210,9 @@ ActiveRecord::Schema.define(version: 20151013224625) do
   add_foreign_key "proposal_roles", "roles", name: "role_id_fkey"
   add_foreign_key "proposal_roles", "users", name: "user_id_fkey"
   add_foreign_key "proposals", "users", column: "requester_id", name: "requester_id_fkey"
+  add_foreign_key "steps", "proposals", name: "proposal_id_fkey"
+  add_foreign_key "steps", "steps", column: "parent_id", name: "parent_id_fkey", on_delete: :cascade
+  add_foreign_key "steps", "users", name: "user_id_fkey"
   add_foreign_key "user_roles", "roles", name: "role_id_fkey"
   add_foreign_key "user_roles", "users", name: "user_id_fkey"
 end


### PR DESCRIPTION
@yozlet, myself, and others talked a bit this last week about how to tackle stories where there are additional actions required by someone involved in a Proposal.

* https://www.pivotaltracker.com/story/show/98295520
* https://www.pivotaltracker.com/story/show/99612190

While there are multiple ways to implement this notion of an additional state ("purchased", in this case), requiring someone to complete a task and indicate when it's done seems a lot like how Approvals are currently handled. Here's a not-awesome diagram illustrating that idea, with the before and after:

![blank](https://cloud.githubusercontent.com/assets/86842/10570370/efc22c82-7600-11e5-83cf-6e5dca0b6282.png)

This PR changes the base concept of our user workflows from Approvals to Steps, which could be an Approval, or a Purchase, or something else. It's not ready for merge yet, but wanted to submit to have something concrete to discuss before going any further.