### PR TITLE
[Delivers #104865396] Ensure adding observer with reason creates an update comment

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -268,7 +268,7 @@ class Proposal < ActiveRecord::Base
     self.observers(true)
     # when explicitly adding an observer using the form in the Proposal page...
     if adder
-      if reason and reason.present?
+      if reason && reason.present?
         add_observation_comment(user, adder, reason)
       end
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -268,7 +268,7 @@ class Proposal < ActiveRecord::Base
     self.observers(true)
     # when explicitly adding an observer using the form in the Proposal page...
     if adder
-      if reason
+      if reason and !reason.blank?
         add_observation_comment(user, adder, reason)
       end
 
@@ -286,6 +286,7 @@ class Proposal < ActiveRecord::Base
         observer: user.full_name,
         reason: reason
       ),
+      update_comment: true,
       user: adder
     )
   end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -268,7 +268,7 @@ class Proposal < ActiveRecord::Base
     self.observers(true)
     # when explicitly adding an observer using the form in the Proposal page...
     if adder
-      if reason and !reason.blank?
+      if reason and reason.present?
         add_observation_comment(user, adder, reason)
       end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,8 +46,7 @@ en:
         rwa_number: "RWA Number"
         soc_code: "Object field / SOC code"
       observation:
-        user_comment: "_%{user} added %{observer} as an observer."
-        user_reason_comment: "_%{user} added %{observer} as an observer, giving reason:_ `%{reason}`."
+        user_reason_comment: "_%{user} added %{observer} as an observer, giving reason:_ `%{reason}`"
   mail:
     subject:
       proposal: "Request %{public_identifier}"

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -314,6 +314,16 @@ describe Proposal do
         end
       end
 
+      context "with a blank reason" do
+        let(:reason) { ' ' }
+
+        it 'does not add a comment' do
+          expect(proposal.comments).to be_empty
+          proposal.add_observer(observer_email, user, reason)
+          expect(proposal.comments).to be_empty
+        end
+      end
+
       context 'with a reason' do
         let(:reason) { 'my mate, innit' }
 

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -321,7 +321,7 @@ describe Proposal do
           expect(proposal.comments).to be_empty
           proposal.add_observer(observer_email, user, reason)
           expect(proposal.comments.length).to eq 1
-          expect(proposal.comments.first.update_comment).to be_truthy
+          expect(proposal.comments.first).to be_update_comment
           expect(proposal.comments.first.comment_text).to include reason
         end
       end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -315,9 +315,8 @@ describe Proposal do
       end
 
       context "with a blank reason" do
-        let(:reason) { ' ' }
-
         it 'does not add a comment' do
+          reason = " "
           expect(proposal.comments).to be_empty
           proposal.add_observer(observer_email, user, reason)
           expect(proposal.comments).to be_empty
@@ -325,9 +324,8 @@ describe Proposal do
       end
 
       context 'with a reason' do
-        let(:reason) { 'my mate, innit' }
-
         it 'adds an update comment mentioning the reason' do
+          reason = "my mate, innit"
           expect(proposal.comments).to be_empty
           proposal.add_observer(observer_email, user, reason)
           expect(proposal.comments.length).to eq 1

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -317,10 +317,11 @@ describe Proposal do
       context 'with a reason' do
         let(:reason) { 'my mate, innit' }
 
-        it 'adds a comment mentioning the reason' do
+        it 'adds an update comment mentioning the reason' do
           expect(proposal.comments).to be_empty
           proposal.add_observer(observer_email, user, reason)
           expect(proposal.comments.length).to eq 1
+          expect(proposal.comments.first.update_comment).to be_truthy
           expect(proposal.comments.first.comment_text).to include reason
         end
       end


### PR DESCRIPTION
Also, adding an observer _without_ specifying a reason should not create a comment.