### PR TITLE
Remove extra dash from beginning link item

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -111,7 +111,7 @@ licenses:
 #   text: Anchor text for the link
 links:
 - url: https://c2.18f.gov/
-- text: C2 website
+  text: C2 website
 
 # Email addresses of points-of-contact
 contact:


### PR DESCRIPTION
The extra dash made it look like two items, one without anchor text, and one without a URL.

cc: @afeld @pkarman @openbrian