### PR TITLE
[Delivers #108012382] fix persistent flash message

### DIFF
--- a/app/controllers/ncr/work_orders_controller.rb
+++ b/app/controllers/ncr/work_orders_controller.rb
@@ -15,7 +15,7 @@ module Ncr
 
     def edit
       if self.proposal.approved?
-        flash[:warning] = "You are about to modify a fully approved request. Changes will be logged and sent to approvers, and this request may require re-approval, depending on the change."
+        flash.now[:warning] = "You are about to modify a fully approved request. Changes will be logged and sent to approvers, and this request may require re-approval, depending on the change."
       end
 
       super

--- a/app/controllers/use_case_controller.rb
+++ b/app/controllers/use_case_controller.rb
@@ -21,7 +21,7 @@ class UseCaseController < ApplicationController
       flash[:success] = "Proposal submitted!"
       redirect_to proposal
     else
-      flash[:error] = errors
+      flash.now[:error] = errors
       render :new
     end
   end

--- a/spec/features/ncr/work_orders/create_spec.rb
+++ b/spec/features/ncr/work_orders/create_spec.rb
@@ -92,6 +92,26 @@ feature 'Creating an NCR work order' do
       ]
     end
 
+    scenario "flash message on error does not persist" do
+      approver = create(:user, client_slug: "ncr")
+      login_as(requester)
+
+      visit '/ncr/work_orders/new'
+      fill_in 'Project title', with: "blue shells"
+      fill_in 'Description', with: "desc content"
+      choose 'BA60'
+      fill_in 'Vendor', with: 'Yoshi'
+      fill_in 'Amount', with: 123.45
+      fill_in 'Building number', with: Ncr::BUILDING_NUMBERS[0]
+      select Ncr::Organization.all[0], from: 'ncr_work_order_org_code'
+      click_on 'Submit for approval'
+
+      expect(page).to have_content("Approving official email can't be blank")
+
+      visit "/proposals"
+      expect(page).to_not have_content("Approving official email can't be blank")
+    end
+
     scenario 'shows the radio button' do
       login_as(requester)
       visit '/ncr/work_orders/new'

--- a/spec/features/ncr/work_orders/post_approval_modification_spec.rb
+++ b/spec/features/ncr/work_orders/post_approval_modification_spec.rb
@@ -59,6 +59,13 @@ describe "post-approval modification" do
     ))
   end
 
+  it "shows flash warning, only on edit page" do
+    visit "/ncr/work_orders/#{work_order.id}/edit"
+    expect(page).to have_content("You are about to modify a fully approved request")
+    click_on "Discard Changes"
+    expect(page).to_not have_content("You are about to modify a fully approved request")
+  end
+
   def approval_statuses
     linear_approval_statuses(work_order.proposal)
   end


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/108012382
Story: https://www.pivotaltracker.com/story/show/97035674

use `flash.now` to make sure warning appears only on the current page

To test this, attempt to modify an already fully-approved NCR request. On the edit page, there should be a warning about attempting to modify the request. When you click "Discard Changes" at the bottom of the page, the flash warning should not appear on the request view page.