### PR TITLE
[Delivers #101710542] Unify naming of client-specific code

### DIFF
--- a/app/controllers/gsa18f/procurements_controller.rb
+++ b/app/controllers/gsa18f/procurements_controller.rb
@@ -1,7 +1,7 @@
 module Gsa18f
-  class ProcurementsController < UseCaseController
+  class ProcurementsController < ClientDataController
     def update
-      @model_instance.assign_attributes(permitted_params)
+      @client_data_instance.assign_attributes(permitted_params)
       super
     end
 
@@ -22,7 +22,7 @@ module Gsa18f
     def add_steps
       super
       if self.errors.empty?
-        @model_instance.add_steps
+        @client_data_instance.add_steps
       end
     end
   end

--- a/app/controllers/ncr/work_orders_controller.rb
+++ b/app/controllers/ncr/work_orders_controller.rb
@@ -1,5 +1,5 @@
 module Ncr
-  class WorkOrdersController < UseCaseController
+  class WorkOrdersController < ClientDataController
     # arbitrary number...number of upload fields that "ought to be enough for anybody"
     MAX_UPLOADS_ON_NEW = 10
 
@@ -32,7 +32,7 @@ module Ncr
     protected
 
     def work_order
-      @model_instance
+      @client_data_instance
     end
 
     def record_changes

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
   end
 
   def display_return_to_proposals
-    controller.is_a?(UseCaseController) ||
+    controller.is_a?(ClientDataController) ||
       (controller.is_a?(ProposalsController) && params[:action] != 'index')
   end
 

--- a/app/models/concerns/client_data_mixin.rb
+++ b/app/models/concerns/client_data_mixin.rb
@@ -1,4 +1,4 @@
-module ClientDataType
+module ClientDataMixin
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/concerns/client_data_type.rb
+++ b/app/models/concerns/client_data_type.rb
@@ -4,11 +4,11 @@ module ClientDataType
   included do
     Proposal::CLIENT_MODELS << self
 
-    has_paper_trail class_name: 'C2Version'
+    has_paper_trail class_name: "C2Version"
 
     has_one :proposal, as: :client_data
     has_many :steps, through: :proposal
-    has_many :individual_steps, ->{ individual }, class_name: 'Steps::Individual', through: :proposal
+    has_many :individual_steps, -> { individual }, class_name: "Steps::Individual", through: :proposal
     has_many :approvers, through: :individual_steps, source: :user
     has_many :observations, through: :proposal
     has_many :observers, through: :observations, source: :user

--- a/app/models/concerns/client_data_type.rb
+++ b/app/models/concerns/client_data_type.rb
@@ -1,4 +1,4 @@
-module ProposalDelegate
+module ClientDataType
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/gsa18f/procurement.rb
+++ b/app/models/gsa18f/procurement.rb
@@ -23,7 +23,7 @@ module Gsa18f
       :cost_per_unit
     end
 
-    include ClientDataType
+    include ClientDataMixin
     include PurchaseCardMixin
 
     validates :cost_per_unit, presence: true

--- a/app/models/gsa18f/procurement.rb
+++ b/app/models/gsa18f/procurement.rb
@@ -23,7 +23,7 @@ module Gsa18f
       :cost_per_unit
     end
 
-    include ProposalDelegate
+    include ClientDataType
     include PurchaseCardMixin
 
     validates :cost_per_unit, presence: true

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -15,8 +15,7 @@ module Ncr
       :amount
     end
 
-    include ValueHelper
-    include ProposalDelegate
+    include ClientDataType
     include PurchaseCardMixin
 
     attr_accessor :approving_official_email

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -15,7 +15,7 @@ module Ncr
       :amount
     end
 
-    include ClientDataType
+    include ClientDataMixin
     include PurchaseCardMixin
 
     attr_accessor :approving_official_email

--- a/app/views/gsa18f/procurements/_form.html.haml
+++ b/app/views/gsa18f/procurements/_form.html.haml
@@ -9,7 +9,7 @@
   %p
     %em
       * Indicates a required field
-  = simple_form_for @model_instance do |f|
+  = simple_form_for @client_data_instance do |f|
     = f.input :office, collection: Gsa18f::Procurement::OFFICES
     = f.input :purchase_type,
       collection: Gsa18f::Procurement::PURCHASE_TYPES.keys,
@@ -30,5 +30,5 @@
     = f.input :urgency, collection: Gsa18f::Procurement::URGENCY, label_method: :last, value_method: :first
     = f.input :additional_info, as: :text
     = f.submit class: "form-button"
-    - if @model_instance.persisted?
-      = link_to 'Discard Changes', proposal_url(@model_instance.proposal)
+    - if @client_data_instance.persisted?
+      = link_to 'Discard Changes', proposal_url(@client_data_instance.proposal)

--- a/app/views/ncr/work_orders/_form.html.haml
+++ b/app/views/ncr/work_orders/_form.html.haml
@@ -9,24 +9,24 @@
     %em
       * Indicates a required field
 
-  = simple_form_for @model_instance, html: { multipart: true } do |f|
+  = simple_form_for @client_data_instance, html: { multipart: true } do |f|
     = f.input :project_title
     = f.input :description
     = field_set_tag "Expense type / Program", class: 'required' do
       = expense_type_radio_button(f, 'BA60')
       = expense_type_radio_button(f, 'BA61')
-      = f.input :emergency, disabled: @model_instance.persisted?, wrapper_html: { data: { filter_key: 'expense-type', filter_value: 'BA61' } }
+      = f.input :emergency, disabled: @client_data_instance.persisted?, wrapper_html: { data: { filter_key: 'expense-type', filter_value: 'BA61' } }
       = expense_type_radio_button(f, 'BA80')
       = render partial: 'ba_80_fields', locals: {f: f}
     = f.input :building_number, input_html: { class: 'js-selectize', data: { initial: JSON.generate(building_options) } }
     = f.input :org_code, collection: Ncr::Organization.all, label_method: :to_s, prompt: :translate, input_html: { class: 'js-selectize' }
-    = f.input :vendor, input_html: { class: 'js-selectize', data: { initial: JSON.generate(vendor_options(@model_instance.vendor)) } }
+    = f.input :vendor, input_html: { class: 'js-selectize', data: { initial: JSON.generate(vendor_options(@client_data_instance.vendor)) } }
     = field_set_tag "Amount", class: 'required' do
       = f.input :amount, as: :currency, label_html: { class: 'sr-only' }, input_html: { data: popover_data_attrs('ncr_amount') }
       = f.input :not_to_exceed, as: :radio_buttons, collection: [['Exact', false], ['Not to exceed', true]], label: false
     = f.input :direct_pay
-    = f.input :approving_official_email, collection: approver_options(@model_instance.ineligible_approvers), include_blank: true, disabled: @model_instance.proposal.approver_email_frozen?, prompt: :translate, input_html: { class: 'js-selectize' }, required: true
-    - if @model_instance.new_record?
+    = f.input :approving_official_email, collection: approver_options(@client_data_instance.ineligible_approvers), include_blank: true, disabled: @client_data_instance.proposal.approver_email_frozen?, prompt: :translate, input_html: { class: 'js-selectize' }, required: true
+    - if @client_data_instance.new_record?
       = render partial: 'attachments'
     - else
       = field_set_tag "Budget codes" do
@@ -34,5 +34,5 @@
         = f.input :function_code
         = f.input :soc_code
     = f.submit class: "form-button"
-    - if @model_instance.persisted?
-      = link_to "Discard Changes", proposal_url(@model_instance.proposal)
+    - if @client_data_instance.persisted?
+      = link_to "Discard Changes", proposal_url(@client_data_instance.proposal)

--- a/spec/lib/services/client_data_creator_spec.rb
+++ b/spec/lib/services/client_data_creator_spec.rb
@@ -3,35 +3,35 @@ describe ClientDataCreator do
 
   describe "#run" do
     it "saves the model instance" do
-      model_instance = build(:ncr_work_order)
+      client_data_instance = build(:ncr_work_order)
       user = create(:user)
 
       expect {
-        ClientDataCreator.new(model_instance, user).run
+        ClientDataCreator.new(client_data_instance, user).run
       }.to change { Ncr::WorkOrder.count }.from(0).to(1)
     end
 
     it "saves the proposal for the user passed in" do
-      model_instance = build(:ncr_work_order, proposal: nil)
+      client_data_instance = build(:ncr_work_order, proposal: nil)
       user = create(:user)
 
       expect {
-        ClientDataCreator.new(model_instance, user).run
+        ClientDataCreator.new(client_data_instance, user).run
       }.to change { user.proposals.count }.from(0).to(1)
     end
 
     it "saves the public_id for the proposal created" do
-      model_instance = build(:ncr_work_order, proposal: nil)
+      client_data_instance = build(:ncr_work_order, proposal: nil)
       user = create(:user)
 
-      client_data_creator = ClientDataCreator.new(model_instance, user)
+      client_data_creator = ClientDataCreator.new(client_data_instance, user)
       proposal = client_data_creator.run
 
       expect(proposal.public_id).not_to be_nil
     end
 
     it "creates attachments for the proposal if attachments present" do
-      model_instance = build(:ncr_work_order, proposal: nil)
+      client_data_instance = build(:ncr_work_order, proposal: nil)
       user = create(:user)
       attachment_params = [
         fixture_file_upload('icon-user.png', 'image/png'),
@@ -39,17 +39,17 @@ describe ClientDataCreator do
       ]
 
       expect {
-        ClientDataCreator.new(model_instance, user, attachment_params).run
+        ClientDataCreator.new(client_data_instance, user, attachment_params).run
       }.to change { Attachment.count }.from(0).to(2)
     end
 
     it "does not error on missing attachments" do
-      model_instance = build(:ncr_work_order, proposal: nil)
+      client_data_instance = build(:ncr_work_order, proposal: nil)
       user = create(:user)
       attachment_params = []
 
       expect {
-        ClientDataCreator.new(model_instance, user, attachment_params).run
+        ClientDataCreator.new(client_data_instance, user, attachment_params).run
       }.not_to raise_error
     end
   end


### PR DESCRIPTION
* Previously, used `UseCase`, `model_instnace`, and `proposal_delegate`
* Move to variations of `client_data` everywhere
* Story: https://www.pivotaltracker.com/story/show/101710542