### PR TITLE
[Delivers #107603900] User factory client_slug now defaults to nil

### DIFF
--- a/spec/controllers/ncr/work_orders_controller_spec.rb
+++ b/spec/controllers/ncr/work_orders_controller_spec.rb
@@ -20,7 +20,7 @@ describe Ncr::WorkOrdersController do
         }
       }
 
-      login_as(create(:user, client_slug: 'ncr'))
+      login_as(create(:user, client_slug: "ncr"))
 
       post :create, params
       ncr = Ncr::WorkOrder.order(:id).last

--- a/spec/factories/ncr/work_orders.rb
+++ b/spec/factories/ncr/work_orders.rb
@@ -17,7 +17,7 @@ FactoryGirl.define do
     end
 
     trait :with_approvers do
-      association :proposal, :with_serial_approvers, flow: 'linear', client_slug: 'ncr'
+      association :proposal, :with_serial_approvers, flow: 'linear', client_slug: "ncr"
       after :create do |wo|
         wo.approving_official_email = wo.approving_official.email_address
       end

--- a/spec/factories/ncr/work_orders.rb
+++ b/spec/factories/ncr/work_orders.rb
@@ -17,7 +17,7 @@ FactoryGirl.define do
     end
 
     trait :with_approvers do
-      association :proposal, :with_serial_approvers, flow: 'linear'
+      association :proposal, :with_serial_approvers, flow: 'linear', client_slug: 'ncr'
       after :create do |wo|
         wo.approving_official_email = wo.approving_official.email_address
       end

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     association :requester, factory: :user
 
     transient do
-      client_slug { ENV['CLIENT_SLUG_DEFAULT'] || 'ncr' }
+      client_slug { nil }
       delegate nil
       approver_user nil
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :user do
-    client_slug { ENV['CLIENT_SLUG_DEFAULT'] || 'ncr' }
+    client_slug { ENV['CLIENT_SLUG_DEFAULT'] || nil }
     sequence(:email_address) {|n| "user#{n}@example.com" }
     sequence(:first_name) {|n| "FirstName#{n}" }
     sequence(:last_name) {|n| "LastName#{n}" }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :user do
-    client_slug { ENV['CLIENT_SLUG_DEFAULT'] || nil }
+    client_slug { nil }
     sequence(:email_address) {|n| "user#{n}@example.com" }
     sequence(:first_name) {|n| "FirstName#{n}" }
     sequence(:last_name) {|n| "LastName#{n}" }

--- a/spec/features/client_slug_authz_spec.rb
+++ b/spec/features/client_slug_authz_spec.rb
@@ -15,7 +15,7 @@ describe "client_slug confers authz rules" do
 
   it "allows Admin role" do
     user = create(:user, :admin, client_slug: '')
-    approver = create(:user, client_slug: 'ncr')
+    approver = create(:user, client_slug: "ncr")
     login_as(user)
     visit '/ncr/work_orders/new'
     expect(page.status_code).to eq(200)
@@ -24,8 +24,8 @@ describe "client_slug confers authz rules" do
   end
 
   it "allows same client_slug to create" do
-    user = create(:user, client_slug: 'ncr')
-    approver = create(:user, client_slug: 'ncr')
+    user = create(:user, client_slug: "ncr")
+    approver = create(:user, client_slug: "ncr")
     login_as(user)
     visit '/ncr/work_orders/new'
     expect(page.status_code).to eq(200)
@@ -34,9 +34,9 @@ describe "client_slug confers authz rules" do
   end
 
   it "rejects different client_slug from viewing existing proposal" do
-    ncr_user = create(:user, client_slug: 'ncr')
+    ncr_user = create(:user, client_slug: "ncr")
     nil_user = create(:user, client_slug: '')
-    approver = create(:user, client_slug: 'ncr')
+    approver = create(:user, client_slug: "ncr")
     login_as(ncr_user)
     visit '/ncr/work_orders/new'
     submit_ba60_work_order(approver)
