### PR TITLE
Refactor to prep for moving organizations to DB

### DIFF
--- a/app/mailers/concerns/proposal_conversation_threading.rb
+++ b/app/mailers/concerns/proposal_conversation_threading.rb
@@ -27,7 +27,7 @@ module ProposalConversationThreading
   def subject(proposal)
     if proposal.client_data_type == "Ncr::WorkOrder"
       client_data = proposal.client_data
-      %Q(Request #{proposal.public_id}, #{client_data.organization_code}, #{client_data.building_id} from #{proposal.requester.email_address})
+      %(Request #{proposal.public_id}, #{client_data.organization_code}, #{client_data.building_id} from #{proposal.requester.email_address})
     else
       "Request #{proposal.public_id}"
     end

--- a/app/mailers/concerns/proposal_conversation_threading.rb
+++ b/app/mailers/concerns/proposal_conversation_threading.rb
@@ -1,63 +1,17 @@
 module ProposalConversationThreading
   extend ActiveSupport::Concern
-
-  included do
-    include ConversationThreading
-  end
-
-  ## helper methods ##
-
-  def self.msg_id(proposal)
-    "<proposal-#{proposal.id}@#{DEFAULT_URL_HOST}>"
-  end
-
-  def self.subject_i18n_key(proposal)
-    if proposal.client_data
-      # We'll look up by the client_data's class name
-      proposal.client_data.class.name.underscore
-    else
-      # Default (no client_data): look up by "proposal"
-      :proposal
-    end
-  end
-
-  def self.subject_params(proposal)
-    params = proposal.as_json
-    params[:public_id] = proposal.public_id
-    proposal.requester.as_json.each { |k, v| params["requester_" + k] = v }
-
-    if proposal.client_data
-      params.merge!(proposal.client_data.as_json)
-    end
-
-    # Add search path, and default lookup key for I18n
-    params.merge!(scope: [:mail, :subject], default: :proposal)
-
-    params
-  end
-
-  def self.subject(proposal)
-    i18n_key = self.subject_i18n_key(proposal)
-    params = self.subject_params(proposal)
-    I18n.t(i18n_key, params.symbolize_keys)
-  end
-
-  ###################
-
-  ## mixin methods ##
-
-  protected
+  include ConversationThreading
 
   def assign_threading_headers(proposal)
-    msg_id = ProposalConversationThreading.msg_id(proposal)
+    msg_id = "<proposal-#{proposal.id}@#{DEFAULT_URL_HOST}>"
     self.thread_id = msg_id
   end
 
   def send_proposal_email(proposal:, to_email:, from_email: nil, template_name: nil)
     @proposal = proposal.decorate
 
-    self.assign_threading_headers(proposal)
-    subject = ProposalConversationThreading.subject(proposal)
+    assign_threading_headers(proposal)
+    subject = subject(proposal)
 
     reply_email = reply_to_email().gsub('@', "+#{proposal.public_id}@")
 
@@ -70,5 +24,12 @@ module ProposalConversationThreading
     )
   end
 
-  ###################
+  def subject(proposal)
+    if proposal.client_data_type == "Ncr::WorkOrder"
+      client_data = proposal.client_data
+      %Q(Request #{proposal.public_id}, #{client_data.organization_code}, #{client_data.building_id} from #{proposal.requester.email_address})
+    else
+      "Request #{proposal.public_id}"
+    end
+  end
 end

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -174,9 +174,7 @@ module Ncr
       attributes.map{|key| [WorkOrder.human_attribute_name(key), self[key]]}
     end
 
-    # will return nil if the `org_code` is blank or not present in Organization list
-    def organization
-      # TODO reference by `code` rather than storing the whole thing
+    def ncr_organization
       code = (org_code || '').split(' ', 2)[0]
       Ncr::Organization.find(code)
     end
@@ -199,21 +197,17 @@ module Ncr
       manager.system_approver_emails
     end
 
-    def org_id
-      self.organization.try(:code)
+    def organization_code
+      ncr_organization.try(:code)
     end
 
     def building_id
       regex = /\A(\w{8}) .*\z/
-      if self.building_number && regex.match(self.building_number)
-        regex.match(self.building_number)[1]
+      if building_number && regex.match(building_number)
+        regex.match(building_number)[1]
       else
-        self.building_number
+        building_number
       end
-    end
-
-    def as_json
-      super.merge(org_id: self.org_id, building_id: self.building_id)
     end
 
     def name

--- a/app/serializers/ncr/work_order_serializer.rb
+++ b/app/serializers/ncr/work_order_serializer.rb
@@ -12,7 +12,7 @@ module Ncr
       :id,
       :name,
       :not_to_exceed,
-      :org_code,
+      :organization_code,
       :rwa_number,
       :vendor
     )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,24 +1,3 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more, please read the Rails Internationalization guide
-# available at http://guides.rubyonrails.org/i18n.html.
-
 en:
   date:
     formats:
@@ -55,7 +34,3 @@ en:
         soc_code: "Object field / SOC code"
       observation:
         user_reason_comment: "_%{user} added %{observer} as an observer, giving reason:_ `%{reason}`"
-  mail:
-    subject:
-      proposal: "Request %{public_id}"
-      ncr/work_order: "Request %{public_id}, %{org_id}, %{building_id} from %{requester_email_address}"

--- a/lib/ncr/approval_manager.rb
+++ b/lib/ncr/approval_manager.rb
@@ -57,7 +57,7 @@ module Ncr
 
     def ba_6x_approver_emails
       results = []
-      unless work_order.organization.try(:whsc?)
+      unless work_order.ncr_organization.try(:whsc?)
         results << Ncr::Mailboxes.ba61_tier1_budget
       end
       results << Ncr::Mailboxes.ba61_tier2_budget
@@ -66,7 +66,7 @@ module Ncr
     end
 
     def ba_80_approver_email
-      if work_order.organization.try(:ool?)
+      if work_order.ncr_organization.try(:ool?)
         Ncr::Mailboxes.ool_ba80_budget
       else
         Ncr::Mailboxes.ba80_budget

--- a/spec/features/requester_switches_work_order_to_whsc_spec.rb
+++ b/spec/features/requester_switches_work_order_to_whsc_spec.rb
@@ -11,7 +11,7 @@ feature 'Requester switches work order to WHSC' do
 
   context 'as a BA61' do
     scenario 'reassigns the approvers properly' do
-      expect(work_order.organization).to_not be_whsc
+      expect(work_order.ncr_organization).to_not be_whsc
       approving_official = work_order.approving_official
 
       visit "/ncr/work_orders/#{work_order.id}/edit"
@@ -30,7 +30,7 @@ feature 'Requester switches work order to WHSC' do
     end
 
     scenario 'notifies the removed approver' do
-      expect(work_order.organization).to_not be_whsc
+      expect(work_order.ncr_organization).to_not be_whsc
       deliveries.clear
 
       visit "/ncr/work_orders/#{work_order.id}/edit"
@@ -54,7 +54,7 @@ feature 'Requester switches work order to WHSC' do
       work_order = create(:ba80_ncr_work_order, org_code: Ncr::Organization.all[0].to_s)
       work_order.setup_approvals_and_observers
       work_order.individual_steps.first.approve!
-      expect(work_order.organization).to_not be_whsc
+      expect(work_order.ncr_organization).to_not be_whsc
       ncr_proposal = work_order.proposal
 
       approving_official = work_order.approving_official

--- a/spec/mailers/communicart_mailer_spec.rb
+++ b/spec/mailers/communicart_mailer_spec.rb
@@ -263,26 +263,6 @@ describe CommunicartMailer do
     end
   end
 
-  describe '#proposal_subject' do
-    it 'defaults when no client_data is present' do
-      proposal = create(:proposal)
-      mail = CommunicartMailer.proposal_created_confirmation(proposal)
-      expect(mail.subject).to eq("Request #{proposal.public_id}")
-    end
-
-    it 'includes custom text for ncr work orders' do
-      requester = create(:user, email_address: 'someone@example.com')
-      wo = create(
-        :ncr_work_order,
-        org_code: 'P0000000 (192X,192M) PRIOR YEAR ACTIVITIES',
-        building_number: 'DC0000ZZ - Building',
-        requester: requester
-      )
-      mail = CommunicartMailer.proposal_created_confirmation(wo.proposal)
-      expect(mail.subject).to eq("Request #{wo.proposal.public_id}, P0000000, DC0000ZZ from someone@example.com")
-    end
-  end
-
   describe 'proposal_fiscal_cancellation' do
     it "sends cancellation email for fiscal-year cleanup" do
       proposal = create(:proposal)

--- a/spec/mailers/concerns/proposal_conversation_threading_spec.rb
+++ b/spec/mailers/concerns/proposal_conversation_threading_spec.rb
@@ -1,0 +1,28 @@
+describe ProposalConversationThreading do
+  class TestClass
+    include ProposalConversationThreading
+  end
+
+  describe "#subject" do
+    it "returns string with pub_id, org_code, building_id, requester email for NCR requests" do
+      object = TestClass.new
+      work_order = build(:ncr_work_order)
+      proposal = build(:proposal, client_data: work_order)
+
+      subject = object.subject(proposal)
+
+      expect(subject).to eq "Request #{proposal.public_id}, #{work_order.organization_code}, #{work_order.building_id} from #{proposal.requester.email_address}"
+    end
+
+    it "returns the public id for non-NCR requests" do
+      object = TestClass.new
+      procurement = build(:gsa18f_procurement)
+      proposal = build(:proposal, client_data: procurement)
+
+      subject = object.subject(proposal)
+
+      expect(subject).to eq "Request #{proposal.public_id}"
+
+    end
+  end
+end

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -54,16 +54,16 @@ describe Ncr::WorkOrder do
     end
   end
 
-  describe "#organization" do
+  describe "#ncr_organization" do
     it "returns the corresponding Organization instance" do
       org = Ncr::Organization.all.last
       work_order = build(:ncr_work_order, org_code: org.code)
-      expect(work_order.organization).to eq(org)
+      expect(work_order.ncr_organization).to eq(org)
     end
 
     it "returns nil for no #org_code" do
       work_order = build(:ncr_work_order)
-      expect(work_order.organization).to eq(nil)
+      expect(work_order.ncr_organization).to eq(nil)
     end
   end
 
@@ -179,15 +179,23 @@ describe Ncr::WorkOrder do
     end
   end
 
-  describe "#org_id" do
-    it "pulls out the organization id when present" do
-      wo = create(:ncr_work_order, org_code: 'P0000000 (192X,192M) PRIOR YEAR ACTIVITIES')
-      expect(wo.org_id).to eq("P0000000")
+  describe "#organization_code" do
+    context "work order has an ncr organization" do
+      it "returns the ncr organization code" do
+        work_order = build(:ncr_work_order)
+        organization = Ncr::Organization.all.first
+        allow(work_order).to receive(:ncr_organization).and_return(organization)
+
+        expect(work_order.organization_code).to eq organization.code
+      end
     end
 
-    it "returns nil when no organization is present" do
-      wo = create(:ncr_work_order, org_code: nil)
-      expect(wo.org_id).to be_nil
+    context "work order does not have an ncr organization" do
+      it "returns nil" do
+        work_order = build(:ncr_work_order, org_code: nil)
+
+        expect(work_order.organization_code).to be_nil
+      end
     end
   end
 

--- a/spec/requests/api/ncr/work_orders_spec.rb
+++ b/spec/requests/api/ncr/work_orders_spec.rb
@@ -29,7 +29,7 @@ describe 'NCR Work Orders API' do
             "id" => work_order.id,
             "name" => work_order.name,
             "not_to_exceed" => work_order.not_to_exceed,
-            "org_code" => work_order.org_code,
+            "organization_code" => work_order.organization_code,
             "proposal" => {
               "steps" => [],
               "created_at" => time_to_json(proposal.created_at),


### PR DESCRIPTION
* Been working on moving NCR orgs to the database. In the process, I
  decided that the relationship betwen `ncr_work_order`s and
  `ncr_organization`s should actually be named `ncr_organization` rather
  than `organization`. By making this change now, the move to AR will be
  smaller

*  In the process of that PR, I also found that the use of I18n for
  dealing with email subject logic was confusing. This clarifies that
  logic and puts it under test at the unit level