### PR TITLE
make sure C2/tmp/pids exists to prevent ./script/start error

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -8,6 +8,8 @@ if [ ! -f .env ]; then
   cp .env.example .env
 fi
 
+mkdir -p tmp/pids
+
 bundle
 
 bin/rake db:setup


### PR DESCRIPTION
No such file or directory error is thrown by delayed_job command when trying to start the server 