### PR TITLE
C2 from email address

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -13,19 +13,19 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def reply_to_email
-    ENV['NOTIFICATION_REPLY_TO'] || 'noreplyto@some.gov'
+    email_with_name(ENV['NOTIFICATION_REPLY_TO'] || 'noreplyto@some.gov', 'C2')
   end
 
   def sender_email
-    ENV['NOTIFICATION_FROM_EMAIL'] || 'noreply@some.gov'
+    email_with_name(ENV['NOTIFICATION_FROM_EMAIL'] || 'noreply@some.gov', 'C2')
   end
 
   def resend_to_email
-    ENV['NOTIFICATION_FALLBACK_EMAIL'] || 'communicart.sender@gsa.gov'
+    email_with_name(ENV['NOTIFICATION_FALLBACK_EMAIL'] || 'communicart.sender@gsa.gov', 'C2')
   end
 
   def default_sender_email
-    email_with_name(sender_email, "Communicart")
+    sender_email
   end
 
   def user_email_with_name(user)

--- a/spec/mailers/communicart_mailer_spec.rb
+++ b/spec/mailers/communicart_mailer_spec.rb
@@ -275,7 +275,7 @@ describe CommunicartMailer do
     end
 
     it "uses the default sender name" do
-      expect(sender_names(mail)).to eq(["Communicart"])
+      expect(sender_names(mail)).to eq(["C2"])
     end
   end
 
@@ -289,7 +289,7 @@ describe CommunicartMailer do
     end
 
     it "uses the default sender name" do
-      expect(sender_names(mail)).to eq(["Communicart"])
+      expect(sender_names(mail)).to eq(["C2"])
     end
   end
 


### PR DESCRIPTION
Since our new production sender email address is *inbox@c2.18f.gov* without any human-readable name, the sender appears as 'inbox' when viewing the message. Let's make it friendlier.