### PR TITLE
[Delivers #107421592] Use HAML instead of markdown in view partial

### DIFF
--- a/app/views/proposals/index.html.erb
+++ b/app/views/proposals/index.html.erb
@@ -23,7 +23,6 @@
     </div>
   </div>
 
-
   <div class="row past-pr">
     <div class="col-md-12">
       <h3>Recently Completed Purchase Requests</h3>

--- a/app/views/shared/formatter/_review_status.html.haml
+++ b/app/views/shared/formatter/_review_status.html.haml
@@ -1,10 +1,10 @@
--#   This snippet describes who needs to review a proposal. It needs access to both "proposal" and "current_user"
-
 - approvers = object.currently_awaiting_approvers
 
 - if object.pending? && approvers.include?(current_user)
-  %p *Please review*
+  %p
+    %strong Please review
 - elsif object.pending?
-  %p _Waiting for review from: #{approvers.map(&:full_name).join(', ')}_
+  %p
+    %em Waiting for review from: #{approvers.map(&:full_name).join(', ')}
 - else
   = object.status.titlecase


### PR DESCRIPTION
To QA: visit proposals index and see that the "status" column is HTML, not non-interpreted markdown.

Story: https://www.pivotaltracker.com/story/show/107421592