@@ -47,9 +47,9 @@ describe "client_slug confers authz rules" do
   end
 
   it "rejects same client_slug non-subscriber to view existing proposal" do
-    ncr_user = create(:user, client_slug: 'ncr')
-    ncr_user2 = create(:user, client_slug: 'ncr')
-    approver = create(:user, client_slug: 'ncr')
+    ncr_user = create(:user, client_slug: "ncr")
+    ncr_user2 = create(:user, client_slug: "ncr")
+    approver = create(:user, client_slug: "ncr")
     login_as(ncr_user)
     visit '/ncr/work_orders/new'
     submit_ba60_work_order(approver)
@@ -60,9 +60,9 @@ describe "client_slug confers authz rules" do
   end
 
   it "rejects subscriber trying to add user with non-client_slug as observer" do
-    ncr_user = create(:user, client_slug: 'ncr')
+    ncr_user = create(:user, client_slug: "ncr")
     gsa_user = create(:user, client_slug: 'gsa18f')
-    approver = create(:user, client_slug: 'ncr')
+    approver = create(:user, client_slug: "ncr")
     login_as(ncr_user)
     visit '/ncr/work_orders/new'
     submit_ba60_work_order(approver)

--- a/spec/features/inactive_users_spec.rb
+++ b/spec/features/inactive_users_spec.rb
@@ -1,8 +1,8 @@
 feature "Inactive users" do
   scenario "not included in approving official dropdown" do
-    inactive_approving_official = create(:user, :inactive)
-    active_approving_official = create(:user, :active)
-    user = create(:user)
+    inactive_approving_official = create(:user, :inactive, client_slug: 'ncr')
+    active_approving_official = create(:user, :active, client_slug: 'ncr')
+    user = create(:user, client_slug: 'ncr')
     login_as(user)
 
     visit new_ncr_work_order_path

--- a/spec/features/inactive_users_spec.rb
+++ b/spec/features/inactive_users_spec.rb
@@ -1,8 +1,8 @@
 feature "Inactive users" do
   scenario "not included in approving official dropdown" do
-    inactive_approving_official = create(:user, :inactive, client_slug: 'ncr')
-    active_approving_official = create(:user, :active, client_slug: 'ncr')
-    user = create(:user, client_slug: 'ncr')
+    inactive_approving_official = create(:user, :inactive, client_slug: "ncr")
+    active_approving_official = create(:user, :active, client_slug: "ncr")
+    user = create(:user, client_slug: "ncr")
     login_as(user)
 
     visit new_ncr_work_order_path

--- a/spec/features/ncr/work_orders/approver_edit_spec.rb
+++ b/spec/features/ncr/work_orders/approver_edit_spec.rb
@@ -5,19 +5,17 @@ feature 'Approver edits NCR work order' do
     end
   end
 
-  let(:work_order) { create(:ncr_work_order, :with_approvers) }
-  let(:ncr_proposal) { work_order.proposal }
-
   scenario 'keeps track of the modification' do
-    approver = ncr_proposal.approvers.first
+    work_order = create(:ncr_work_order, :with_approvers)
+    approver = work_order.proposal.approvers.first
     login_as(approver)
 
     visit "/ncr/work_orders/#{work_order.id}/edit"
     fill_in 'CL number', with: 'CL1234567'
     click_on 'Update'
 
-    ncr_proposal.reload
-    update_comments = ncr_proposal.comments.update_comments
+    work_order.proposal.reload
+    update_comments = work_order.proposal.comments.update_comments
     expect(update_comments.count).to eq(1)
     # properly attributed
     update_comment = update_comments.first

--- a/spec/features/ncr/work_orders/comment_spec.rb
+++ b/spec/features/ncr/work_orders/comment_spec.rb
@@ -1,7 +1,7 @@
 feature 'Delegates for NCR work order' do
   let(:work_order) { create(:ncr_work_order, description: 'test') }
   let(:proposal) { work_order.proposal }
-  let(:delegate) { create(:user, client_slug: 'ncr') }
+  let(:delegate) { create(:user, client_slug: "ncr") }
 
   scenario 'adds current user to the observers list when commenting' do
     work_order.setup_approvals_and_observers

