### PR TITLE
Add `Ncr::OrganizationCollection` class

### DIFF
--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -174,9 +174,7 @@ module Ncr
       attributes.map{|key| [WorkOrder.human_attribute_name(key), self[key]]}
     end
 
-    # will return nil if the `org_code` is blank or not present in Organization list
     def organization
-      # TODO reference by `code` rather than storing the whole thing
       code = (self.org_code || '').split(' ', 2)[0]
       Ncr::Organization.find(code)
     end
@@ -203,21 +201,21 @@ module Ncr
       manager.system_approver_emails
     end
 
+    def as_json
+      super.merge(org_id: org_id, building_id: building_id)
+    end
+
     def org_id
-      self.organization.try(:code)
+      organization.try(:code)
     end
 
     def building_id
       regex = /\A(\w{8}) .*\z/
-      if self.building_number && regex.match(self.building_number)
+      if building_number && regex.match(building_number)
         regex.match(self.building_number)[1]
       else
-        self.building_number
+        building_number
       end
-    end
-
-    def as_json
-      super.merge(org_id: self.org_id, building_id: self.building_id)
     end
 
     def public_identifier

--- a/config/data/ncr/ool_org_codes.yml
+++ b/config/data/ncr/ool_org_codes.yml
@@ -1,4 +1,4 @@
 ---
 P1171001: Lease Execution (LED)
 P1172001: Lease Project Management (LPMD)
-P1173001: Real Estate Administration (REA) 
+P1173001: Real Estate Administration (REA)

--- a/lib/ncr/organization.rb
+++ b/lib/ncr/organization.rb
@@ -1,69 +1,37 @@
 module Ncr
   class Organization
-    BY_CODE = {} # populated later
-    OOL_CODES = Set.new # populated later
-    WHSC_CODE = 'P1122021'
+    WHSC_CODE = "P1122021"
+    OOL_CODES = [
+      "P1171001",
+      "P1172001",
+      "P1173001"
+    ]
 
-    attr_accessor :code, :name
+    attr_reader :code, :name
 
     def initialize(code:, name:)
-      self.code = code
-      self.name = name
-    end
-
-    def ==(other)
-      other.code == self.code
+      @code = code
+      @name = name
     end
 
     def to_s
-      "#{self.code} #{self.name}"
+      "#{code} #{name}"
     end
 
-    # Office of Leasing
     def ool?
-      OOL_CODES.include?(self.code)
+      OOL_CODES.include?(code)
     end
 
-    # White House Service Center
     def whsc?
-      self.code == WHSC_CODE
+      code == WHSC_CODE
     end
 
     def self.all
-      BY_CODE.values
+      Ncr::OrganizationCollection.new.all
     end
 
     def self.find(code)
-      BY_CODE[code]
+      Ncr::OrganizationCollection.new.finder[code]
     end
-
-    def self.from_csv_row(row)
-      self.new(
-        code: row['organization_cd'],
-        name: row['organization_nm']
-      )
-    end
-
-    protected
-
-    def self.load_csv
-      rows = CSV.read(Rails.root.join(*%w(config data ncr org_codes_2015-05-18.csv)), headers: true)
-      rows.each do |row|
-        org = Ncr::Organization.from_csv_row(row)
-        BY_CODE[org.code] = org
-      end
-    end
-
-    def self.load_ool_yaml
-      data = YAML.load_file(Rails.root.join(*%w(config data ncr ool_org_codes.yml)))
-      data.each do |code, name|
-        org = Ncr::Organization.new(code: code, name: name)
-        BY_CODE[code] = org
-        OOL_CODES << code
-      end
-    end
-
-    self.load_csv
-    self.load_ool_yaml
   end
 end

--- a/lib/ncr/organization_collection.rb
+++ b/lib/ncr/organization_collection.rb
@@ -1,0 +1,37 @@
+module Ncr
+  class OrganizationCollection
+    def all
+      organization_records
+    end
+
+    def finder
+      Hash[organization_codes.zip(organization_records)]
+    end
+
+    private
+
+    attr_reader :type
+
+    def organization_codes
+      org_code_data.map do |row|
+        row["organization_cd"]
+      end
+    end
+
+    def organization_records
+      org_code_data.map do |row|
+        Ncr::Organization.new(
+          code: row["organization_cd"],
+          name: row["organization_nm"]
+        )
+      end
+    end
+
+    def org_code_data
+      @org_code_data ||= CSV.read(
+        Rails.root.join(*%w(config data ncr org_codes_2015-05-18.csv)),
+        headers: true
+      )
+    end
+  end
+end

--- a/lib/ncr/reporter.rb
+++ b/lib/ncr/reporter.rb
@@ -87,7 +87,7 @@ module Ncr
     end
 
     def self.proposals_tier_one_pending_sql
-      approver_sql   = self.proposals_tier_one_pending_approver_sql
+      approver_sql = self.proposals_tier_one_pending_approver_sql
       work_order_sql = self.proposals_tier_one_work_order_sql
       <<-SQL.gsub(/^ {8}/, '')
         SELECT * FROM proposals AS p

