### PR TITLE
[Delivers #107393700] /history endpoint returns 500 error

### DIFF
--- a/app/decorators/hash_diff_decorator/base.rb
+++ b/app/decorators/hash_diff_decorator/base.rb
@@ -19,10 +19,10 @@ module HashDiffDecorator
     def diff_val(val)
       if val.nil?
         "[nil]"
-      elsif val.empty?
-        "[empty]"
       elsif val.is_a?(Numeric)
         format('%.2f', val)
+      elsif val.empty?
+        "[empty]"
       else
         val.inspect
       end

--- a/spec/decorators/hash_diff_decorator_spec.rb
+++ b/spec/decorators/hash_diff_decorator_spec.rb
@@ -24,5 +24,10 @@ describe HashDiffDecorator do
       output = HashDiffDecorator.html_for(['~', 'foo', '', 'bar'])
       expect(output).to eq("<code>foo</code> was changed from <code>[empty]</code> to <code>&quot;bar&quot;</code>")
     end
+
+    it "renders numeric events" do
+      output = HashDiffDecorator.html_for(['~', 'a_number', 456, 123])
+      expect(output).to eq("<code>a_number</code> was changed from <code>456.00</code> to <code>123.00</code>")
+    end
   end
 end


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/107393700

This fixes a regression introduced in #751 where the `empty?` method was being called on an object w/o that method.