### PR TITLE
Add defaults to DB for boolean NCR::WorkOrder fields

### DIFF
--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -64,9 +64,6 @@ module Ncr
       if !self.approving_official_email && self.approvers.any?
         self.approving_official_email = self.approvers.first.try(:email_address)
       end
-      self.direct_pay ||= false
-      self.not_to_exceed ||= false
-      self.emergency ||= false
     end
 
     # For budget attributes, converts empty strings to `nil`, so that the request isn't shown as being modified when the fields appear in the edit form.

--- a/db/migrate/20151028234110_add_defaults_to_ncr_work_orders.rb
+++ b/db/migrate/20151028234110_add_defaults_to_ncr_work_orders.rb
@@ -1,0 +1,13 @@
+class AddDefaultsToNcrWorkOrders < ActiveRecord::Migration
+  def up
+    change_column :ncr_work_orders, :direct_pay, :boolean, null: false, default: false
+    change_column :ncr_work_orders, :emergency, :boolean, null: false, default: false
+    change_column :ncr_work_orders, :not_to_exceed, :boolean, null: false, default: false
+  end
+
+  def down
+    change_column :ncr_work_orders, :direct_pay, :boolean, null: true, default: nil
+    change_column :ncr_work_orders, :emergency, :boolean, null: true, default: nil
+    change_column :ncr_work_orders, :not_to_exceed, :boolean, null: true, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151027230223) do
+ActiveRecord::Schema.define(version: 20151028234110) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -123,9 +123,9 @@ ActiveRecord::Schema.define(version: 20151027230223) do
     t.decimal  "amount"
     t.string   "expense_type",    limit: 255
     t.string   "vendor",          limit: 255
-    t.boolean  "not_to_exceed"
+    t.boolean  "not_to_exceed",               default: false, null: false
     t.string   "building_number", limit: 255
-    t.boolean  "emergency"
+    t.boolean  "emergency",                   default: false, null: false
     t.string   "rwa_number",      limit: 255
     t.string   "org_code",        limit: 255
     t.string   "code",            limit: 255
@@ -133,7 +133,7 @@ ActiveRecord::Schema.define(version: 20151027230223) do
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "direct_pay"
+    t.boolean  "direct_pay",                  default: false, null: false
     t.string   "cl_number",       limit: 255
     t.string   "function_code",   limit: 255
     t.string   "soc_code",        limit: 255


### PR DESCRIPTION
* Add DB constraint rather than setting in a callback