### PR TITLE
[Delivers #89851836] drop Properties table

### DIFF
--- a/db/migrate/20151103223107_drop_properties.rb
+++ b/db/migrate/20151103223107_drop_properties.rb
@@ -1,0 +1,5 @@
+class DropProperties < ActiveRecord::Migration
+  def change
+    drop_table :properties
+  end
+end

--- a/db/migrate/20151103223107_drop_properties.rb
+++ b/db/migrate/20151103223107_drop_properties.rb
@@ -1,5 +1,9 @@
 class DropProperties < ActiveRecord::Migration
-  def change
+  def up
     drop_table :properties
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151028234110) do
+ActiveRecord::Schema.define(version: 20151103223107) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -137,13 +137,6 @@ ActiveRecord::Schema.define(version: 20151028234110) do
     t.string   "cl_number",       limit: 255
     t.string   "function_code",   limit: 255
     t.string   "soc_code",        limit: 255
-  end
-
-  create_table "properties", force: :cascade do |t|
-    t.text    "property"
-    t.text    "value"
-    t.integer "hasproperties_id"
-    t.string  "hasproperties_type", limit: 255
   end
 
   create_table "proposal_roles", force: :cascade do |t|


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/89851836

Final clean up for deprecated Properties table. Related code was removed several months ago in dd5b0b5c56b28b44fa5d5effed7967f44294dde1

DB snapshots since then have backed up data.