--- a/spec/features/ncr/work_orders/create_spec.rb
+++ b/spec/features/ncr/work_orders/create_spec.rb
@@ -132,10 +132,9 @@ feature 'Creating an NCR work order' do
 
     scenario 'defaults to the approver from the last request' do
       login_as(requester)
-      proposal = create(:proposal, :with_serial_approvers, requester: requester)
+      proposal = create(:proposal, :with_serial_approvers, requester: requester, client_slug: 'ncr')
       visit '/ncr/work_orders/new'
-      expect(find_field("Approving official's email address").value).to eq(
-        proposal.approvers.first.email_address)
+      expect(find_field("Approving official's email address").value).to eq(proposal.approvers.first.email_address)
     end
 
     scenario 'requires a project_title' do

--- a/spec/features/ncr/work_orders/create_spec.rb
+++ b/spec/features/ncr/work_orders/create_spec.rb
@@ -28,7 +28,7 @@ feature 'Creating an NCR work order' do
     let(:ncr_helper_class) { Class.new { extend Ncr::WorkOrdersHelper } }
 
     scenario 'saves a Proposal with the attributes' do
-      approver = create(:user)
+      approver = create(:user, client_slug: 'ncr')
       login_as(requester)
       expect(Dispatcher).to receive(:deliver_new_proposal_emails)
 
@@ -67,7 +67,7 @@ feature 'Creating an NCR work order' do
     end
 
     scenario 'saves a BA60 Proposal with the attributes' do
-      approver = create(:user)
+      approver = create(:user, client_slug: 'ncr')
       login_as(requester)
       expect(Dispatcher).to receive(:deliver_new_proposal_emails)
 
@@ -103,7 +103,7 @@ feature 'Creating an NCR work order' do
     scenario "does not show system approver emails as approver options", :js do
       expect(Ncr::WorkOrder.all_system_approver_emails.size).to eq 4
       login_as(requester)
-      approving_official = create(:user)
+      approving_official = create(:user, client_slug: 'ncr')
       visit "/ncr/work_orders/new"
       within(".ncr_work_order_approving_official_email") do
         find(".selectize-control").click
@@ -188,7 +188,7 @@ feature 'Creating an NCR work order' do
     end
 
     scenario "includes has overwritten field names" do
-      approver = create(:user)
+      approver = create(:user, client_slug: 'ncr')
       login_as(requester)
       visit '/ncr/work_orders/new'
       fill_in 'Project title', with: "buying stuff"
@@ -275,7 +275,7 @@ feature 'Creating an NCR work order' do
 
     context "selected common values on proposal page" do
       before do
-        approver = create(:user)
+        approver = create(:user, client_slug: 'ncr')
         login_as(requester)
         visit '/ncr/work_orders/new'
 

--- a/spec/features/ncr/work_orders/create_spec.rb
+++ b/spec/features/ncr/work_orders/create_spec.rb
@@ -13,7 +13,7 @@ feature 'Creating an NCR work order' do
 
   with_feature 'RESTRICT_ACCESS' do
     scenario 'requires a GSA email address' do
-      user = create(:user, email_address: 'intruder@example.com', client_slug: 'ncr')
+      user = create(:user, email_address: 'intruder@example.com', client_slug: "ncr")
       login_as(user)
 
       visit '/ncr/work_orders/new'
@@ -24,11 +24,11 @@ feature 'Creating an NCR work order' do
   end
 
   context 'when signed in as the requester' do
-    let(:requester) { create(:user, client_slug: 'ncr') }
+    let(:requester) { create(:user, client_slug: "ncr") }
     let(:ncr_helper_class) { Class.new { extend Ncr::WorkOrdersHelper } }
 
     scenario 'saves a Proposal with the attributes' do
-      approver = create(:user, client_slug: 'ncr')
+      approver = create(:user, client_slug: "ncr")
       login_as(requester)
       expect(Dispatcher).to receive(:deliver_new_proposal_emails)
 
