### PR TITLE
[Delivers #106019438] CSV should respect proposal status when picking approver

### DIFF
--- a/app/decorators/ncr/work_order_decorator.rb
+++ b/app/decorators/ncr/work_order_decorator.rb
@@ -13,6 +13,14 @@ module Ncr
       approver_email_address(final_approver)
     end
 
+    def status_aware_approver_email_address
+      if proposal.approved?
+        final_approver_email_address
+      else
+        current_approver_email_address
+      end
+    end
+
     private
 
     def approver_email_address(approver)

--- a/lib/ncr/reporter.rb
+++ b/lib/ncr/reporter.rb
@@ -49,7 +49,7 @@ module Ncr
       [
         self.proposal_public_url(proposal),
         proposal.requester.email_address,
-        proposal.client_data.decorate.current_approver_email_address,
+        proposal.client_data.decorate.status_aware_approver_email_address,
         proposal.client_data.cl_number,
         proposal.client_data.function_code,
         proposal.client_data.soc_code,

--- a/spec/decorators/ncr_work_order_decorator_spec.rb
+++ b/spec/decorators/ncr_work_order_decorator_spec.rb
@@ -19,10 +19,16 @@ describe Ncr::WorkOrderDecorator do
     expect(wo.current_approver_email_address).to eq(wo.approvers.first.email_address)
   end
 
-  it "returns approver email address based on proposal status" do
+  it "returns current approver email address when status is pending" do
     wo = create(:ncr_work_order, :with_approvers).decorate
+    expect(wo.pending?).to be_truthy
     expect(wo.status_aware_approver_email_address).to eq(wo.current_approver_email_address)
+  end
+
+  it "returns final approver when status is approved" do
+    wo = create(:ncr_work_order, :with_approvers).decorate
     wo.proposal.approve!
+    expect(wo.approved?).to be_truthy
     expect(wo.status_aware_approver_email_address).to eq(wo.final_approver_email_address)
   end
 end

--- a/spec/decorators/ncr_work_order_decorator_spec.rb
+++ b/spec/decorators/ncr_work_order_decorator_spec.rb
@@ -18,4 +18,11 @@ describe Ncr::WorkOrderDecorator do
     wo = create(:ncr_work_order, :with_approvers).decorate
     expect(wo.current_approver_email_address).to eq(wo.approvers.first.email_address)
   end
+
+  it "returns approver email address based on proposal status" do
+    wo = create(:ncr_work_order, :with_approvers).decorate
+    expect(wo.status_aware_approver_email_address).to eq(wo.current_approver_email_address)
+    wo.proposal.approve!
+    expect(wo.status_aware_approver_email_address).to eq(wo.final_approver_email_address)
+  end
 end


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/106019438

This makes the CSV logic match the in-line report email logic.