### PR TITLE
[Delivers #104744396] allow Observer to delete themselves from a Proposal

### DIFF
--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -13,7 +13,7 @@ class ObservationsController < ApplicationController
   def destroy
     proposal = observation.proposal
     if current_user == observation.user
-      redirect_path = "/proposals"
+      redirect_path = proposals_path
     else
       redirect_path = proposal_path(proposal)
     end

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -18,7 +18,7 @@ class ObservationsController < ApplicationController
       redirect_path = proposal_path(proposal)
     end
     observation.destroy
-    flash[:success] = "Deleted Observation for #{proposal.public_id}"
+    flash[:success] = "Removed Observation for #{proposal.public_id}"
     redirect_to redirect_path
   end
 

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -11,9 +11,15 @@ class ObservationsController < ApplicationController
   end
 
   def destroy
-    self.observation.destroy
-    flash[:success] = "Deleted Observation"
-    redirect_to proposal_path(self.observation.proposal_id)
+    proposal = observation.proposal
+    if current_user == observation.user
+      redirect_path = "/proposals"
+    else
+      redirect_path = proposal_path(proposal)
+    end
+    observation.destroy
+    flash[:success] = "Deleted Observation for #{proposal.public_id}"
+    redirect_to redirect_path
   end
 
   protected

--- a/app/policies/observation_policy.rb
+++ b/app/policies/observation_policy.rb
@@ -11,7 +11,7 @@ class ObservationPolicy
   end
 
   def can_destroy!
-    self.can_show_proposal!
+    self.can_show_proposal! || user_is_observer!
   end
 
   protected
@@ -19,5 +19,9 @@ class ObservationPolicy
   def can_show_proposal!
     policy = PolicyFinder.policy_for(@user, @observation.proposal)
     policy.can_show!
+  end
+
+  def user_is_observer!
+    @user == @observation.user
   end
 end

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -32,7 +32,7 @@
   .row
     = client_partial(@proposal.client, 'proposal_properties', locals: {proposal: @proposal })
   .row
-    %table.tabular-data
+    %table.tabular-data.observers
       %thead
         %tr.header
           %th{colspan: "2"}

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -46,7 +46,7 @@
               = "(#{role_str})" if role_str
             %td.righted
               - if observation && policy(observation).can_destroy?
-                = button_to "Delete", proposal_observation_path(@proposal, observation), method: :delete, data: {confirm: "Are you sure?"}
+                = button_to "Remove", proposal_observation_path(@proposal, observation), method: :delete, data: {confirm: "Are you sure?"}
         - if policy(Observation.new(proposal: @proposal)).can_create?
           %tr.add-more-row
             %td{colspan: 2}

--- a/spec/features/observer_spec.rb
+++ b/spec/features/observer_spec.rb
@@ -88,9 +88,9 @@ describe "observers" do
 
     login_as(observer)
     visit "/proposals/#{proposal.id}"
-    delete_button = find('table.observers .button_to input[value="Delete"]')
+    delete_button = find('table.observers .button_to input[value="Remove"]')
     delete_button.click
-    expect(page).to have_content("Deleted Observation for ")
+    expect(page).to have_content("Removed Observation for ")
   end
 
   # adapted from http://stackoverflow.com/a/25047358

--- a/spec/features/observer_spec.rb
+++ b/spec/features/observer_spec.rb
@@ -54,8 +54,8 @@ describe "observers" do
   end
 
   it "hides the reason field until a new observer is selected", js: true do
-    proposal = FactoryGirl.create(:proposal)
-    observer = FactoryGirl.create(:user)
+    proposal = create(:proposal)
+    observer = create(:user)
     login_as(proposal.requester)
 
     visit "/proposals/#{proposal.id}"
@@ -66,8 +66,8 @@ describe "observers" do
   end
 
   it "disables the submit button until a new observer is selected", js: true do
-    proposal = FactoryGirl.create(:proposal)
-    observer = FactoryGirl.create(:user)
+    proposal = create(:proposal)
+    observer = create(:user)
     login_as(proposal.requester)
 
     visit "/proposals/#{proposal.id}"
@@ -78,8 +78,8 @@ describe "observers" do
   end
 
   it "observer can delete themselves as observer" do
-    proposal = FactoryGirl.create(:proposal)
-    observer = FactoryGirl.create(:user, client_slug: nil)
+    proposal = create(:proposal)
+    observer = create(:user, client_slug: nil)
 
     login_as(proposal.requester)
     visit "/proposals/#{proposal.id}"

--- a/spec/features/observer_spec.rb
+++ b/spec/features/observer_spec.rb
@@ -77,6 +77,22 @@ describe "observers" do
     expect(submit_button).to_not be_disabled
   end
 
+  it "observer can delete themselves as observer" do
+    proposal = FactoryGirl.create(:proposal)
+    observer = FactoryGirl.create(:user, client_slug: nil)
+
+    login_as(proposal.requester)
+    visit "/proposals/#{proposal.id}"
+    select observer.email_address, from: 'observation_user_email_address'
+    click_on 'Add an Observer'
+
+    login_as(observer)
+    visit "/proposals/#{proposal.id}"
+    delete_button = find('table.observers .button_to input[value="Delete"]')
+    delete_button.click
+    expect(page).to have_content("Deleted Observation for ")
+  end
+
   # adapted from http://stackoverflow.com/a/25047358
   def fill_in_selectized(key, *values)
     values.flatten.each do |value|


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/104744396

Enables **Delete** button for Observers to remove themselves from a Proposal.

Testing:

1. Login as User A
1. Create Proposal
1. Add User B as an Observer
1. Login as User B
1. Navigate to the Proposal
1. Click Delete next to User B's name
1. Verify success message says "Deleted Observation for {Proposal.public_id}"