### PR TITLE
[Delivers #109559252] Do not trigger reapproval when delegate updates…

### DIFF
--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -151,7 +151,7 @@ module Ncr
     end
 
     def budget_approvers
-      self.approvers.merge(self.budget_approvals)
+      budget_approvals.map(&:completed_by)
     end
 
     def editable?

--- a/spec/features/ncr/work_orders/post_approval_modification_spec.rb
+++ b/spec/features/ncr/work_orders/post_approval_modification_spec.rb
@@ -1,16 +1,11 @@
-describe "post-approval modification" do
+feature "post-approval modification" do
   include ProposalSpecHelper
 
-  let(:work_order) { create(:ncr_work_order) }
-
-  before do
+  scenario "doesn't require re-approval for the amount being decreased" do
     work_order.setup_approvals_and_observers
     fully_approve(work_order.proposal)
 
     login_as(work_order.requester)
-  end
-
-  it "doesn't require re-approval for the amount being decreased" do
     visit "/ncr/work_orders/#{work_order.id}/edit"
     fill_in 'Amount', with: work_order.amount - 1
     click_on 'Update'
@@ -19,7 +14,11 @@ describe "post-approval modification" do
     expect(work_order.status).to eq('approved')
   end
 
-  it "can do end-to-end re-approval" do
+  scenario "can do end-to-end re-approval" do
+    work_order.setup_approvals_and_observers
+    fully_approve(work_order.proposal)
+
+    login_as(work_order.requester)
     visit "/ncr/work_orders/#{work_order.id}/edit"
     fill_in 'Amount', with: work_order.amount + 1
     click_on 'Update'
@@ -53,11 +52,19 @@ describe "post-approval modification" do
     ))
   end
 
-  it "shows flash warning, only on edit page" do
+  scenario "shows flash warning, only on edit page" do
+    work_order.setup_approvals_and_observers
+    fully_approve(work_order.proposal)
+
+    login_as(work_order.requester)
     visit "/ncr/work_orders/#{work_order.id}/edit"
     expect(page).to have_content("You are about to modify a fully approved request")
     click_on "Discard Changes"
     expect(page).to_not have_content("You are about to modify a fully approved request")
+  end
+
+  def work_order
+    @_work_order ||= create(:ncr_work_order)
   end
 
   def approval_statuses

--- a/spec/lib/ncr/work_order_reapproval_checker_spec.rb
+++ b/spec/lib/ncr/work_order_reapproval_checker_spec.rb
@@ -1,74 +1,53 @@
 describe Ncr::WorkOrderReapprovalChecker do
   include ProposalSpecHelper
 
-  describe '#protected_fields_changed?' do
-    it "returns true when the value is changed" do
-      expect(Ncr::WorkOrderReapprovalChecker).to receive(:protected_fields).and_return([:soc_code])
-
-      work_order = create(:ncr_work_order, soc_code: '123')
-      checker = Ncr::WorkOrderReapprovalChecker.new(work_order)
-
-      work_order.update!(soc_code: '456')
-      expect(checker.protected_fields_changed?).to eq(true)
-    end
-
-    it "returns false when the value is set for the first time" do
-      expect(Ncr::WorkOrderReapprovalChecker).to receive(:protected_fields).and_return([:soc_code])
-
-      work_order = create(:ncr_work_order, soc_code: nil)
-      checker = Ncr::WorkOrderReapprovalChecker.new(work_order)
-
-      work_order.update!(soc_code: '123')
-      expect(checker.protected_fields_changed?).to eq(false)
-    end
-
-    it "returns false when the field changed isn't protected" do
-      expect(Ncr::WorkOrderReapprovalChecker).to receive(:protected_fields).and_return([])
-
-      work_order = create(:ncr_work_order, soc_code: '123')
-      checker = Ncr::WorkOrderReapprovalChecker.new(work_order)
-
-      work_order.update!(soc_code: '456')
-      expect(checker.protected_fields_changed?).to eq(false)
-    end
-  end
-
   describe '#requires_budget_reapproval?' do
     it "returns false by when the amount is decreased" do
       work_order = create(:ncr_work_order)
       work_order.approve!
-      work_order.update!(amount: work_order.amount - 1)
 
+      work_order.update!(amount: work_order.amount - 1)
       checker = Ncr::WorkOrderReapprovalChecker.new(work_order)
+
       expect(checker.requires_budget_reapproval?).to eq(false)
     end
 
     it "returns true if amount is increased" do
       work_order = create(:ncr_work_order)
       work_order.approve!
-      work_order.update!(amount: work_order.amount + 1)
 
+      work_order.update!(amount: work_order.amount + 1)
       checker = Ncr::WorkOrderReapprovalChecker.new(work_order)
+
       expect(checker.requires_budget_reapproval?).to eq(true)
     end
 
     it "returns true if one of the protected fields is changed" do
-      work_order = create(:ncr_work_order)
+      work_order = create(:ncr_work_order, function_code: "PGABC")
       work_order.approve!
-      work_order.update!(created_at: Time.zone.now) # just need to trigger an update
 
+      work_order.update!(function_code: "PG123")
       checker = Ncr::WorkOrderReapprovalChecker.new(work_order)
