### PR TITLE
Include cancellation reason in email

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -42,7 +42,7 @@ class ProposalsController < ApplicationController
 
       flash[:success] = "Your request has been cancelled"
       redirect_to proposal_path(proposal)
-      Dispatcher.new.deliver_cancellation_emails(proposal)
+      Dispatcher.new.deliver_cancellation_emails(proposal, params[:reason_input])
     else
       redirect_to(
         cancel_form_proposal_path(params[:id]),

--- a/app/helpers/communicart_mailer_helper.rb
+++ b/app/helpers/communicart_mailer_helper.rb
@@ -26,15 +26,28 @@ module CommunicartMailerHelper
     approve_proposal_url(proposal, opts)
   end
 
-  def observer_text
-    text = "You have been added as a subscriber to this request"
-    adder = @observation.created_by
-    if adder
-      text << " by #{adder.full_name}"
-    end
-    if @reason && !@reason.blank?
-      text << " with given reason '#{@reason}'"
-    end
+  def cancellation_text(proposal, reason = nil)
+    text = "The request, #{proposal.name} (#{proposal.public_id}), has been cancelled"
+    add_reason(text, reason)
     text + '.'
+  end
+
+  def observer_text(observation, reason = nil)
+    text = "You have been added as a subscriber to this request"
+    add_author(text, observation.created_by)
+    add_reason(text, reason)
+    text + '.'
+  end
+
+  def add_author(text, user)
+    if user
+      text << " by #{user.full_name}"
+    end
+  end
+
+  def add_reason(text, reason)
+    if reason.present?
+      text << " with given reason '#{reason}'"
+    end
   end
 end

--- a/app/helpers/communicart_mailer_helper.rb
+++ b/app/helpers/communicart_mailer_helper.rb
@@ -26,7 +26,7 @@ module CommunicartMailerHelper
     approve_proposal_url(proposal, opts)
   end
 
-  def cancellation_text(proposal, reason = nil)
+  def cancellation_text(proposal, reason)
     text = "The request, #{proposal.name} (#{proposal.public_id}), has been cancelled"
     add_reason(text, reason)
     text + '.'

--- a/app/mailers/communicart_mailer.rb
+++ b/app/mailers/communicart_mailer.rb
@@ -51,9 +51,18 @@ class CommunicartMailer < ApplicationMailer
       proposal: proposal
     )
   end
-  alias_method :cancellation_email, :general_proposal_email
+
   alias_method :proposal_observer_email, :general_proposal_email
   alias_method :new_attachment_email, :general_proposal_email
