### PR TITLE
[Delivers #107239306] improve OOO comment coverage

### DIFF
--- a/app/mailers/concerns/proposal_conversation_threading.rb
+++ b/app/mailers/concerns/proposal_conversation_threading.rb
@@ -59,10 +59,13 @@ module ProposalConversationThreading
     self.assign_threading_headers(proposal)
     subject = ProposalConversationThreading.subject(proposal)
 
+    reply_email = reply_to_email().gsub('@', "+#{proposal.public_id}@")
+
     mail(
       to: to_email,
       subject: subject,
       from: from_email || default_sender_email,
+      reply_to: reply_email,
       template_name: template_name
     )
   end

--- a/spec/mailers/communicart_mailer_spec.rb
+++ b/spec/mailers/communicart_mailer_spec.rb
@@ -25,7 +25,7 @@ describe CommunicartMailer do
     end
 
     it "uses the configured replyto email" do
-      expect(mail.reply_to).to eq(['replyto@example.com'])
+      expect(mail.reply_to).to eq(["replyto+#{proposal.public_id}@example.com"])
     end
 
     it "includes the appropriate headers for threading" do


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/107239306

This makes the reply-to address of each email include the proposal `public_id` so that OOO auto-replies are unique-per-request rather than unique-per-requester.

To test, trigger any email and check that the reply-to address contains the request public_id.