### PR TITLE
fix deprecation warning for DelayedJob actions in ActiveAdmin

### DIFF
--- a/app/admin/job.rb
+++ b/app/admin/job.rb
@@ -39,17 +39,17 @@ ActiveAdmin.register Delayed::Job, as: 'Job' do
     f.buttons
   end
 
-  action_item only: [:edit] do
+  action_item :delete, only: [:edit] do
     link_to 'Delete Job', admin_job_path(resource),
             'data-method' => :delete, 'data-confirm' => 'Are you sure?'
   end
 
-  action_item :only => [:show, :edit] do
+  action_item :schedule, only: [:show, :edit] do
     link_to 'Schedule now', run_now_admin_job_path(resource), 'data-method' => :post,
       title: 'Cause a job scheduled in the future to run now.'
   end
 
-  action_item :only => [:show, :edit] do
+  action_item :reset, only: [:show, :edit] do
     link_to 'Reset Job', reset_admin_job_path(resource), 'data-method' => :post,
       title: 'Resets the state caused by errors. Lets a worker give it another go ASAP.'
   end


### PR DESCRIPTION
Was getting this when starting the app:

```
DEPRECATION WARNING: Active Admin: using `action_item` without a name is deprecated! Use `action_item(:edit)`. (called from action_item at /Users/aidanfeldman/.rvm/gems/ruby-2.2.3/bundler/gems/activeadmin-470817d8b43b/lib/active_admin/dsl.rb:92)
DEPRECATION WARNING: Active Admin: using `action_item` without a name is deprecated! Use `action_item(:edit)`. (called from action_item at /Users/aidanfeldman/.rvm/gems/ruby-2.2.3/bundler/gems/activeadmin-470817d8b43b/lib/active_admin/dsl.rb:92)
DEPRECATION WARNING: Active Admin: using `action_item` without a name is deprecated! Use `action_item(:edit)`. (called from action_item at /Users/aidanfeldman/.rvm/gems/ruby-2.2.3/bundler/gems/activeadmin-470817d8b43b/lib/active_admin/dsl.rb:92)
```

There shouldn't be any change in behavior.

http://activeadmin.info/docs/8-custom-actions.html#action-items