+
+  def cancellation_email(to_email, proposal, reason = nil)
+    @reason = reason
+
+    send_proposal_email(
+      to_email: to_email,
+      proposal: proposal,
+    )
+  end
 
   def proposal_created_confirmation(proposal)
     send_proposal_email(

--- a/app/views/communicart_mailer/cancellation_email.html.haml
+++ b/app/views/communicart_mailer/cancellation_email.html.haml
@@ -2,7 +2,7 @@
   %p
     Hello,
     %br
-    The request, #{@proposal.name} (#{@proposal.public_id}), has been cancelled.
+    = cancellation_text(@proposal, @reason)
 
 %p
   %strong

--- a/app/views/communicart_mailer/on_observer_added.html.haml
+++ b/app/views/communicart_mailer/on_observer_added.html.haml
@@ -1,4 +1,4 @@
 .alert.alert-notice
-  = observer_text
+  = observer_text(@observation, @reason)
 - proposal = @observation.proposal
 = client_partial(proposal.client, 'proposal_mail', locals: {proposal: proposal, title: "Purchase Request"})

--- a/app/views/communicart_mailer/on_observer_added.text.erb
+++ b/app/views/communicart_mailer/on_observer_added.text.erb
@@ -1,3 +1,3 @@
-= observer_text
+<%= observer_text(@observation, @reason) %>
 
 View Request: <%= proposal_url(@observation.proposal) %>

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -39,11 +39,11 @@ class Dispatcher
     end
   end
 
-  def deliver_cancellation_emails(proposal)
+  def deliver_cancellation_emails(proposal, reason = nil)
     cancellation_notification_recipients = active_approvers(proposal) + active_observers(proposal)
 
     cancellation_notification_recipients.each do |recipient|
-      CommunicartMailer.cancellation_email(recipient.email_address, proposal).deliver_later
+      CommunicartMailer.cancellation_email(recipient.email_address, proposal, reason).deliver_later
     end
 
     CommunicartMailer.cancellation_confirmation(proposal).deliver_later

--- a/spec/lib/dispatcher_spec.rb
+++ b/spec/lib/dispatcher_spec.rb
@@ -55,13 +55,26 @@ describe Dispatcher do
       dispatcher.deliver_cancellation_emails(proposal)
     end
 
+    it "sends the reason to the cancellation email if there is one" do
+      proposal = create(:proposal, :with_approver)
+      approver = proposal.approvers.first
+      reason = "reason for cancellation"
+      allow(CommunicartMailer).to receive(:cancellation_email).
+        with(approver.email_address, proposal, reason).
+        and_return(mock_deliverer)
+
+      expect(mock_deliverer).to receive(:deliver_later).once
+
+      dispatcher.deliver_cancellation_emails(proposal, reason)
+    end
+
     it "sends an email to each actionable approver" do
       allow(CommunicartMailer).to receive(:cancellation_email).and_return(mock_deliverer)
       expect(serial_proposal.approvers.count).to eq 2
       expect(mock_deliverer).to receive(:deliver_later).once
 
       dispatcher.deliver_cancellation_emails(serial_proposal)
-    end 
+    end
 
     it "sends a confirmation email to the requester" do
       allow(CommunicartMailer).to receive(:cancellation_confirmation).and_return(mock_deliverer)

--- a/spec/lib/dispatcher_spec.rb
+++ b/spec/lib/dispatcher_spec.rb
@@ -55,7 +55,7 @@ describe Dispatcher do
       dispatcher.deliver_cancellation_emails(proposal)
     end
 
-    it "sends the reason to the cancellation email if there is one" do
+    it "sends the reason to the cancellation email" do
       proposal = create(:proposal, :with_approver)
       approver = proposal.approvers.first
       reason = "reason for cancellation"

--- a/spec/mailers/communicart_mailer_spec.rb
+++ b/spec/mailers/communicart_mailer_spec.rb
@@ -264,7 +264,7 @@ describe CommunicartMailer do
   end
 
   describe "cancellation_email" do
-    it "includes the cancellation reason, if there is one" do
+    it "includes the cancellation reason" do
       user = create(:user)
       proposal = create(:proposal, requester: user)
       reason = "cancellation reason"
@@ -273,32 +273,6 @@ describe CommunicartMailer do
 
       expect(mail.body.encoded).to include(
         "has been cancelled with given reason '#{reason}'."
-      )
-    end
-
-    it "does not include the cancellation reason if there is not one" do
-      user = create(:user)
-      proposal = create(:proposal, requester: user)
-
-      mail = CommunicartMailer.cancellation_email(user.email_address, proposal)
-
-      expect(mail.body.encoded).to include(
-        "The request, #{proposal.name} (#{proposal.public_id}), has been cancelled."
-      )
-      expect(mail.body.encoded).not_to include(
-        "has been cancelled with given reason"
-      )
-    end
-
-    it "does not include the cancellation reason if it is an empty string" do
-      user = create(:user)
-      proposal = create(:proposal, requester: user)
-      reason = ""
-
-      mail = CommunicartMailer.cancellation_email(user.email_address, proposal, reason)
-
-      expect(mail.body.encoded).not_to include(
-        "has been cancelled with given reason"
       )
     end
   end

--- a/spec/mailers/communicart_mailer_spec.rb
+++ b/spec/mailers/communicart_mailer_spec.rb
@@ -263,6 +263,46 @@ describe CommunicartMailer do
     end
   end
 
+  describe "cancellation_email" do
+    it "includes the cancellation reason, if there is one" do
+      user = create(:user)
+      proposal = create(:proposal, requester: user)
+      reason = "cancellation reason"
+
+      mail = CommunicartMailer.cancellation_email(user.email_address, proposal, reason)
+
+      expect(mail.body.encoded).to include(
+        "has been cancelled with given reason '#{reason}'."
+      )
+    end
+
+    it "does not include the cancellation reason if there is not one" do
+      user = create(:user)
+      proposal = create(:proposal, requester: user)
+
+      mail = CommunicartMailer.cancellation_email(user.email_address, proposal)
+
+      expect(mail.body.encoded).to include(
+        "The request, #{proposal.name} (#{proposal.public_id}), has been cancelled."
+      )
+      expect(mail.body.encoded).not_to include(
+        "has been cancelled with given reason"
+      )
+    end
+
+    it "does not include the cancellation reason if it is an empty string" do
+      user = create(:user)
+      proposal = create(:proposal, requester: user)
+      reason = ""
+
+      mail = CommunicartMailer.cancellation_email(user.email_address, proposal, reason)
+
+      expect(mail.body.encoded).not_to include(
+        "has been cancelled with given reason"
+      )
+    end
+  end
+
   describe 'proposal_observer_email' do
     let(:observation) { proposal.add_observer('observer1@example.com') }
     let(:observer) { observation.user }


### PR DESCRIPTION
* Include reason if there is one
* Story: https://www.pivotaltracker.com/story/show/101131916

To QA: 

scenario 1:
create a proposal with an approver with a non-pending approval status (aka - approver knows about proposal)
cancel the proposal as a requester WITH a reason
email to approver SHOULD include the reason