### PR TITLE
[Delivers #107501786] hashdiff numerics

### DIFF
--- a/app/decorators/hash_diff_decorator/base.rb
+++ b/app/decorators/hash_diff_decorator/base.rb
@@ -19,14 +19,20 @@ module HashDiffDecorator
     def diff_val(val)
       if val.nil?
         "[nil]"
-      elsif val.is_a?(Fixnum)
-        val.to_s
       elsif val.is_a?(Numeric)
-        format('%.2f', val)
+        diff_numeric(val)
       elsif val.empty?
         "[empty]"
       else
         val.inspect
+      end
+    end
+
+    def diff_numeric(val)
+      if val.is_a?(Fixnum)
+        val.to_s
+      elsif val.is_a?(Numeric)
+        format("%.2f", val)
       end
     end
   end

--- a/app/decorators/hash_diff_decorator/base.rb
+++ b/app/decorators/hash_diff_decorator/base.rb
@@ -19,6 +19,8 @@ module HashDiffDecorator
     def diff_val(val)
       if val.nil?
         "[nil]"
+      elsif val.is_a?(Fixnum)
+        val.to_s
       elsif val.is_a?(Numeric)
         format('%.2f', val)
       elsif val.empty?

--- a/app/decorators/hash_diff_decorator/base.rb
+++ b/app/decorators/hash_diff_decorator/base.rb
@@ -21,7 +21,7 @@ module HashDiffDecorator
         "[nil]"
       elsif val.is_a?(Numeric)
         diff_numeric(val)
-      elsif val.empty?
+      elsif val.try(:empty?)
         "[empty]"
       else
         val.inspect

--- a/app/decorators/hash_diff_decorator/base.rb
+++ b/app/decorators/hash_diff_decorator/base.rb
@@ -19,10 +19,10 @@ module HashDiffDecorator
     def diff_val(val)
       if val.nil?
         "[nil]"
-      elsif val.empty?
-        "[empty]"
       elsif val.is_a?(Numeric)
         format('%.2f', val)
+      elsif val.empty?
+        "[empty]"
       else
         val.inspect
       end

--- a/spec/decorators/hash_diff_decorator_spec.rb
+++ b/spec/decorators/hash_diff_decorator_spec.rb
@@ -27,7 +27,9 @@ describe HashDiffDecorator do
 
     it "renders numeric events" do
       output = HashDiffDecorator.html_for(['~', 'a_number', 456, 123])
-      expect(output).to eq("<code>a_number</code> was changed from <code>456.00</code> to <code>123.00</code>")
+      expect(output).to eq("<code>a_number</code> was changed from <code>456</code> to <code>123</code>")
+      output = HashDiffDecorator.html_for(['~', 'a_float', 123.0, 456.9])
+      expect(output).to eq("<code>a_float</code> was changed from <code>123.00</code> to <code>456.90</code>")
     end
   end
 end

--- a/spec/decorators/hash_diff_decorator_spec.rb
+++ b/spec/decorators/hash_diff_decorator_spec.rb
@@ -24,5 +24,10 @@ describe HashDiffDecorator do
       output = HashDiffDecorator.html_for(['~', 'foo', '', 'bar'])
       expect(output).to eq("<code>foo</code> was changed from <code>[empty]</code> to <code>&quot;bar&quot;</code>")
     end
+
+    it "renders numeric events" do
+      output = HashDiffDecorator.html_for(['~', 'a_number', 456, 123])
+      expect(output).to eq("<code>a_number</code> was changed from <code>456.00</code> to <code>123.00</code>")
+    end
   end
 end


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/107501786

Treat `Fixnum` numeric objects like integers, not floats.

You should see this in action on the `/proposals/:id/history` endpoint. Id values and other integers should display as `123` (integers) not as `123.00` (floats).