### PR TITLE
[Delivers #102133698] delayed job queue visibility

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -7,15 +7,15 @@ ActiveAdmin.register_page "Dashboard" do
       now = Time.zone.now
       ul do
         li do
-          jobs = DelayedJob.where('failed_at is not null').count(:id)
+          jobs = Delayed::Job.where('failed_at is not null').count(:id)
           link_to "#{jobs} failing jobs", admin_jobs_path(q: {failed_at_is_not_null: true}), style: 'color: red'
         end
         li do
-          jobs = DelayedJob.where('run_at <= ?', now).count(:id)
+          jobs = Delayed::Job.where('run_at <= ?', now).count(:id)
           link_to "#{jobs} late jobs", admin_jobs_path(q: {run_at_lte: now.to_s(:db)}), style: 'color: hsl(40, 100%, 40%)'
         end
         li do
-          jobs = DelayedJob.where('run_at >= ?', now).count(:id)
+          jobs = Delayed::Job.where('run_at >= ?', now).count(:id)
           link_to "#{jobs} scheduled jobs", admin_jobs_path(q: {run_at_gte: now.to_s(:db)}), style: 'color: green'
         end
       end

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -2,10 +2,22 @@ ActiveAdmin.register_page "Dashboard" do
   menu priority: 1, label: proc { I18n.t("active_admin.dashboard") }
 
   content title: proc { I18n.t("active_admin.dashboard") } do
-    div class: "blank_slate_container", id: "dashboard_default_message" do
-      span class: "blank_slate" do
-        span I18n.t("active_admin.dashboard_welcome.welcome")
-        small I18n.t("active_admin.dashboard_welcome.call_to_action")
+
+    section "Background Jobs" do
+      now = Time.now.getgm
+      ul do
+        li do
+          jobs = DelayedJob.where('failed_at is not null').count(:id)
+          link_to "#{jobs} failing jobs", admin_jobs_path(q: {failed_at_is_not_null: true}), style: 'color: red'
+        end
+        li do
+          jobs = DelayedJob.where('run_at <= ?', now).count(:id)
+          link_to "#{jobs} late jobs", admin_jobs_path(q: {run_at_lte: now.to_s(:db)}), style: 'color: hsl(40, 100%, 40%)'
+        end
+        li do
+          jobs = DelayedJob.where('run_at >= ?', now).count(:id)
+          link_to "#{jobs} scheduled jobs", admin_jobs_path(q: {run_at_gte: now.to_s(:db)}), style: 'color: green'
+        end
       end
     end
 

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register_page "Dashboard" do
   content title: proc { I18n.t("active_admin.dashboard") } do
 
     section "Background Jobs" do
-      now = Time.now.getgm
+      now = Time.zone.now
       ul do
         li do
           jobs = DelayedJob.where('failed_at is not null').count(:id)

--- a/app/admin/job.rb
+++ b/app/admin/job.rb
@@ -1,5 +1,5 @@
 # based on https://gist.github.com/webmat/1887148
-ActiveAdmin.register DelayedJob, as: 'Job' do
+ActiveAdmin.register Delayed::Job, as: 'Job' do
   actions :index, :show, :edit, :update, :destroy
 
   index do
@@ -39,27 +39,27 @@ ActiveAdmin.register DelayedJob, as: 'Job' do
     f.buttons
   end
 
-  action_item :only => [:edit] do
+  action_item only: [:edit] do
     link_to 'Delete Job', admin_job_path(resource),
             'data-method' => :delete, 'data-confirm' => 'Are you sure?'
   end
 
   action_item :only => [:show, :edit] do
     link_to 'Schedule now', run_now_admin_job_path(resource), 'data-method' => :post,
-      :title => 'Cause a job scheduled in the future to run now.'
+      title: 'Cause a job scheduled in the future to run now.'
   end
 
   action_item :only => [:show, :edit] do
     link_to 'Reset Job', reset_admin_job_path(resource), 'data-method' => :post,
-      :title => 'Resets the state caused by errors. Lets a worker give it another go ASAP.'
+      title: 'Resets the state caused by errors. Lets a worker give it another go ASAP.'
   end
 
-  member_action :run_now, :method => :post do
+  member_action :run_now, method: :post do
     resource.update_attributes run_at: Time.now
     redirect_to action: :index
   end
 
-  member_action :reset, :method => :post do
+  member_action :reset, method: :post do
     resource.update_attributes locked_at: nil, locked_by: nil, attempts: 0, last_error: nil
     resource.update_attribute :attempts, 0
     redirect_to action: :index

--- a/app/admin/job.rb
+++ b/app/admin/job.rb
@@ -1,0 +1,68 @@
+# based on https://gist.github.com/webmat/1887148
+ActiveAdmin.register DelayedJob, as: 'Job' do
+  actions :index, :show, :edit, :update, :destroy
+
+  index do
+    column :id
+    column :queue
+    column :priority
+    column :attempts
+    column :failed_at
+    column :run_at
+    column :created_at
+    column :locked_by
+    column :locked_at
+    actions
+  end
+
+  form do |f|
+    f.inputs "Scheduling" do
+      f.input :priority
+      f.input :queue
+      f.input :run_at
+    end
+
+    f.inputs "Details" do
+      f.input :id, input_html:          {disabled: true}
+      f.input :created_at, input_html:  {disabled: true}
+      f.input :updated_at, input_html:  {disabled: true}
+      f.input :handler, input_html:     {disabled: true}
+    end
+
+    f.inputs "Diagnostics" do
+      f.input :attempts,    input_html: {disabled: true}
+      f.input :failed_at,   input_html: {disabled: true}
+      f.input :last_error,  input_html: {disabled: true}
+      f.input :locked_at,   input_html: {disabled: true}
+      f.input :locked_by,   input_html: {disabled: true}
+    end
+    f.buttons
+  end
+
+  action_item :only => [:edit] do
+    link_to 'Delete Job', admin_job_path(resource),
+            'data-method' => :delete, 'data-confirm' => 'Are you sure?'
+  end
+
+  action_item :only => [:show, :edit] do
+    link_to 'Schedule now', run_now_admin_job_path(resource), 'data-method' => :post,
+      :title => 'Cause a job scheduled in the future to run now.'
+  end
+
+  action_item :only => [:show, :edit] do
+    link_to 'Reset Job', reset_admin_job_path(resource), 'data-method' => :post,
+      :title => 'Resets the state caused by errors. Lets a worker give it another go ASAP.'
+  end
+
+  member_action :run_now, :method => :post do
+    resource.update_attributes run_at: Time.now
+    redirect_to action: :index
+  end
+
+  member_action :reset, :method => :post do
+    resource.update_attributes locked_at: nil, locked_by: nil, attempts: 0, last_error: nil
+    resource.update_attribute :attempts, 0
+    redirect_to action: :index
+  end
+
+end

--- a/app/models/delayed_job.rb
+++ b/app/models/delayed_job.rb
@@ -1,0 +1,3 @@
+class DelayedJob < ActiveRecord::Base
+
+end

--- a/app/models/delayed_job.rb
+++ b/app/models/delayed_job.rb
@@ -1,3 +1,0 @@
-class DelayedJob < ActiveRecord::Base
-
-end

--- a/spec/features/active_admin_spec.rb
+++ b/spec/features/active_admin_spec.rb
@@ -23,6 +23,7 @@ describe '/admin endpoint' do
 
     expect(page.status_code).to eq(200)
     expect(page).to have_content('Dashboard')
+    expect(page).to have_content('scheduled jobs')
   end
 
   def user


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/102133698

Adds `delayed_jobs` to the `/admin` UI.

It seems like there could/should be a way to monitor queue length with New Relic, but I'm not sure how best to do that, since we are testing for a negative activity. See comments on https://www.pivotaltracker.com/story/show/103541696

**Testing**: since the intended non-dev behavior is for delayed jobs to be executed very quickly, it can be difficult to test this under our CF environments. If you wanted to QA this in dev environment, you could generate email and then check the dashboard to verify that the reporting SQL correctly finds the pending jobs. Otherwise, to QA in a CF environment, generate email in any common way and verify that there are no regressions. In practice the `/admin` UI will usually be empty for jobs unless you are very fast in your click-and-reload browser dexterity.