### PR TITLE
[Delivers #108485468] User with admin role can cancel any request

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -127,7 +127,7 @@ class Proposal < ActiveRecord::Base
 
     # this authz check is here instead of in a Policy because the Policy classes
     # are applied to the current_user, not (as in this case) the user being acted upon.
-    if client_data && !client_data.slug_matches?(user)
+    if client_data && !client_data.slug_matches?(user) && !user.admin?
       fail Pundit::NotAuthorizedError.new("May not add observer belonging to a different organization.")
     end
 

--- a/app/policies/gsa18f/procurement_policy.rb
+++ b/app/policies/gsa18f/procurement_policy.rb
@@ -13,7 +13,7 @@ module Gsa18f
     alias_method :can_new!, :can_create!
 
     def can_cancel!
-      not_cancelled! && check((approver? || delegate? || requester?) && !purchaser?, 
+      not_cancelled! && check((approver? || delegate? || requester?) && !purchaser?,
         "Sorry, you are neither the requester, approver or delegate")
     end
     alias_method :can_cancel_form!, :can_cancel!

--- a/app/policies/gsa18f/procurement_policy.rb
+++ b/app/policies/gsa18f/procurement_policy.rb
@@ -13,8 +13,10 @@ module Gsa18f
     alias_method :can_new!, :can_create!
 
     def can_cancel!
-      not_cancelled! && check((approver? || delegate? || requester?) && !purchaser?,
-        "Sorry, you are neither the requester, approver or delegate")
+      not_cancelled! && check(
+        (approver? || delegate? || requester? || admin?) && !purchaser?,
+        "Sorry, you are neither the requester, approver or delegate"
+      )
     end
     alias_method :can_cancel_form!, :can_cancel!
 

--- a/app/policies/ncr/work_order_policy.rb
+++ b/app/policies/ncr/work_order_policy.rb
@@ -8,7 +8,10 @@ module Ncr
     end
 
     def can_edit!
-      check(self.requester? || self.approver? || self.observer?, "You must be the requester, approver, or observer to edit")
+      check(
+        self.requester? || self.approver? || self.observer?,
+        "You must be the requester, approver, or observer to edit"
+      )
     end
 
     alias_method :can_update!, :can_edit!

--- a/app/policies/proposal_policy.rb
+++ b/app/policies/proposal_policy.rb
@@ -11,7 +11,7 @@ class ProposalPolicy
   end
 
   def can_edit!
-    (@user.admin? || requester!) && not_approved! && not_cancelled!
+    (admin? || requester!) && not_approved! && not_cancelled!
   end
   alias_method :can_update!, :can_edit!
 
@@ -26,7 +26,7 @@ class ProposalPolicy
   alias_method :can_new!, :can_create!
 
   def can_cancel!
-    (@user.admin? || requester!) && not_cancelled!
+    (admin? || requester!) && not_cancelled!
   end
   alias_method :can_cancel_form!, :can_cancel!
 
@@ -54,8 +54,10 @@ class ProposalPolicy
   end
 
   def not_approved!
-    check(!@proposal.approved?,
-          "That proposal's already approved. New proposal?")
+    check(
+      !@proposal.approved?,
+      "That proposal's already approved. New proposal?"
+    )
   end
 
   def not_cancelled!
@@ -70,9 +72,15 @@ class ProposalPolicy
     @proposal.delegate?(@user)
   end
 
+  def admin?
+    @user.admin?
+  end
+
   def approver!
-    check(self.approver? || self.delegate?,
-          "Sorry, you're not an approver on this proposal")
+    check(
+      self.approver? || self.delegate?,
+      "Sorry, you're not an approver on this proposal"
+    )
   end
 
   def observer!

--- a/app/policies/proposal_policy.rb
+++ b/app/policies/proposal_policy.rb
@@ -11,7 +11,7 @@ class ProposalPolicy
   end
 
   def can_edit!
-    @user.admin? || requester! && not_approved! && not_cancelled!
+    (@user.admin? || requester!) && not_approved! && not_cancelled!
   end
   alias_method :can_update!, :can_edit!
 
@@ -26,7 +26,7 @@ class ProposalPolicy
   alias_method :can_new!, :can_create!
 
   def can_cancel!
-    @user.admin? || requester! && not_cancelled!
+    (@user.admin? || requester!) && not_cancelled!
   end
   alias_method :can_cancel_form!, :can_cancel!
 

--- a/app/policies/proposal_policy.rb
+++ b/app/policies/proposal_policy.rb
@@ -11,7 +11,7 @@ class ProposalPolicy
   end
 
   def can_edit!
-    requester! && not_approved! && not_cancelled!
+    @user.admin? || requester! && not_approved! && not_cancelled!
   end
   alias_method :can_update!, :can_edit!
 
@@ -26,7 +26,7 @@ class ProposalPolicy
   alias_method :can_new!, :can_create!
 
   def can_cancel!
-    requester! && not_cancelled!
+    @user.admin? || requester! && not_cancelled!
   end
   alias_method :can_cancel_form!, :can_cancel!
 

--- a/spec/features/cancel_spec.rb
+++ b/spec/features/cancel_spec.rb
@@ -17,6 +17,27 @@ describe 'Canceling a request' do
     expect(page).to_not have_content('Cancel this request')
   end
 
+  it "shows cancel link for admins" do
+    proposal = create(:proposal, :with_approver)
+    admin_user = create(:user, :admin)
+    login_as(admin_user)
+
+    visit proposal_path(proposal)
+
+    expect(page).to have_content("Cancel this request")
+  end
+
+  it "allows admin to cancel a proposal even with different client_slug" do
+    work_order = create(:ncr_work_order)
+    proposal = work_order.proposal
+    admin_user = create(:user, :admin, client_slug: "gsa18f")
+    login_as(admin_user)
+
+    cancel_proposal(proposal)
+
+    expect(page).to_not have_content("May not add observer")
+  end
+
   it 'prompts the requester for a reason' do
     proposal = create(:proposal)
     login_as(proposal.requester)

--- a/spec/policies/gsa18f/procurement_policy_spec.rb
+++ b/spec/policies/gsa18f/procurement_policy_spec.rb
@@ -1,11 +1,9 @@
 describe Gsa18f::ProcurementPolicy do
-  subject { described_class }
-
   permissions :can_create? do
     it "allows a user with an arbitrary email to create" do
       user = User.new(email_address: 'user@example.com', client_slug: 'gsa18f')
       procurement = Gsa18f::Procurement.new
-      expect(subject).to permit(user, procurement)
+      expect(Gsa18f::ProcurementPolicy).to permit(user, procurement)
     end
 
     with_feature 'RESTRICT_ACCESS' do
@@ -14,13 +12,13 @@ describe Gsa18f::ProcurementPolicy do
         stub_const("GsaPolicy::GSA_DOMAIN", gsa_domain)
         user = User.new(email_address: "user#{gsa_domain}", client_slug: 'gsa18f')
         procurement = Gsa18f::Procurement.new
-        expect(subject).to permit(user, procurement)
+        expect(Gsa18f::ProcurementPolicy).to permit(user, procurement)
       end
 
       it "doesn't allow someone with a non-GSA email to create" do
         user = User.new(email_address: 'intruder@example.com', client_slug: 'gsa18f')
         procurement = Gsa18f::Procurement.new
-        expect(subject).not_to permit(user, procurement)
+        expect(Gsa18f::ProcurementPolicy).not_to permit(user, procurement)
       end
     end
   end
@@ -28,24 +26,31 @@ describe Gsa18f::ProcurementPolicy do
   permissions :can_cancel? do
     it "allows requester to cancel" do
       procurement = create(:gsa18f_procurement)
-      expect(subject).to permit(procurement.proposal.requester, procurement)
+      expect(Gsa18f::ProcurementPolicy).to permit(procurement.proposal.requester, procurement)
+    end
+
+    it "allows admins to cancel" do
+      procurement = create(:gsa18f_procurement)
+      admin = create(:user)
+      admin.add_role("admin")
+      expect(Gsa18f::ProcurementPolicy).to permit(admin, procurement)
     end
 
     it "allows approver to cancel" do
       procurement = create(:gsa18f_procurement, :with_steps)
-      expect(subject).to permit(procurement.proposal.approvers.first, procurement)
+      expect(Gsa18f::ProcurementPolicy).to permit(procurement.proposal.approvers.first, procurement)
     end
 
     it "allows approver delegate to cancel" do
       procurement = create(:gsa18f_procurement, :with_steps)
       the_delegate = create(:user, client_slug: "gsa18f")
       procurement.proposal.approvers.first.add_delegate(the_delegate)
-      expect(subject).to permit(the_delegate, procurement)
+      expect(Gsa18f::ProcurementPolicy).to permit(the_delegate, procurement)
     end
 
     it "does not allow purchaser to cancel" do
       procurement = create(:gsa18f_procurement, :with_steps)
-      expect(subject).to_not permit(procurement.purchaser, procurement)
+      expect(Gsa18f::ProcurementPolicy).to_not permit(procurement.purchaser, procurement)
     end
   end
 end

--- a/spec/policies/proposal_policy_spec.rb
+++ b/spec/policies/proposal_policy_spec.rb
@@ -89,10 +89,14 @@ describe ProposalPolicy do
   end
 
   permissions :can_edit? do
-    let(:proposal) { create(:proposal, :with_parallel_approvers, :with_observers) }
-
-    it "allows the requester to edit it" do
+    it "allows the requester to edit" do
       expect(subject).to permit(proposal.requester, proposal)
+    end
+
+    it "allows an admin to edit" do
+      admin = create(:user)
+      admin.add_role("admin")
+      expect(subject).to permit(admin, proposal)
     end
 
     it "doesn't allow an approver to edit it" do
@@ -115,9 +119,7 @@ describe ProposalPolicy do
   end
 
   permissions :can_cancel? do
-    let(:proposal) { create(:proposal, :with_parallel_approvers) }
-
-    it "allows the requester to edit it" do
+    it "allows the requester to cancel it" do
       expect(subject).to permit(proposal.requester, proposal)
     end
 
@@ -129,5 +131,15 @@ describe ProposalPolicy do
     it "doesn't allow an approver to cancel it" do
       expect(subject).not_to permit(proposal.approvers[0], proposal)
     end
+
+    it "allows admins to cancel" do
+      admin = create(:user)
+      admin.add_role("admin")
+      expect(subject).to permit(admin, proposal)
+    end
+  end
+
+  def proposal
+    @_proposal = create(:proposal, :with_parallel_approvers, :with_observers)
   end
 end

--- a/spec/policies/proposal_policy_spec.rb
+++ b/spec/policies/proposal_policy_spec.rb
@@ -1,6 +1,4 @@
 describe ProposalPolicy do
-  subject { described_class }
-
   permissions :can_approve? do
     it "allows pending delegates" do
       proposal = create(:proposal, :with_parallel_approvers)
@@ -10,7 +8,7 @@ describe ProposalPolicy do
       approver = approval.user
       approver.add_delegate(delegate)
 
-      expect(subject).to permit(delegate, proposal)
+      expect(ProposalPolicy).to permit(delegate, proposal)
     end
 
     context "parallel proposal" do
@@ -19,18 +17,18 @@ describe ProposalPolicy do
 
       it "allows when there's a pending approval" do
         proposal.approvers.each{ |approver|
-          expect(subject).to permit(approver, proposal)
+          expect(ProposalPolicy).to permit(approver, proposal)
         }
       end
 
       it "does not allow when the user's already approved" do
         approval.update_attribute(:status, 'approved')  # skip state machine
-        expect(subject).not_to permit(approval.user, proposal)
+        expect(ProposalPolicy).not_to permit(approval.user, proposal)
       end
 
       it "does not allow with a non-existent approval" do
         user = create(:user)
-        expect(subject).not_to permit(user, proposal)
+        expect(ProposalPolicy).not_to permit(user, proposal)
       end
     end
 
@@ -40,22 +38,22 @@ describe ProposalPolicy do
       let(:second_approval) { proposal.individual_steps.last }
 
       it "allows when there's a pending approval" do
-        expect(subject).to permit(first_approval.user, proposal)
+        expect(ProposalPolicy).to permit(first_approval.user, proposal)
       end
 
       it "does not allow when it's not the user's turn" do
-        expect(subject).not_to permit(second_approval.user, proposal)
+        expect(ProposalPolicy).not_to permit(second_approval.user, proposal)
       end
 
       it "does not allow when the user's already approved" do
         first_approval.approve!
-        expect(subject).not_to permit(first_approval.user, proposal)
-        expect(subject).to permit(second_approval.user, proposal)
+        expect(ProposalPolicy).not_to permit(first_approval.user, proposal)
+        expect(ProposalPolicy).to permit(second_approval.user, proposal)
       end
 
       it "does not allow with a non-existent approval" do
         user = create(:user)
-        expect(subject).not_to permit(user, proposal)
+        expect(ProposalPolicy).not_to permit(user, proposal)
       end
     end
   end
@@ -64,82 +62,82 @@ describe ProposalPolicy do
     let(:proposal) {create(:proposal, :with_parallel_approvers, :with_observers)}
 
     it "allows the requester to see it" do
-      expect(subject).to permit(proposal.requester, proposal)
+      expect(ProposalPolicy).to permit(proposal.requester, proposal)
     end
 
     it "allows an approver to see it" do
-      expect(subject).to permit(proposal.approvers[0], proposal)
-      expect(subject).to permit(proposal.approvers[1], proposal)
+      expect(ProposalPolicy).to permit(proposal.approvers[0], proposal)
+      expect(ProposalPolicy).to permit(proposal.approvers[1], proposal)
     end
 
     it "does not allow a pending approver to see it" do
       first_approval = proposal.individual_steps.first
       first_approval.update_attribute(:status, 'pending')
-      expect(subject).not_to permit(first_approval.user, proposal)
-      expect(subject).to permit(proposal.approvers.last, proposal)
+      expect(ProposalPolicy).not_to permit(first_approval.user, proposal)
+      expect(ProposalPolicy).to permit(proposal.approvers.last, proposal)
     end
 
     it "allows an observer to see it" do
-      expect(subject).to permit(proposal.observers[0], proposal)
+      expect(ProposalPolicy).to permit(proposal.observers[0], proposal)
     end
 
     it "does not allow anyone else to see it" do
-      expect(subject).not_to permit(create(:user), proposal)
+      expect(ProposalPolicy).not_to permit(create(:user), proposal)
     end
   end
 
   permissions :can_edit? do
     it "allows the requester to edit" do
-      expect(subject).to permit(proposal.requester, proposal)
+      expect(ProposalPolicy).to permit(proposal.requester, proposal)
     end
 
     it "allows an admin to edit" do
       admin = create(:user)
       admin.add_role("admin")
-      expect(subject).to permit(admin, proposal)
+      expect(ProposalPolicy).to permit(admin, proposal)
     end
 
     it "doesn't allow an approver to edit it" do
-      expect(subject).not_to permit(proposal.approvers[0], proposal)
-      expect(subject).not_to permit(proposal.approvers[1], proposal)
+      expect(ProposalPolicy).not_to permit(proposal.approvers[0], proposal)
+      expect(ProposalPolicy).not_to permit(proposal.approvers[1], proposal)
     end
 
     it "doesn't allow an observer to edit it" do
-      expect(subject).not_to permit(proposal.observers[0], proposal)
+      expect(ProposalPolicy).not_to permit(proposal.observers[0], proposal)
     end
 
     it "does not allow anyone else to edit it" do
-      expect(subject).not_to permit(create(:user), proposal)
+      expect(ProposalPolicy).not_to permit(create(:user), proposal)
     end
 
     it "does not allow an approved request to be edited" do
       proposal.update_attribute(:status, 'approved')  # skip state machine
-      expect(subject).not_to permit(proposal.requester, proposal)
+      expect(ProposalPolicy).not_to permit(proposal.requester, proposal)
     end
   end
 
   permissions :can_cancel? do
     it "allows the requester to cancel it" do
-      expect(subject).to permit(proposal.requester, proposal)
+      expect(ProposalPolicy).to permit(proposal.requester, proposal)
     end
 
     it "does not allow a requester to edit a cancelled one" do
       proposal.cancel!
-      expect(subject).not_to permit(proposal.requester, proposal)
+      expect(ProposalPolicy).not_to permit(proposal.requester, proposal)
     end
 
     it "doesn't allow an approver to cancel it" do
-      expect(subject).not_to permit(proposal.approvers[0], proposal)
+      expect(ProposalPolicy).not_to permit(proposal.approvers[0], proposal)
     end
 
     it "allows admins to cancel" do
       admin = create(:user)
       admin.add_role("admin")
-      expect(subject).to permit(admin, proposal)
+      expect(ProposalPolicy).to permit(admin, proposal)
     end
   end
 
   def proposal
-    @_proposal = create(:proposal, :with_parallel_approvers, :with_observers)
+    @_proposal ||= create(:proposal, :with_parallel_approvers, :with_observers)
   end
 end


### PR DESCRIPTION
* Via regular UI
* To test:
  log in as admin
  visit proposal that you are not a requester or approver for (will have
  to find via rails console since it will not be in your dashboard)
  you should see option to cancel
  confirm that you can cancel

- story https://www.pivotaltracker.com/story/show/108485468