### PR TITLE
simplify assignment of WorkOrder#approving_official_email

### DIFF
--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -60,10 +60,7 @@ module Ncr
     }
 
     def set_defaults
-      # not sure why the latter condition is necessary...was getting some weird errors from the tests without it. -AF 10/5/2015
-      if !self.approving_official_email && self.approvers.any?
-        self.approving_official_email = self.approvers.first.try(:email_address)
-      end
+      self.approving_official_email ||= self.approving_official.try(:email_address)
       self.direct_pay ||= false
       self.not_to_exceed ||= false
       self.emergency ||= false

--- a/spec/factories/ncr/work_orders.rb
+++ b/spec/factories/ncr/work_orders.rb
@@ -15,6 +15,7 @@ FactoryGirl.define do
     trait :with_approvers do
       association :proposal, :with_serial_approvers, flow: 'linear'
       after :create do |wo|
+        wo.reload # since approvers may be cached-as-empty
         wo.approving_official_email = wo.approving_official.email_address
       end
     end


### PR DESCRIPTION
I feel like I'm losing my mind here...can anyone explain to me why [the previous commit](https://github.com/18F/C2/commit/176a03c43768484ce48b243ba58246d578c5a0c2) is [passing](https://circleci.com/gh/18F/C2/2555), but this change makes it fail?