@@ -53,7 +53,7 @@ feature 'Creating an NCR work order' do
       expect(proposal.name).to eq("buying stuff")
       expect(proposal.flow).to eq('linear')
       work_order = proposal.client_data
-      expect(work_order.client).to eq('ncr')
+      expect(work_order.client).to eq("ncr")
       expect(work_order.expense_type).to eq('BA80')
       expect(work_order.vendor).to eq('ACME')
       expect(work_order.amount).to eq(123.45)
@@ -67,7 +67,7 @@ feature 'Creating an NCR work order' do
     end
 
     scenario 'saves a BA60 Proposal with the attributes' do
-      approver = create(:user, client_slug: 'ncr')
+      approver = create(:user, client_slug: "ncr")
       login_as(requester)
       expect(Dispatcher).to receive(:deliver_new_proposal_emails)
 
@@ -103,7 +103,7 @@ feature 'Creating an NCR work order' do
     scenario "does not show system approver emails as approver options", :js do
       expect(Ncr::WorkOrder.all_system_approver_emails.size).to eq 4
       login_as(requester)
-      approving_official = create(:user, client_slug: 'ncr')
+      approving_official = create(:user, client_slug: "ncr")
       visit "/ncr/work_orders/new"
       within(".ncr_work_order_approving_official_email") do
         find(".selectize-control").click
@@ -132,7 +132,7 @@ feature 'Creating an NCR work order' do
 
     scenario 'defaults to the approver from the last request' do
       login_as(requester)
-      proposal = create(:proposal, :with_serial_approvers, requester: requester, client_slug: 'ncr')
+      proposal = create(:proposal, :with_serial_approvers, requester: requester, client_slug: "ncr")
       visit '/ncr/work_orders/new'
       expect(find_field("Approving official's email address").value).to eq(proposal.approvers.first.email_address)
     end
@@ -187,7 +187,7 @@ feature 'Creating an NCR work order' do
     end
 
     scenario "includes has overwritten field names" do
-      approver = create(:user, client_slug: 'ncr')
+      approver = create(:user, client_slug: "ncr")
       login_as(requester)
       visit '/ncr/work_orders/new'
       fill_in 'Project title', with: "buying stuff"
@@ -274,7 +274,7 @@ feature 'Creating an NCR work order' do
 
     context "selected common values on proposal page" do
       before do
-        approver = create(:user, client_slug: 'ncr')
+        approver = create(:user, client_slug: "ncr")
         login_as(requester)
         visit '/ncr/work_orders/new'
 

--- a/spec/features/ncr/work_orders/edit_spec.rb
+++ b/spec/features/ncr/work_orders/edit_spec.rb
@@ -8,7 +8,7 @@ feature 'Editing NCR work orders' do
   let(:work_order) { create(:ncr_work_order, description: 'test') }
 
   scenario 'current user is not the requester, approver, or observer' do
-    stranger = create(:user, client_slug: 'ncr')
+    stranger = create(:user, client_slug: "ncr")
     login_as(stranger)
 
     visit "/ncr/work_orders/#{work_order.id}/edit"

--- a/spec/features/ncr/work_orders/requester_edit_spec.rb
+++ b/spec/features/ncr/work_orders/requester_edit_spec.rb
@@ -7,7 +7,7 @@ feature 'Requester edits their NCR work order' do
 
   let(:work_order) { create(:ncr_work_order, description: 'test') }
   let(:ncr_proposal) { work_order.proposal }
-  let!(:approver) { create(:user, client_slug: 'ncr') }
+  let!(:approver) { create(:user, client_slug: "ncr") }
 
   before do
     work_order.setup_approvals_and_observers
@@ -59,7 +59,7 @@ feature 'Requester edits their NCR work order' do
   end
 
   scenario 'allows requester to change the approving official' do
-    approver = create(:user, client_slug: 'ncr')
+    approver = create(:user, client_slug: "ncr")
     old_approver = ncr_proposal.approvers.first
     expect(Dispatcher).to receive(:on_approver_removal).with(ncr_proposal, [old_approver])
     visit "/ncr/work_orders/#{work_order.id}/edit"

