### PR TITLE
[Delivers #107609788] exclude Delegates from attachment notifications

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -99,6 +99,10 @@ class Proposal < ActiveRecord::Base
 
   alias_method :subscribers, :users
 
+  def users_except_delegates
+    users - delegates
+  end
+
   def root_step=(root)
     old_steps = self.steps.to_a
     step_list = root.pre_order_tree_traversal

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,7 @@ class User < ActiveRecord::Base
   has_many :proposals, foreign_key: "requester_id", dependent: :destroy
 
   has_many :outgoing_delegations, class_name: 'ApprovalDelegate', foreign_key: 'assigner_id'
+  has_many :outgoing_delegates, through: :outgoing_delegations, source: :assignee
 
   def self.active
     where(active: true)

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -30,7 +30,7 @@ class Dispatcher
   end
 
   def deliver_attachment_emails(proposal)
-    proposal.users.each do |user|
+    proposal.users_except_delegates.each do |user|
       approval = proposal.steps.find_by(user_id: user.id)
 
       if user_is_not_approver?(approval) || approver_knows_about_proposal?(approval)

--- a/spec/lib/dispatcher_spec.rb
+++ b/spec/lib/dispatcher_spec.rb
@@ -42,6 +42,18 @@ describe Dispatcher do
       dispatcher.deliver_attachment_emails(serial_proposal)
       expect(email_recipients).to_not include(serial_proposal.approvers.last.email_address)
     end
+
+    it "does not email delegates" do
+      wo = create(:ncr_work_order, :with_approvers)
+      tier_one_approver = wo.proposal.approvers.second
+      delegate_one = create(:user, client_slug: 'ncr')
+      delegate_two = create(:user, client_slug: 'ncr')
+      tier_one_approver.add_delegate(delegate_one)
+      tier_one_approver.add_delegate(delegate_two)
+      wo.proposal.individual_approvals.first.approve!
+      dispatcher.deliver_attachment_emails(wo.proposal)
+      expect(email_recipients).to_not include(delegate_one.email_address)
+    end
   end
 
   describe "#deliver_cancellation_emails" do

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -112,6 +112,15 @@ describe Proposal do
       proposal.add_observer(observer)
       expect(proposal.users).to eq [observer]
     end
+
+    it "can exclude delegates" do
+      delegate_one = create(:user)
+      delegate_two = create(:user)
+      proposal = create(:proposal, :with_approver)
+      proposal.approvers.first.add_delegate(delegate_one)
+      proposal.approvers.first.add_delegate(delegate_two)
+      expect(proposal.users).to match_array(proposal.users_except_delegates + [delegate_one, delegate_two])
+    end
   end
 
   describe '#root_step=' do

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -112,7 +112,17 @@ describe Proposal do
       proposal.add_observer(observer)
       expect(proposal.users).to eq [observer]
     end
+  end
 
+  describe "#eligible_observers" do
+    it "identifies eligible observers" do
+      observer = create(:user, client_slug: nil)
+      proposal = create(:proposal, requester: observer)
+      expect(proposal.eligible_observers.to_a).to include(observer)
+    end
+  end
+
+  describe "#users_except_delegates" do
     it "can exclude delegates" do
       delegate_one = create(:user)
       delegate_two = create(:user)
@@ -120,12 +130,6 @@ describe Proposal do
       proposal.approvers.first.add_delegate(delegate_one)
       proposal.approvers.first.add_delegate(delegate_two)
       expect(proposal.users).to match_array(proposal.users_except_delegates + [delegate_one, delegate_two])
-    end
-
-    it "identifies eligible observers" do
-      observer = create(:user, client_slug: nil)
-      proposal = create(:proposal, requester: observer)
-      expect(proposal.eligible_observers.to_a).to include(observer)
     end
   end
 


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/107609788

Do not send attachment notification emails to proposal delegates, even if they relate to the currently actionable approval/step.

Testing guidelines are listed in the Story (link above).