### PR TITLE
[Delivers #99273060] Send cancellation conf email to active observers

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ActiveRecord::Base
 
   has_many :approvals
   has_many :observations
+  has_many :observers, through: :observers, source: :user
   has_many :comments
 
   # we do not use rolify gem (e.g.) but declare relationship like any other.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ActiveRecord::Base
 
   has_many :approvals
   has_many :observations
-  has_many :observers, through: :observers, source: :user
+  has_many :observers, through: :observations, source: :user
   has_many :comments
 
   # we do not use rolify gem (e.g.) but declare relationship like any other.

--- a/lib/role_picker.rb
+++ b/lib/role_picker.rb
@@ -20,7 +20,7 @@ class RolePicker
 
   # Active Observer means, their main role is an observer
   def active_observer?
-    self.observer? && !self.active_approver? && !self.requester?
+    observer? && !active_approver? && !requester?
   end
 
   # observer? approver? etc. get converted into scanning role_types


### PR DESCRIPTION
* Active observers are observer who are not approver or requester
* Previously, were not receiving an email
* Story: https://www.pivotaltracker.com/story/show/99273060