### PR TITLE
Update CF docs links

### DIFF
--- a/doc/developer_onboarding.md
+++ b/doc/developer_onboarding.md
@@ -16,8 +16,8 @@ Create a [new issue](https://github.com/18F/C2/issues/new), and copy the raw Mar
 
 ### Later
 
-* [ ] [Set up the Cloud Foundry CLI](https://docs.18f.gov/getting-started/setup/) (which you will need to deploy)
-* [ ] [Learn more about Cloud Foundry](https://docs.18f.gov)
+* [ ] [Set up the Cloud Foundry CLI](https://docs.cloud.gov/getting-started/setup/) (which you will need to deploy)
+* [ ] [Learn more about Cloud Foundry](https://docs.cloud.gov)
 * [ ] Deploy C2 to `c2-dev` (or `c2-staging`)
 * [ ] [Get added to the MailChimp account](production.md#getting-access)
 * [ ] Access support emails `capdevs@gsa.gov`, `communicart.sender@gsa.gov`, and `gatewaycommunicator`

--- a/doc/production.md
+++ b/doc/production.md
@@ -4,7 +4,7 @@ Live at https://cap.18f.gov.
 
 18F's [deployments](http://12factor.net/codebase) of C2 live in AWS, and are
 deployed via [Cloud Foundry](http://www.cloudfoundry.org). See [the 18F Cloud
-Foundry documentation](https://docs.18f.gov) for more details on how to inspect
+Foundry documentation](https://docs.cloud.gov) for more details on how to inspect
 and configure them.
 
 Once you're set up with Cloud Foundry, open a [new issue in the DevOps


### PR DESCRIPTION
* Most updated docs are now at docs.cloud.gov
* See convo at https://18f.slack.com/archives/cloud-gov-support/p1447700999000073