### PR TITLE
[Delivers #87947800] myusa first last

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -106,7 +106,9 @@ class User < ActiveRecord::Base
 
   def self.from_oauth_hash(auth_hash)
     user_data = auth_hash.extra.raw_info.to_hash
-    self.find_or_create_by(email_address: user_data['email'])
+    user = self.for_email(user_data['email'])
+    user.update_attributes(first_name: user_data['first_name'], last_name: user_data['last_name'])
+    user
   end
 
   def role_on(proposal)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,7 +107,9 @@ class User < ActiveRecord::Base
   def self.from_oauth_hash(auth_hash)
     user_data = auth_hash.extra.raw_info.to_hash
     user = self.for_email(user_data['email'])
-    user.update_attributes(first_name: user_data['first_name'], last_name: user_data['last_name'])
+    if user_data['first_name'].present? && user_data['last_name'].present?
+      user.update_attributes(first_name: user_data['first_name'], last_name: user_data['last_name'])
+    end
     user
   end
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,7 +4,7 @@ MYUSA_URL = ENV['MYUSA_URL'] || 'https://alpha.my.usa.gov'
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :myusa, MYUSA_KEY, MYUSA_SECRET, {
-    scope: 'profile.email',
+    scope: 'profile.email profile.first_name profile.last_name',
     client_options: {
       site: MYUSA_URL,
       token_url: "/oauth/authorize"

--- a/spec/features/link_to_new_proposal_spec.rb
+++ b/spec/features/link_to_new_proposal_spec.rb
@@ -6,7 +6,7 @@ describe "Link to New Proposal" do
   end
 
   it "is not visible if the user has a random client" do
-    expect(Proposal).to receive(:client_slugs).and_return(['something else'])
+    expect(Proposal).to receive(:client_slugs).and_return(['something else']).twice
     login_as(create(:user, client_slug: "something else"))
     visit '/'
     expect(page).not_to have_content('New NCR Request')

--- a/spec/requests/set_user_after_login_spec.rb
+++ b/spec/requests/set_user_after_login_spec.rb
@@ -11,7 +11,10 @@ describe 'User creation when logging in with Oauth to view a protected page' do
       get '/auth/myusa/callback'
     }.to change { User.count }.by(1)
 
-    expect(User.last.email_address).to eq('george-test@example.com')
+    new_user = User.last
+    expect(new_user.email_address).to eq('george-test@example.com')
+    expect(new_user.first_name).to eq("Georgie")
+    expect(new_user.last_name).to eq("Jetsonian")
   end
 
   it 'does not create a user if the current user already exists' do

--- a/spec/requests/set_user_after_login_spec.rb
+++ b/spec/requests/set_user_after_login_spec.rb
@@ -17,6 +17,14 @@ describe 'User creation when logging in with Oauth to view a protected page' do
     expect(new_user.last_name).to eq("Jetsonian")
   end
 
+  it "absence of first/last name does not throw error" do
+    user = StructUser.new('somebody@example.com', nil, nil)
+    setup_mock_auth(:myusa, user)
+    expect {
+      get '/auth/myusa/callback'
+    }.to change { User.count }.by(1)
+  end
+
   it 'does not create a user if the current user already exists' do
     create(:user, email_address: 'george-test@example.com')
 


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/87947800

If the User has configured MyUSA to share first and last name, the app will now use those values to populate the local User record.

Testing:

1. Logout of app
1. Logout of https://alpha.my.usa.gov/
1. Login to app
1. On MyUSA confirmation page, select **yes** for first and last names.
1. Confirm name is populated on app login