### PR TITLE
[Delivers #109362998] Add 2 more purchase types for 18F

### DIFF
--- a/app/models/gsa18f/procurement.rb
+++ b/app/models/gsa18f/procurement.rb
@@ -25,7 +25,9 @@ module Gsa18f
     PURCHASE_TYPES = {
       "Software" => 0,
       "Training/Event" => 1,
-      "Office Supply/Miscellaneous" => 2
+      "Office Supply/Miscellaneous" => 2,
+      "Hardware" => 3,
+      "Other" => 4,
     }
 
     enum purchase_type: PURCHASE_TYPES

--- a/spec/models/gsa18f/procurement_spec.rb
+++ b/spec/models/gsa18f/procurement_spec.rb
@@ -55,6 +55,18 @@ describe Gsa18f::Procurement do
 
       expect(procurement.purchase_type).to eq "Office Supply/Miscellaneous"
     end
+
+    it "associates 3 with hardware" do
+      procurement = build(:gsa18f_procurement, purchase_type: 3)
+
+      expect(procurement.purchase_type).to eq "Hardware"
+    end
+
+    it "associates 4 with other" do
+      procurement = build(:gsa18f_procurement, purchase_type: 4)
+
+      expect(procurement.purchase_type).to eq "Other"
+    end
   end
 
   describe "#editable?" do


### PR DESCRIPTION
* To QA:
   log in as an 18F user
   visit new procurement form
   see 2 new purchase type options: hardware and other

* Story: https://www.pivotaltracker.com/story/show/109362998