### PR TITLE
[Delivers #108372360] 18f approver can cancel

### DIFF
--- a/app/models/gsa18f/procurement.rb
+++ b/app/models/gsa18f/procurement.rb
@@ -80,7 +80,9 @@ module Gsa18f
     end
 
     def purchaser
-      purchase_step ? purchase_step.user : nil
+      if purchase_step
+        purchase_step.user
+      end
     end
 
     def self.approver_email

--- a/app/models/gsa18f/procurement.rb
+++ b/app/models/gsa18f/procurement.rb
@@ -79,6 +79,10 @@ module Gsa18f
       "##{proposal.id}"
     end
 
+    def purchaser
+      purchase_step ? purchase_step.user : nil
+    end
+
     def self.approver_email
       self.user_with_role('gsa18f_approver').email_address
     end
@@ -94,6 +98,12 @@ module Gsa18f
       end
 
       users.first
+    end
+
+    private
+
+    def purchase_step
+      steps.select{|step| step.is_a?(Steps::Purchase)}.first
     end
   end
 end

--- a/app/policies/gsa18f/procurement_policy.rb
+++ b/app/policies/gsa18f/procurement_policy.rb
@@ -16,6 +16,7 @@ module Gsa18f
       not_cancelled! && check((approver? || delegate? || requester?) && !purchaser?, 
         "Sorry, you are neither the requester, approver or delegate")
     end
+    alias_method :can_cancel_form!, :can_cancel!
 
     protected
 

--- a/app/policies/gsa18f/procurement_policy.rb
+++ b/app/policies/gsa18f/procurement_policy.rb
@@ -11,5 +11,16 @@ module Gsa18f
       super && self.gsa_if_restricted!
     end
     alias_method :can_new!, :can_create!
+
+    def can_cancel!
+      not_cancelled! && check((approver? || delegate? || requester?) && !purchaser?, 
+        "Sorry, you are neither the requester, approver or delegate")
+    end
+
+    protected
+
+    def purchaser?
+      @procurement.purchaser == @user
+    end
   end
 end

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -68,9 +68,9 @@
     - unless @proposal.cancelled?
       %li
         = modify_client_button(@proposal)
-      - if policy(@proposal).can_cancel?
-        %li
-          = link_to "Cancel my request", cancel_form_proposal_path
+  - if policy(@proposal).can_cancel?
+    %li
+      = link_to "Cancel this request", cancel_form_proposal_path
   - if current_user.admin?
     %li
       = link_to "View history", history_proposal_path(@proposal)

--- a/spec/features/18f_procurement_spec.rb
+++ b/spec/features/18f_procurement_spec.rb
@@ -208,9 +208,14 @@ describe "GSA 18f Purchase Request Form" do
     end
 
     it "the step execution button is correctly marked" do
-      visit "/proposals/#{proposal.id}"
+      visit proposal_path(proposal)
       expect(page).to have_button('Approve')
     end
+
+    it "shows a cancel link for approver" do
+      visit proposal_path(proposal)
+      expect(page).to have_content('Cancel this request')
+    end 
   end
 
   context "when signed in as the purchaser" do
@@ -225,6 +230,11 @@ describe "GSA 18f Purchase Request Form" do
       login_as(purchaser)
       visit "/proposals/#{proposal.id}"
       expect(page).to have_button('Mark as Purchased')
+    end
+
+    it "does not show a cancel link for purchaser" do
+      visit proposal_path(proposal)
+      expect(page).to_not have_content('Cancel this request')
     end
   end
 end

--- a/spec/features/cancel_spec.rb
+++ b/spec/features/cancel_spec.rb
@@ -5,7 +5,7 @@ describe 'Canceling a request' do
 
     visit proposal_path(proposal)
 
-    expect(page).to have_content('Cancel my request')
+    expect(page).to have_content('Cancel this request')
   end
 
   it 'does not show a cancel link for non-requesters' do
@@ -14,7 +14,7 @@ describe 'Canceling a request' do
 
     visit proposal_path(proposal)
 
-    expect(page).to_not have_content('Cancel my request')
+    expect(page).to_not have_content('Cancel this request')
   end
 
   it 'prompts the requester for a reason' do
@@ -22,7 +22,7 @@ describe 'Canceling a request' do
     login_as(proposal.requester)
 
     visit proposal_path(proposal)
-    click_on('Cancel my request')
+    click_on('Cancel this request')
 
     expect(current_path).to eq("/proposals/#{proposal.id}/cancel_form")
   end
@@ -99,7 +99,7 @@ describe 'Canceling a request' do
       login_as(proposal.requester)
 
       visit proposal_path(proposal)
-      click_on('Cancel my request')
+      click_on('Cancel this request')
       fill_in 'reason_input', with: ''
       click_on('Yes, cancel this request')
 
@@ -131,7 +131,7 @@ describe 'Canceling a request' do
 
   def cancel_proposal(proposal)
     visit proposal_path(proposal)
-    click_on('Cancel my request')
+    click_on('Cancel this request')
     fill_in 'reason_input', with: 'This is a good reason for the cancellation.'
     click_on('Yes, cancel this request')
   end

--- a/spec/features/ncr/work_orders/show_spec.rb
+++ b/spec/features/ncr/work_orders/show_spec.rb
@@ -36,7 +36,7 @@ describe "viewing a work order" do
 
   it "doesn't show a edit/cancel/add observer link from a cancelled proposal" do
     visit "/proposals/#{ncr_proposal.id}"
-    expect(page).to have_content('Cancel my request')
+    expect(page).to have_content('Cancel this request')
     ncr_proposal.update_attribute(:status, 'cancelled')
     visit "/proposals/#{ncr_proposal.id}"
     expect(page).not_to have_content('Modify Request')

--- a/spec/models/gsa18f/procurement_spec.rb
+++ b/spec/models/gsa18f/procurement_spec.rb
@@ -9,6 +9,7 @@ describe Gsa18f::Procurement do
       procurement = create(:gsa18f_procurement, :with_steps)
       expect(procurement.approvers.map(&:email_address)).to eq(["approver@example.com", "purchaser@example.com"])
       expect(procurement.observers.map(&:email_address)).to be_empty
+      expect(procurement.purchaser.email_address).to eq("purchaser@example.com")
     end
 
     it "identifies eligible observers based on client_slug" do

--- a/spec/policies/gsa18f/procurement_policy_spec.rb
+++ b/spec/policies/gsa18f/procurement_policy_spec.rb
@@ -36,6 +36,13 @@ describe Gsa18f::ProcurementPolicy do
       expect(subject).to permit(procurement.proposal.approvers.first, procurement)
     end
 
+    it "allows approver delegate to cancel" do
+      procurement = create(:gsa18f_procurement, :with_steps)
+      the_delegate = create(:user, client_slug: "gsa18f")
+      procurement.proposal.approvers.first.add_delegate(the_delegate)
+      expect(subject).to permit(the_delegate, procurement)
+    end
+
     it "does not allow purchaser to cancel" do
       procurement = create(:gsa18f_procurement, :with_steps)
       expect(subject).to_not permit(procurement.purchaser, procurement)

--- a/spec/policies/gsa18f/procurement_policy_spec.rb
+++ b/spec/policies/gsa18f/procurement_policy_spec.rb
@@ -24,4 +24,21 @@ describe Gsa18f::ProcurementPolicy do
       end
     end
   end
+
+  permissions :can_cancel? do
+    it "allows requester to cancel" do
+      procurement = create(:gsa18f_procurement)
+      expect(subject).to permit(procurement.proposal.requester, procurement)
+    end
+
+    it "allows approver to cancel" do
+      procurement = create(:gsa18f_procurement, :with_steps)
+      expect(subject).to permit(procurement.proposal.approvers.first, procurement)
+    end
+
+    it "does not allow purchaser to cancel" do
+      procurement = create(:gsa18f_procurement, :with_steps)
+      expect(subject).to_not permit(procurement.purchaser, procurement)
+    end
+  end
 end


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/108372360

This PR adds a couple methods to distinguish a *purchaser* from another kind of approver, and amends the gsa18f policy to allow non-purchaser approver on gsa18f procurement to cancel the proposal.

Testing:

* Verify who the gsa18f purchaser user is. That is controlled via Roles so you should be able to manage/view it from the `/admin` UI. Verify you will be able to login as that user.
* Create a gsa18f procurement
* Login as the approver and verify that you can cancel the procurement