### PR TITLE
[Delivers #109396552] treat step.completer as an approver in proposal policy

### DIFF
--- a/app/models/concerns/client_data_mixin.rb
+++ b/app/models/concerns/client_data_mixin.rb
@@ -10,6 +10,7 @@ module ClientDataMixin
     has_many :steps, through: :proposal
     has_many :individual_steps, -> { individual }, class_name: "Steps::Individual", through: :proposal
     has_many :approvers, through: :individual_steps, source: :user
+    has_many :completers, through: :individual_steps, source: :completer
     has_many :observations, through: :proposal
     has_many :observers, through: :observations, source: :user
     has_many :comments, through: :proposal

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -33,6 +33,7 @@ class Proposal < ActiveRecord::Base
   has_many :steps
   has_many :individual_steps, ->{ individual }, class_name: 'Steps::Individual'
   has_many :approvers, through: :individual_steps, source: :user
+  has_many :completers, through: :individual_steps, source: :completer
   has_many :api_tokens, through: :individual_steps
   has_many :attachments, dependent: :destroy
   has_many :approval_delegates, through: :approvers, source: :outgoing_delegations

--- a/app/policies/proposal_policy.rb
+++ b/app/policies/proposal_policy.rb
@@ -65,7 +65,7 @@ class ProposalPolicy
   end
 
   def approver?
-    @proposal.approvers.exists?(@user.id)
+    @proposal.approvers.exists?(@user.id) || @proposal.completers.exists?(@user.id)
   end
 
   def delegate?

--- a/spec/policies/ncr/work_order_policy_spec.rb
+++ b/spec/policies/ncr/work_order_policy_spec.rb
@@ -14,6 +14,14 @@ describe Ncr::WorkOrderPolicy do
       expect(subject).to permit(work_order.approvers[1], work_order)
     end
 
+    it "allows approval.completer to edit it" do
+      approval = work_order.individual_steps.first
+      delegate_user = create(:user, client_slug: "ncr")
+      approval.completer = delegate_user
+      approval.save!
+      expect(subject).to permit(delegate_user, work_order)
+    end
+
     it "allows an observer to edit it" do
       observer = create(:user, client_slug: "ncr")
       proposal.add_observer(observer.email_address)


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/109396552

To test:

* create a NCR Work Order
* login as a Tier 1 approver delegate (see #823 for testing detail tips)
* after approving the request, the delegate user should be able to modify the proposal (has a big blue Modify Request button on the /proposals/:id page)