--- a/spec/features/ncr/work_orders/show_spec.rb
+++ b/spec/features/ncr/work_orders/show_spec.rb
@@ -29,7 +29,7 @@ describe "viewing a work order" do
   end
 
   it "does not show a edit link for non requester" do
-    ncr_proposal.set_requester(create(:user, client_slug: 'ncr'))
+    ncr_proposal.set_requester(create(:user, client_slug: "ncr"))
     visit "/proposals/#{ncr_proposal.id}"
     expect(page).not_to have_content('Modify Request')
   end

--- a/spec/features/observer_spec.rb
+++ b/spec/features/observer_spec.rb
@@ -79,7 +79,7 @@ describe "observers" do
 
   it "observer can delete themselves as observer" do
     proposal = create(:proposal)
-    observer = create(:user, client_slug: nil)
+    observer = create(:user)
 
     login_as(proposal.requester)
     visit "/proposals/#{proposal.id}"

--- a/spec/helpers/ncr/work_orders_helper_spec.rb
+++ b/spec/helpers/ncr/work_orders_helper_spec.rb
@@ -2,22 +2,22 @@ describe Ncr::WorkOrdersHelper do
   describe '#approver_options' do
     it 'includes existing users' do
       expect(helper.approver_options.size).to eq(0)
-      users = [create(:user, client_slug: 'ncr'), create(:user, client_slug: 'ncr')]
+      users = [create(:user, client_slug: "ncr"), create(:user, client_slug: "ncr")]
       expect(helper.approver_options).to include(*users.map(&:email_address))
     end
 
     it "does not include inactive users" do
-      inactive_approving_official = create(:user, :inactive, client_slug: 'ncr')
-      active_approving_official = create(:user, :active, client_slug: 'ncr')
+      inactive_approving_official = create(:user, :inactive, client_slug: "ncr")
+      active_approving_official = create(:user, :active, client_slug: "ncr")
 
       expect(helper.approver_options).to include(active_approving_official.email_address)
       expect(helper.approver_options).not_to include(inactive_approving_official.email_address)
     end
 
     it 'sorts the results' do
-      create(:user, email_address: 'b@example.com', client_slug: 'ncr')
-      create(:user, email_address: 'c@example.com', client_slug: 'ncr')
-      create(:user, email_address: 'a@example.com', client_slug: 'ncr')
+      create(:user, email_address: 'b@example.com', client_slug: "ncr")
+      create(:user, email_address: 'c@example.com', client_slug: "ncr")
+      create(:user, email_address: 'a@example.com', client_slug: "ncr")
       create(:user, email_address: 'd@example.com', client_slug: 'gsa18f')
       expect(helper.approver_options).to include(*%w(a@example.com b@example.com c@example.com))
       expect(helper.approver_options).not_to include(*%w(d@example.com))

--- a/spec/helpers/ncr/work_orders_helper_spec.rb
+++ b/spec/helpers/ncr/work_orders_helper_spec.rb
@@ -7,8 +7,8 @@ describe Ncr::WorkOrdersHelper do
     end
 
     it "does not include inactive users" do
-      inactive_approving_official = create(:user, :inactive)
-      active_approving_official = create(:user, :active)
+      inactive_approving_official = create(:user, :inactive, client_slug: 'ncr')
+      active_approving_official = create(:user, :active, client_slug: 'ncr')
 
       expect(helper.approver_options).to include(active_approving_official.email_address)
       expect(helper.approver_options).not_to include(inactive_approving_official.email_address)

--- a/spec/lib/dispatcher_spec.rb
+++ b/spec/lib/dispatcher_spec.rb
@@ -4,7 +4,7 @@ describe Dispatcher do
   describe '.deliver_new_proposal_emails' do
     it "uses the LinearDispatcher for linear approvals" do
       proposal.flow = 'linear'
