### PR TITLE
Fixes database migrations to run on empty database

### DIFF
--- a/db/migrate/20141031215718_add_flow_to_approval_groups.rb
+++ b/db/migrate/20141031215718_add_flow_to_approval_groups.rb
@@ -1,4 +1,7 @@
 class AddFlowToApprovalGroups < ActiveRecord::Migration
+  class ApprovalGroup < ActiveRecord::Base
+  end
+
   def change
     add_column :approval_groups, :flow, :string
 

--- a/db/migrate/20150319212424_migrate_ncr_to_models.rb
+++ b/db/migrate/20150319212424_migrate_ncr_to_models.rb
@@ -2,19 +2,23 @@ class MigrateNcrToModels < ActiveRecord::Migration
   class TempProperty < ActiveRecord::Base
     self.table_name = 'properties'
   end
+
   class TempCart < ActiveRecord::Base
     self.table_name = 'carts'
     has_many :properties, -> { where hasproperties_type: 'Cart' },
-              foreign_key: "hasproperties_id"
+              foreign_key: "hasproperties_id",
+              class_name: 'TempProperty'
     belongs_to :proposal
     def props
       Hash[self.properties.collect{|p| [p.property, YAML::load(p.value)]}]
     end
   end
+
   class TempProposal < ActiveRecord::Base
     self.table_name = 'proposals'
-    has_one :cart
+    has_one :cart, class_name: 'TempCart'
   end
+
   class TempNcrWorkOrder < ActiveRecord::Base
     self.table_name = 'ncr_work_orders'
     has_many :proposals, -> { where client_data_type: 'Ncr::WorkOrder' },

--- a/db/migrate/20150319212424_migrate_ncr_to_models.rb
+++ b/db/migrate/20150319212424_migrate_ncr_to_models.rb
@@ -7,7 +7,7 @@ class MigrateNcrToModels < ActiveRecord::Migration
     self.table_name = 'carts'
     has_many :properties, -> { where hasproperties_type: 'Cart' },
               foreign_key: "hasproperties_id",
-              class_name: 'TempProperty'
+              class_name: "TempProperty"
     belongs_to :proposal
     def props
       Hash[self.properties.collect{|p| [p.property, YAML::load(p.value)]}]
@@ -16,7 +16,7 @@ class MigrateNcrToModels < ActiveRecord::Migration
 
   class TempProposal < ActiveRecord::Base
     self.table_name = 'proposals'
-    has_one :cart, class_name: 'TempCart'
+    has_one :cart, class_name: "TempCart"
   end
 
   class TempNcrWorkOrder < ActiveRecord::Base


### PR DESCRIPTION
        I wasn't able to run migrations on an empty database. These
        modifications will make it easier for developers to jump into
        the project my making the migrations work from scratch.