### PR TITLE
[Delivers #108469926] add User.display_name method for active_admin to use

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,6 +71,14 @@ class User < ActiveRecord::Base
     end
   end
 
+  def display_name
+    if full_name == email_address
+      email_address
+    else
+      "#{full_name} <#{email_address}>"
+    end
+  end
+
   def last_requested_proposal
     proposals.order("created_at DESC").first
   end

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -43,4 +43,15 @@ describe "admin" do
 
     expect(page).not_to have_content("Edit")
   end
+
+  it "shows user.display_name when viewing User records" do
+    user = create(:user)
+    user.add_role("admin")
+    proposal = create(:proposal, requester: user)
+    login_as(user)
+
+    visit admin_proposals_path
+
+    expect(page).to have_content(user.display_name)
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -137,6 +137,31 @@ describe User do
     end
   end
 
+  describe "#display_name" do
+    it "uses full_name if not equal to email_address" do
+      user.first_name = "George"
+      user.last_name = "Jetson"
+      user.email_address = "george.jetson@example.com"
+      expect(user.display_name).to eq "George Jetson <george.jetson@example.com>"
+    end
+
+    it "returns the user's email address if no first name and last name" do
+      user.first_name = nil
+      user.last_name = nil
+      user.email_address = "george.jetson@example.com"
+
+      expect(user.display_name).to eq "george.jetson@example.com"
+    end
+
+    it "returns the user's email address if the first name and last name are blank" do
+      user.first_name = ""
+      user.last_name = ""
+      user.email_address = "george.jetson@example.com"
+
+      expect(user.display_name).to eq "george.jetson@example.com"
+    end
+  end
+
   describe "#requires_profile_attention?" do
     it "recognizes user needs to update their profile" do
       user = create(:user)


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/108469926

Testing:

 * visit `/admin`
 * any time a user record is displayed, it should use the name+email if both are defined, otherwise just email