### PR TITLE
ruboconf directive for double_quotes fails on CodeClimate

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,8 @@ Style/RedundantSelf:
   Enabled: false
 Style/SignalException:
   Enabled: false
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
 Style/TrailingComma:
   Enabled: false
 Style/AndOr:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,7 @@ Style/RedundantSelf:
 Style/SignalException:
   Enabled: false
 Style/StringLiterals:
+  Enabled: true
   EnforcedStyle: double_quotes
 Style/TrailingComma:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Style/RedundantSelf:
 Style/SignalException:
   Enabled: false
 Style/StringLiterals:
-  EnforcedStyle:double_quotes
+  EnforcedStyle: double_quotes
 Style/TrailingComma:
   Enabled: false
 Style/AndOr:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,9 +24,6 @@ Style/RedundantSelf:
   Enabled: false
 Style/SignalException:
   Enabled: false
-Style/StringLiterals:
-  Enabled: true
-  EnforcedStyle: double_quotes
 Style/TrailingComma:
   Enabled: false
 Style/AndOr:


### PR DESCRIPTION
CodeClimate appears unhappy with this directive. Maybe a version issue?
```
undefined method `each_key' for "EnforcedStyle:double_quotes":String
```

FWIW, Rubocop does not require double quotes by default, on purpose: https://github.com/bbatsov/rubocop/issues/1615

