### PR TITLE
[Delivers #107777486] disable Delete User action in /admin/users

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,4 +1,6 @@
 ActiveAdmin.register User do
+  actions :all, :except => [:destroy]
+
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
   permit_params :active, :first_name, :last_name, :email_address, :client_slug, role_ids: []

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register User do
-  actions :all, except: [:destroy]
+  actions :index, :show, :create, :edit, :update
 
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register User do
-  actions :all, :except => [:destroy]
+  actions :all, except: [:destroy]
 
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters

--- a/spec/features/active_admin_spec.rb
+++ b/spec/features/active_admin_spec.rb
@@ -26,6 +26,14 @@ describe '/admin endpoint' do
     expect(page).to have_content('scheduled jobs')
   end
 
+  it "does not allow Delete of Users" do
+    user.add_role('admin')
+    login_as(user)
+    visit "/admin/users/#{user.id}"
+    
+    expect(page).to_not have_content("Delete User")
+  end
+
   def user
     @user ||= create(:user)
   end


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/107777486

`/admin/` section should not have a Delete User button.