-      expect(proposal).to receive(:client_data).and_return(double(client: 'ncr'))
+      expect(proposal).to receive(:client_data).and_return(double(client: "ncr"))
       expect_any_instance_of(LinearDispatcher).to receive(:deliver_new_proposal_emails).with(proposal)
       Dispatcher.deliver_new_proposal_emails(proposal)
     end

--- a/spec/lib/query/proposal/listing_spec.rb
+++ b/spec/lib/query/proposal/listing_spec.rb
@@ -14,7 +14,7 @@ describe Query::Proposal::Listing do
 
       context "with an arbitrary client" do
         before do
-          user.update_attribute(:client_slug, 'ncr')
+          user.update_attribute(:client_slug, "ncr")
           user.add_role('client_admin')
         end
 

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -164,7 +164,7 @@ describe Ncr::WorkOrder do
 
     it "respects user with same client_slug" do
       wo = create(:ba80_ncr_work_order)
-      user = create(:user, client_slug: 'ncr')
+      user = create(:user, client_slug: "ncr")
       expect(wo.slug_matches?(user)).to eq(true)
     end
   end

--- a/spec/policies/ncr/work_order_policy_spec.rb
+++ b/spec/policies/ncr/work_order_policy_spec.rb
@@ -15,7 +15,7 @@ describe Ncr::WorkOrderPolicy do
     end
 
     it "allows an observer to edit it" do
-      observer = create(:user, client_slug: 'ncr')
+      observer = create(:user, client_slug: "ncr")
       proposal.add_observer(observer)
       expect(subject).to permit(observer, work_order)
     end
@@ -32,7 +32,7 @@ describe Ncr::WorkOrderPolicy do
 
   permissions :can_create? do
     it "allows a user with an arbitrary email to create" do
-      user = User.new(email_address: 'user@example.com', client_slug: 'ncr')
+      user = User.new(email_address: 'user@example.com', client_slug: "ncr")
       work_order = Ncr::WorkOrder.new
       expect(subject).to permit(user, work_order)
     end
@@ -41,13 +41,13 @@ describe Ncr::WorkOrderPolicy do
       it "allows someone with a GSA email to create" do
         gsa_domain = "@example.net"
         stub_const("GsaPolicy::GSA_DOMAIN", gsa_domain)
-        user = User.new(email_address: "user#{gsa_domain}", client_slug: 'ncr')
+        user = User.new(email_address: "user#{gsa_domain}", client_slug: "ncr")
         work_order = Ncr::WorkOrder.new
         expect(subject).to permit(user, work_order)
       end
 
       it "doesn't allow someone with a non-GSA email to create" do
-        user = User.new(email_address: 'intruder@example.com', client_slug: 'ncr')
+        user = User.new(email_address: 'intruder@example.com', client_slug: "ncr")
         work_order = Ncr::WorkOrder.new
         expect(subject).not_to permit(user, work_order)
       end

--- a/spec/services/proposal_update_recorder_spec.rb
+++ b/spec/services/proposal_update_recorder_spec.rb
@@ -62,7 +62,7 @@ describe ProposalUpdateRecorder do
 
     it "does not send a comment email for the update comment to proposal listeners" do
       work_order = create(:ncr_work_order, vendor: "old")
-      listener = create(:user, client_slug: 'ncr')
+      listener = create(:user, client_slug: "ncr")
       work_order.proposal.add_observer(listener)
 
       work_order.vendor = "VenVenVen"

--- a/spec/services/proposal_update_recorder_spec.rb
+++ b/spec/services/proposal_update_recorder_spec.rb
@@ -62,7 +62,7 @@ describe ProposalUpdateRecorder do
 
     it "does not send a comment email for the update comment to proposal listeners" do
       work_order = create(:ncr_work_order, vendor: "old")
-      listener = create(:user)
+      listener = create(:user, client_slug: 'ncr')
       work_order.proposal.add_observer(listener)
 
       work_order.vendor = "VenVenVen"


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/107603900

Internal refactor to make User factory default to `client_slug: nil`

This makes our tests not assume `ncr` by default.

Opened in response to https://github.com/18F/C2/pull/772#discussion_r44179509