### PR TITLE
[Delivers #106987202] Do not show system approver emails as approver …

### DIFF
--- a/app/controllers/use_case_controller.rb
+++ b/app/controllers/use_case_controller.rb
@@ -15,7 +15,7 @@ class UseCaseController < ApplicationController
   def create
     if errors.empty?
       proposal = ClientDataCreator.new(@model_instance, current_user, attachment_params).run
-      add_approvals()
+      add_approvals
       Dispatcher.deliver_new_proposal_emails(proposal)
 
       flash[:success] = "Proposal submitted!"

--- a/app/helpers/ncr/work_orders_helper.rb
+++ b/app/helpers/ncr/work_orders_helper.rb
@@ -1,7 +1,8 @@
 module Ncr
   module WorkOrdersHelper
     def approver_options
-      User.active.where(client_slug: 'ncr').order(:email_address).pluck(:email_address)
+      User.active.where(client_slug: "ncr").order(:email_address).pluck(:email_address) -
+        Ncr::WorkOrder.all_system_approver_emails
     end
 
     def building_options

--- a/app/models/approval.rb
+++ b/app/models/approval.rb
@@ -10,13 +10,15 @@ class Approval < ActiveRecord::Base
 
   belongs_to :proposal
   acts_as_list scope: :proposal
-  validates :proposal, presence: true
 
+  belongs_to :user
   belongs_to :parent, class_name: 'Approval'
   has_many :child_approvals, class_name: 'Approval', foreign_key: 'parent_id', dependent: :destroy
 
-  scope :individual, -> { where(type: 'Approvals::Individual') }
+  validates :proposal, presence: true
+  validates :user_id, uniqueness: { scope: :proposal_id }
 
+  scope :individual, -> { where(type: "Approvals::Individual") }
 
   self.statuses.each do |status|
     scope status, -> { where(status: status) }

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -107,20 +107,6 @@ module Ncr
       fields
     end
 
-    def self.update_comment_format(key, value, bullet, former=nil)
-      if !former || former.empty?
-        from = ""
-      else
-        from = "from #{former} "
-      end
-      if value.empty?
-        to = "*empty*"
-      else
-        to = value
-      end
-      "#{bullet}*#{key}* was changed " + from + "to #{to}"
-    end
-
     def set_defaults
       # not sure why the latter condition is necessary...was getting some weird errors from the tests without it. -AF 10/5/2015
       if !self.approving_official_email && self.approvers.any?

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -162,7 +162,7 @@ ActiveRecord::Schema.define(version: 20151028234110) do
     t.integer  "client_data_id"
     t.string   "client_data_type", limit: 255
     t.integer  "requester_id"
-    t.string   "public_id",        limit: 255
+    t.string   "public_id"
   end
 
   add_index "proposals", ["client_data_id", "client_data_type"], name: "index_proposals_on_client_data_id_and_client_data_type", using: :btree

--- a/spec/factories/approvals.rb
+++ b/spec/factories/approvals.rb
@@ -3,8 +3,11 @@ FactoryGirl.define do
     proposal
     user
     status 'pending'
-  end
 
-  factory :parallel_approval, class: Approvals::Parallel do
+    factory :parallel_approval, class: Approvals::Parallel do
+    end
+
+    factory :individual_approval, class: Approvals::Individual do
+    end
   end
 end

--- a/spec/features/ncr/work_orders/create_spec.rb
+++ b/spec/features/ncr/work_orders/create_spec.rb
@@ -107,13 +107,12 @@ feature 'Creating an NCR work order' do
       visit "/ncr/work_orders/new"
       within(".ncr_work_order_approving_official_email") do
         find(".selectize-control").click
+        expect(page).to have_content(approving_official.email_address)
+        expect(page).not_to have_content(Ncr::WorkOrder.ba61_tier1_budget_mailbox)
+        expect(page).not_to have_content(Ncr::WorkOrder.ba61_tier2_budget_mailbox)
+        expect(page).not_to have_content(Ncr::WorkOrder.ba80_budget_mailbox)
+        expect(page).not_to have_content(Ncr::WorkOrder.ool_ba80_budget_mailbox)
       end
-
-      expect(page).to have_content(approving_official.email_address)
-      expect(page).not_to have_content(Ncr::WorkOrder.ba61_tier1_budget_mailbox)
-      expect(page).not_to have_content(Ncr::WorkOrder.ba61_tier2_budget_mailbox)
-      expect(page).not_to have_content(Ncr::WorkOrder.ba80_budget_mailbox)
-      expect(page).not_to have_content(Ncr::WorkOrder.ool_ba80_budget_mailbox)
     end
 
     scenario 'shows hint text for amount field', :js do

--- a/spec/helpers/ncr/work_orders_helper_spec.rb
+++ b/spec/helpers/ncr/work_orders_helper_spec.rb
@@ -1,7 +1,7 @@
 describe Ncr::WorkOrdersHelper do
   describe '#approver_options' do
     it 'includes existing users' do
-      expect(helper.approver_options.size).to eq(User.count)  # seed Users
+      expect(helper.approver_options.size).to eq(0)
       users = [create(:user, client_slug: 'ncr'), create(:user, client_slug: 'ncr')]
       expect(helper.approver_options).to include(*users.map(&:email_address))
     end

--- a/spec/models/approval_spec.rb
+++ b/spec/models/approval_spec.rb
@@ -1,4 +1,17 @@
 describe Approval do
+  describe "Associations" do
+    it { should belong_to(:user) }
+    it { should belong_to(:proposal) }
+  end
+
+  describe "Validations" do
+    it { should validate_presence_of(:proposal) }
+    it do
+      create(:approval) # needed for spec, see https://github.com/thoughtbot/shoulda-matchers/issues/194
+      should validate_uniqueness_of(:user_id).scoped_to(:proposal_id)
+    end
+  end
+
   let(:approval) { create(:approval) }
 
   describe '#api_token' do
@@ -49,9 +62,9 @@ describe Approval do
 
     it "does not notify the proposal if a child gets approved" do
       proposal = create(:proposal)
-      child1 = Approvals::Individual.new(user: create(:user))
-      child2 = Approvals::Individual.new(user: create(:user))
-      proposal.root_approval = Approvals::Parallel.new(child_approvals: [child1, child2])
+      child1 = build(:individual_approval, user: create(:user))
+      child2 = build(:individual_approval, user: create(:user))
+      proposal.root_approval = build(:parallel_approval, child_approvals: [child1, child2])
 
       expect(proposal).not_to receive(:approve!)
       child1.approve!


### PR DESCRIPTION
…options

* Cannot have two approvals for some approver bc of DB constraint, so
  was returning a 500
* Adding a uniqueness validation did not improve UX because approval is
  created after work order is created so validation came to late
* Short term fix is to not show these user emails as options
* Longer term fix is probably to wrap creation of all objects on a
  transaction per http://blog.endpoint.com/2011/10/rails-controllers-and-transactions.html
* Story: https://www.pivotaltracker.com/story/show/106987202