-      expect(checker).to receive(:protected_fields_changed?).and_return(true)
+
       expect(checker.requires_budget_reapproval?).to eq(true)
+    end
+
+    it "returns false if a protected field is set for the first time" do
+      work_order = create(:ncr_work_order, function_code: nil)
+      work_order.approve!
+
+      work_order.update!(function_code: "PG123")
+      checker = Ncr::WorkOrderReapprovalChecker.new(work_order)
+
+      expect(checker.requires_budget_reapproval?).to eq(false)
     end
 
     it "returns false if none of the protected fields are changed" do
       work_order = create(:ncr_work_order)
       work_order.approve!
-      work_order.update!(created_at: Time.zone.now) # just need to trigger an update
 
+      work_order.update!(created_at: Time.zone.now)
       checker = Ncr::WorkOrderReapprovalChecker.new(work_order)
-      expect(checker).to receive(:protected_fields_changed?).and_return(false)
       expect(checker.requires_budget_reapproval?).to eq(false)
     end
 
@@ -76,20 +55,29 @@ describe Ncr::WorkOrderReapprovalChecker do
       work_order = create(:ncr_work_order)
       work_order.setup_approvals_and_observers
       fully_approve(work_order.proposal)
+      work_order.reload
 
       work_order.modifier = work_order.budget_approvers.first
       work_order.update!(function_code: "PG789")
-
       checker = Ncr::WorkOrderReapprovalChecker.new(work_order)
+
       expect(checker.requires_budget_reapproval?).to eq(false)
     end
-  end
 
-  describe '.protected_fields' do
-    it "is a subset of the WorkOrder attributes" do
-      all_fields = Ncr::WorkOrder.attribute_names.map(&:to_sym)
-      protected_fields = Ncr::WorkOrderReapprovalChecker.protected_fields
-      expect(all_fields).to include(*protected_fields)
+    it "returns false if a protected field is changed by a budget approver delegate" do
+      work_order = create(:ncr_work_order)
+      work_order.setup_approvals_and_observers
+      budget_approver = work_order.steps.last.user
+      delegate_user = create(:user)
+      create(:approval_delegate, assigner: budget_approver, assignee: delegate_user)
+      fully_approve(work_order.proposal, delegate_user)
+      work_order.reload
+
+      work_order.modifier = delegate_user
+      work_order.update!(function_code: "PG789")
+      checker = Ncr::WorkOrderReapprovalChecker.new(work_order)
+
+      expect(checker.requires_budget_reapproval?).to eq(false)
     end
   end
 end

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -274,4 +274,25 @@ describe Ncr::WorkOrder do
       ))
     end
   end
+
+  describe "#budget_approvers" do
+    it "returns users assigned to budget approval steps" do
+      work_order = create(:ncr_work_order)
+      work_order.setup_approvals_and_observers
+      budget_mailbox_step = work_order.steps.last
+      user = budget_mailbox_step.user
+
+      expect(work_order.budget_approvers).to include(user)
+    end
+
+    it "returns users who completed budget approval steps" do
+      work_order = create(:ncr_work_order)
+      work_order.setup_approvals_and_observers
+      completer = create(:user)
+      budget_mailbox_step = work_order.steps.last
+      budget_mailbox_step.update(completer: completer)
+
+      expect(work_order.budget_approvers).to include(completer)
+    end
+  end
 end

--- a/spec/support/proposal_spec_helper.rb
+++ b/spec/support/proposal_spec_helper.rb
@@ -3,20 +3,13 @@ module ProposalSpecHelper
     proposal.individual_steps.pluck(:status)
   end
 
-  def fully_approve(proposal)
-    proposal.individual_steps.each do |approval|
-      approval.reload
-      approval.approve!
+  def fully_approve(proposal, completer = nil)
+    proposal.individual_steps.each do |step|
+      step.reload
+      step.approve!
+      if completer
+        step.update(completer: completer)
+      end
     end
-
-    # sanity checks
-    proposal.reload
-    expect(proposal.status).to eq('approved')
-    expect(proposal.root_step.status).to eq('approved')
-    linear_approval_statuses(proposal).each do |status|
-      expect(status).to eq('approved')
-    end
-
-    deliveries.clear
   end
 end


### PR DESCRIPTION
… work order

* Previously were checking if a "budget approver" was updating when deciding
  whether to require reapproval
* A budget approver is defined as someone other than the approving
  official
* If one of the approver mailboxes had a delegate that updated a
  request, it should not have been triggering a reapproval
* This was a new bug because we recently introduced the concept of
  "compeleted" where an approval is completed by a delegate even though
  the approver for the step remains the original approver (mailbox)

Fix:

* Update `Ncr::Workrder#budget_approvers` to include completers
* Update specs in `WorkOrderReapprovalChecker` that were passing for the wrong reasons

* Story: https://www.pivotaltracker.com/story/show/109559252

To QA:

* Create a work order
* Fully approve work order
* Set completer of one of the budget approval steps as a user
* Log in as that user and modify a protected field (eg: function code)
* Make sure that the field was previously set. Setting val from nil
  never triggers reapproval
* Ensure that the field update has not triggered a reapproval flow (see
  emails sent out)