### PR TITLE
ensure no calls to external sites are made from tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,9 +78,10 @@ group :test do
   gem 'capybara'
   gem 'codeclimate-test-reporter'
   gem 'poltergeist'
-  gem "shoulda-matchers"
+  gem 'shoulda-matchers'
   gem 'simplecov'
   gem 'timecop'
+  gem 'webmock'
   gem 'zonebie'
 
   # For better test reporting in CircleCI

--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ group :test do
   gem 'shoulda-matchers'
   gem 'simplecov'
   gem 'timecop'
-  gem 'webmock'
+  gem 'webmock', require: false
   gem 'zonebie'
 
   # For better test reporting in CircleCI

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,8 @@ GEM
     coffee-script-source (1.9.1.1)
     colorize (0.7.7)
     columnize (0.9.0)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     css_parser (1.3.7)
       addressable
     daemons (1.2.3)
@@ -398,6 +400,7 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
+    safe_yaml (1.0.4)
     sass (3.4.18)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -443,6 +446,9 @@ GEM
     uniform_notifier (1.9.0)
     validates_email_format_of (1.6.3)
       i18n
+    webmock (1.21.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
     websocket-driver (0.6.2)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -528,6 +534,7 @@ DEPENDENCIES
   turbolinks
   uglifier
   validates_email_format_of
+  webmock
   workflow
   zonebie
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,10 @@ end
 require 'zonebie'
 Zonebie.set_random_timezone
 
+require 'webmock/rspec'
+# localhost needed for omniauth
+WebMock.disable_net_connect!(allow_localhost: true)
+
 require 'rack_session_access/capybara'
 
 require 'capybara/poltergeist'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,7 @@ Zonebie.set_random_timezone
 
 require 'webmock/rspec'
 # localhost needed for omniauth
-WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(allow_localhost: true, allow: 'codeclimate.com:443')
 
 require 'rack_session_access/capybara'
 


### PR DESCRIPTION
I've used WebMock in a bunch of other projects, and it's really useful to ensure that you're not accidentally making calls to an external API (or SMTP, etc.) from the test suite. The [discussion](https://18f.slack.com/archives/cap/p1446842150000127) around API calls to MyUSA reminded me of this.