### PR TITLE
[Delivers #106855394] close authorization backdoor for non-subscriber email reply

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -100,6 +100,8 @@ class Proposal < ActiveRecord::Base
     results.compact.uniq
   end
 
+  alias_method :subscribers, :users
+
   def root_approval=(root)
     old_approvals = self.approvals.to_a
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -143,6 +143,10 @@ class Proposal < ActiveRecord::Base
     end
   end
 
+  def has_subscriber?(user)
+    users.include?(user)
+  end
+
   def existing_observation_for(user)
     observations.find_by(user: user)
   end

--- a/lib/incoming_mail/handler.rb
+++ b/lib/incoming_mail/handler.rb
@@ -26,7 +26,7 @@ module IncomingMail
       resp = Response.new(type: identify_mail_type(payload))
       case resp.type
       when REQUEST
-        resp.comment = create_comment(payload['msg'])
+        resp.comment = transform_msg_to_comment(payload['msg'])
         if resp.comment
           resp.action = Response::COMMENT
         else
@@ -64,7 +64,7 @@ module IncomingMail
       CommunicartMailer.resend(msg).deliver_later
     end
 
-    def create_comment(msg)
+    def transform_msg_to_comment(msg)
       # IMPORTANT that we check/add as observer before we create comment,
       # since comment will create as a user if not already,
       # and we want the reason logged.
@@ -77,6 +77,13 @@ module IncomingMail
       unless user && proposal.has_subscriber?(user)
         return
       end
+
+      create_comment(parsed_email)
+    end
+
+    def create_comment(parsed_email)
+      proposal = parsed_email.proposal
+      user = parsed_email.comment_user
 
       unless proposal.existing_observation_for(user)
         reason = "Added comment via email reply"

--- a/lib/incoming_mail/handler.rb
+++ b/lib/incoming_mail/handler.rb
@@ -72,7 +72,11 @@ module IncomingMail
       proposal = parsed_email.proposal
       user = parsed_email.comment_user
 
-      return unless user  # cannot create comment for non-existent user
+      # cannot create comment for non-existent user, or
+      # for user who is not already a subscriber
+      unless user && proposal.has_subscriber?(user)
+        return
+      end
 
       unless proposal.existing_observation_for(user)
         reason = "Added comment via email reply"

--- a/spec/features/incoming_mail_handler_spec.rb
+++ b/spec/features/incoming_mail_handler_spec.rb
@@ -84,7 +84,7 @@ describe "Handles incoming email" do
 
     expect(resp.action).to eq(IncomingMail::Response::FORWARDED)
     expect(deliveries.length).to eq(1)
-    expect(my_proposal.has_subscriber?(user)).to be_falsey
+    expect(my_proposal.has_subscriber?(user)).to eq(false)
   end
 
   it "should parse proposal public_id from email headers" do

--- a/spec/features/incoming_mail_handler_spec.rb
+++ b/spec/features/incoming_mail_handler_spec.rb
@@ -69,7 +69,7 @@ describe "Handles incoming email" do
     expect(deliveries.length).to eq(2) # 1 each to requester and approver
   end
 
-  it "should create comment for non-subscriber and add as observer" do
+  it "should not create comment for non-subscriber and not add as observer" do
     my_approval = approval
     my_proposal = my_approval.proposal
     user = create(:user)
@@ -82,19 +82,9 @@ describe "Handles incoming email" do
 
     resp = handler.handle(mandrill_event)
 
-    expect(resp.action).to eq(IncomingMail::Response::COMMENT)
-    expect(resp.comment.proposal.existing_observation_for(user)).to be_present
-    expect(resp.comment.proposal.existing_approval_for(user)).not_to be_present
-    expect(my_approval.user).to_not eq(my_proposal.individual_approvals.last.user)
-
-    comment_recipients = [
-      my_proposal.requester.email_address, # comment
-      my_proposal.individual_approvals.last.user.email_address, # comment
-      my_approval.user.email_address, # comment
-    ]
-
-    expect(deliveries.length).to eq(comment_recipients.size)
-    expect(deliveries.map{|m| m.to.first}.sort).to eq(comment_recipients.sort)
+    expect(resp.action).to eq(IncomingMail::Response::FORWARDED)
+    expect(deliveries.length).to eq(1)
+    expect(my_proposal.has_subscriber?(user)).to be_falsey
   end
 
   it "should parse proposal public_id from email headers" do

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -82,6 +82,11 @@ describe Proposal do
       expect(proposal.users).to eq([proposal.requester])
     end
 
+    it "uses 'subscribers' as an aliased method" do
+      proposal = create(:proposal)
+      expect(proposal.users).to eq(proposal.subscribers)
+    end
+
     it "removes duplicates" do
       requester = create(:user)
       proposal = create(:proposal, requester: requester)


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/106855394

Removes authorization backdoor where a non-subscriber could add themselves as an observer by replying to an email mentioning a request. The rules were clarified in a24118d9012c2bd53af40997907fa9dbd9fc88ea

**Testing**: this can be tested by sending an email to the `*inbox@c2.18f.gov` address from a non-subscriber. The email subject should have the same Request ID pattern as any legit email from the system. The most straightforward way to do this would be:

* create new request
* reply to the generated announcement email, cc'ing a non-subscriber who is a user in the system
* reply from the non-subscriber's email account