### PR TITLE
[Delivers #99135662] improve HashDiff for empty original values

### DIFF
--- a/app/decorators/hash_diff_decorator/base.rb
+++ b/app/decorators/hash_diff_decorator/base.rb
@@ -17,7 +17,11 @@ module HashDiffDecorator
     protected
 
     def diff_val(val)
-      if val.is_a?(Numeric)
+      if val.nil?
+        "[nil]"
+      elsif val.empty?
+        "[empty]"
+      elsif val.is_a?(Numeric)
         format('%.2f', val)
       else
         val.inspect

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -300,7 +300,12 @@ module Ncr
       else
         from = "from #{former} "
       end
-      "#{bullet}*#{key}* was changed " + from + "to #{value}"
+      if value.empty?
+        to = "*empty*"
+      else
+        to = value
+      end
+      "#{bullet}*#{key}* was changed " + from + "to #{to}"
     end
 
     # Generally shouldn't be called directly as it doesn't account for

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -295,7 +295,11 @@ module Ncr
     end
 
     def self.update_comment_format(key, value, bullet, former=nil)
-      from = former ? "from #{former} " : ''
+      if !former || former.empty?
+        from = ""
+      else
+        from = "from #{former} "
+      end
       "#{bullet}*#{key}* was changed " + from + "to #{value}"
     end
 

--- a/spec/decorators/hash_diff_decorator_spec.rb
+++ b/spec/decorators/hash_diff_decorator_spec.rb
@@ -14,5 +14,15 @@ describe HashDiffDecorator do
       output = HashDiffDecorator.html_for(['-', 'foo'])
       expect(output).to eq("<code>foo</code> was removed.")
     end
+
+    it "renders original-was-nil events" do
+      output = HashDiffDecorator.html_for(['~', 'foo', nil, 'bar'])
+      expect(output).to eq("<code>foo</code> was changed from <code>[nil]</code> to <code>&quot;bar&quot;</code>")
+    end
+
+    it "renders original-was-empty-string events" do
+      output = HashDiffDecorator.html_for(['~', 'foo', '', 'bar'])
+      expect(output).to eq("<code>foo</code> was changed from <code>[empty]</code> to <code>&quot;bar&quot;</code>")
+    end
   end
 end

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -395,6 +395,13 @@ describe Ncr::WorkOrder do
       comment_text += "- *Amount* was changed from $1,000.00 to $123.45\n"
       comment_text += "- *Description* was changed to some text"
       expect(comment.comment_text).to eq(comment_text)
+
+      work_order.update(description: '')
+
+      expect(work_order.proposal.comments.count).to be 2
+      comment = Comment.last
+      expect(comment.update_comment).to be(true)
+      expect(comment.comment_text).to eq("*Description* was changed from some text to *empty*")
     end
 
     it 'includes extra information if modified post approval' do

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -386,13 +386,14 @@ describe Ncr::WorkOrder do
     let (:work_order) { create(:ncr_work_order) }
 
     it 'adds a change comment' do
-      work_order.update(vendor: 'Mario Brothers', amount: 123.45)
+      work_order.update(vendor: 'Mario Brothers', amount: 123.45, description: 'some text')
 
       expect(work_order.proposal.comments.count).to be 1
       comment = Comment.last
       expect(comment.update_comment).to be(true)
       comment_text = "- *Vendor* was changed from Some Vend to Mario Brothers\n"
-      comment_text += "- *Amount* was changed from $1,000.00 to $123.45"
+      comment_text += "- *Amount* was changed from $1,000.00 to $123.45\n"
+      comment_text += "- *Description* was changed to some text"
       expect(comment.comment_text).to eq(comment_text)
     end
 


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/99135662

* render nil and empty strings explicitly in HashDiff so it is clear what the original value was