--- a/spec/lib/ncr/organization_collection_spec.rb
+++ b/spec/lib/ncr/organization_collection_spec.rb
@@ -1,0 +1,23 @@
+describe Ncr::OrganizationCollection do
+  describe "#all" do
+    it "returns a collection of all Ncr Organization records" do
+      collection = Ncr::OrganizationCollection.new.all
+
+      expect(collection.size).to eq 891
+      expect(collection.first).to be_an_instance_of(Ncr::Organization)
+    end
+  end
+
+  describe "#finder" do
+    it "returns a hash with org codes pointing to objects for code" do
+      code = Ncr::Organization::WHSC_CODE
+      name_from_fixture = "(192X,192M) WHITE HOUSE DISTRICT"
+      org = Ncr::Organization.new(code: code, name: name_from_fixture)
+
+      found_org = Ncr::OrganizationCollection.new.finder[code]
+
+      expect(found_org.code).to eq org.code
+      expect(found_org.name).to eq org.name
+    end
+  end
+end

--- a/spec/lib/ncr/organization_spec.rb
+++ b/spec/lib/ncr/organization_spec.rb
@@ -1,44 +1,43 @@
 describe Ncr::Organization do
-  describe '#==' do
-    it "considers two objects with the same #code identical" do
-      expect(Ncr::Organization.new(code: '12', name: 'foo')).to eq(Ncr::Organization.new(code: '12', name: 'foo'))
+  describe "#to_s" do
+    it "returns code and name" do
+      org = Ncr::Organization.new(code: "123", name: "ABC")
+
+      expect(org.to_s).to eq "123 ABC"
     end
   end
-
-  describe '#ool?' do
+  describe "#ool?" do
     it "returns true for an Office of Leasing org code" do
-      org = Ncr::Organization.find(Ncr::Organization::OOL_CODES.first)
-      expect(org.ool?).to eq(true)
+      ool_org = Ncr::Organization.new(code: Ncr::Organization::OOL_CODES[0], name: "test")
+      expect(ool_org.ool?).to eq(true)
     end
 
     it "returns false for other org codes" do
-      org = Ncr::Organization.new(code: '12', name: 'foo')
+      org = Ncr::Organization.new(code: "12", name: "foo")
       expect(org.ool?).to eq(false)
     end
   end
 
-  describe '#whsc?' do
+  describe "#whsc?" do
     it "returns true for a White House Service Center org code" do
-      org = Ncr::Organization.find(Ncr::Organization::WHSC_CODE)
+      org = Ncr::Organization.new(code: Ncr::Organization::WHSC_CODE, name: "test")
       expect(org.whsc?).to eq(true)
     end
 
     it "returns false for other org codes" do
-      org = Ncr::Organization.new(code: '12', name: 'foo')
+      org = Ncr::Organization.new(code: "12", name: "foo")
       expect(org.whsc?).to eq(false)
     end
   end
 
-  describe '.all' do
-    it "returns all records" do
-      expect(Ncr::Organization.all.size).to be > 10
-    end
+  describe ".find" do
+    it "returns Ncr Organization based on code" do
+      code = Ncr::Organization::WHSC_CODE
+      name_from_fixture = "(192X,192M) WHITE HOUSE DISTRICT"
+      org = Ncr::Organization.new(code: code, name: name_from_fixture)
 
-    it "populates the attributes for each" do
-      Ncr::Organization.all.each do |org|
-        expect(org.code).to be_present
-        expect(org.name).to be_present
-      end
+      expect(Ncr::Organization.find(code).code).to eq org.code
+      expect(Ncr::Organization.find(code).name).to eq org.name
     end
   end
 end

--- a/spec/lib/ncr/reporter_spec.rb
+++ b/spec/lib/ncr/reporter_spec.rb
@@ -24,12 +24,15 @@ describe Ncr::Reporter do
 
   describe '.proposals_tier_one_pending' do
     it "only returns Proposals where Tier One approval is actionable" do
+      white_house_org_code = Ncr::OrganizationCollection.new.finder[Ncr::Organization::WHSC_CODE].to_s
+
       whs_work_order = create(
         :ncr_work_order,
         :with_approvers,
-        org_code: Ncr::Organization::WHSC_CODE
+        org_code: white_house_org_code
       )
       whs_work_order.setup_approvals_and_observers
+      whs_work_order.individual_steps.first.approve!
 
       approved_work_order = create(:ncr_work_order, :with_approvers)
       approved_work_order.setup_approvals_and_observers

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -55,7 +55,7 @@ describe Ncr::WorkOrder do
     it "returns the corresponding Organization instance" do
       org = Ncr::Organization.all.last
       work_order = Ncr::WorkOrder.new(org_code: org.code)
-      expect(work_order.organization).to eq(org)
+      expect(work_order.organization.code).to eq(org.code)
     end
 
     it "returns nil for no #org_code" do


### PR DESCRIPTION
* Previously, Ncr::Organization was handling methods for single and
  collection methods
* Simplify (and test) collection methods via adding collection class
* Added more specs around WHSC SQL because I wasn't sure it was working
  before (since we save both code and name for organizations)