### PR TITLE
optimize /admin/users endpoint to not load filters for all relationships

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register User do
   filter :last_name
   filter :first_name
   filter :email_address
-  filter :status
+  filter :active
   filter :client_slug
 
   # See permitted parameters documentation:

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,6 +1,12 @@
 ActiveAdmin.register User do
   actions :index, :show, :new, :create, :edit, :update
 
+  filter :last_name
+  filter :first_name
+  filter :email_address
+  filter :status
+  filter :client_slug
+
   # See permitted parameters documentation:
   # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
   permit_params :active, :first_name, :last_name, :email_address, :client_slug, role_ids: []


### PR DESCRIPTION
because `/admin/users` endpoints create filters for all relationships by default, page load time was 10+ seconds every time. This gets it down in the 1-2 second range.