### PR TITLE
Turn on JS for feature specs using selectize

### DIFF
--- a/spec/features/attachment_spec.rb
+++ b/spec/features/attachment_spec.rb
@@ -13,7 +13,7 @@ describe "Add attachments" do
     expect(page).to have_content(attachment.file_file_name)
   end
 
-  it "disables 'add attachment' button if no attachment is selected", js: true do
+  it "disables 'add attachment' button if no attachment is selected", :js do
     proposal = create(:proposal)
     login_as(proposal.requester)
 

--- a/spec/features/ncr/work_orders/create_approver_options_spec.rb
+++ b/spec/features/ncr/work_orders/create_approver_options_spec.rb
@@ -1,0 +1,68 @@
+feature "Approver options during create", :js do
+  scenario "inactive users do not appear as potential approvers" do
+    approver = create(:user, client_slug: "ncr")
+    inactive_user = create(:user, client_slug: "ncr", active: false)
+
+    login_as(requester)
+    visit new_ncr_work_order_path
+
+    within(".ncr_work_order_approving_official_email") do
+      find(".selectize-control").click
+      expect(page).not_to have_content(inactive_user.email_address)
+      expect(page).to have_content(approver.email_address)
+    end
+  end
+
+  scenario "does not show system approver emails as approver options" do
+    _approving_official = create(:user, client_slug: "ncr")
+
+    login_as(requester)
+    visit new_ncr_work_order_path
+
+    expect_page_not_to_have_selectized_options(
+      "ncr_work_order_approving_official_email",
+      Ncr::WorkOrder.ba61_tier1_budget_mailbox,
+      Ncr::WorkOrder.ba61_tier2_budget_mailbox,
+      Ncr::WorkOrder.ba80_budget_mailbox,
+      Ncr::WorkOrder.ool_ba80_budget_mailbox
+    )
+  end
+
+  scenario "does not show requester as approver option" do
+    login_as(requester)
+    visit new_ncr_work_order_path
+
+    expect_page_not_to_have_selectized_options(
+      "ncr_work_order_approving_official_email",
+      requester.email_address
+    )
+  end
+
+  scenario "defaults to no approver if there was no previous request" do
+    _approver = create(:user, client_slug: "ncr")
+    login_as(requester)
+
+    visit new_ncr_work_order_path
+
+    expect_page_not_to_have_selected_selectize_option(
+      "ncr_work_order_approving_official_email",
+      /@example.com/
+    )
+  end
+
+  scenario "defaults to the approver from the last request" do
+    login_as(requester)
+    proposal = create(:proposal, :with_approver, requester: requester, client_slug: "ncr")
+
+    visit new_ncr_work_order_path
+
+    expect_page_to_have_selected_selectize_option(
+      "ncr_work_order_approving_official_email",
+       proposal.approvers.first.email_address
+    )
+  end
+
+  def requester
+    @_requester ||= create(:user, client_slug: "ncr")
+  end
+end

--- a/spec/features/ncr/work_orders/create_requires_login_spec.rb
+++ b/spec/features/ncr/work_orders/create_requires_login_spec.rb
@@ -1,0 +1,19 @@
+feature "Creating an NCR work order requires user to log in" do
+  scenario "requires sign-in" do
+    visit new_ncr_work_order_path
+
+    expect(current_path).to eq root_path
+    expect(page).to have_content("You need to sign in")
+  end
+
+  with_feature "RESTRICT_ACCESS" do
+    scenario "requires a GSA email address" do
+      user = create(:user, email_address: "intruder@example.com", client_slug: "ncr")
+      login_as(user)
+
+      visit new_ncr_work_order_path
+
+      expect(page).to have_content("You must be logged in with a GSA email address")
+    end
+  end
+end

--- a/spec/features/ncr/work_orders/create_spec.rb
+++ b/spec/features/ncr/work_orders/create_spec.rb
@@ -1,411 +1,89 @@
-feature 'Creating an NCR work order' do
-  scenario 'requires sign-in' do
-    visit '/ncr/work_orders/new'
-    expect(current_path).to eq('/')
-    expect(page).to have_content("You need to sign in")
-  end
-
-  with_feature 'RESTRICT_ACCESS' do
-    scenario 'requires a GSA email address' do
-      user = create(:user, email_address: 'intruder@example.com', client_slug: "ncr")
-      login_as(user)
-
-      visit '/ncr/work_orders/new'
-
-      expect(page.status_code).to eq(403)
-      expect(page).to have_content("You must be logged in with a GSA email address")
-    end
-  end
-
-  context 'when signed in as the requester' do
-    let(:requester) { create(:user, client_slug: "ncr") }
-    let(:ncr_helper_class) { Class.new { extend Ncr::WorkOrdersHelper } }
-
-    scenario 'saves a Proposal with the attributes' do
+feature "Creating an NCR work order", :js do
+  context "when signed in as an NCR user" do
+    scenario "saves a Proposal with the attributes" do
       approver = create(:user, client_slug: "ncr")
       project_title = "buying stuff"
       login_as(requester)
-      expect(Dispatcher).to receive(:deliver_new_proposal_emails)
 
-      visit '/ncr/work_orders/new'
+      visit new_ncr_work_order_path
       fill_in 'Project title', with: project_title
       fill_in 'Description', with: "desc content"
       choose 'BA80'
       fill_in 'RWA Number', with: 'F1234567'
-      fill_in 'Vendor', with: 'ACME'
+      fill_in_selectized("ncr_work_order_building_number", "Test building")
+      fill_in_selectized("ncr_work_order_vendor", "ACME")
       fill_in 'Amount', with: 123.45
-      check "I am going to be using direct pay for this transaction"
-      select approver.email_address, from: 'ncr_work_order[approving_official_email]'
-      fill_in 'Building number', with: Ncr::BUILDING_NUMBERS[0]
-      select Ncr::Organization.all[0], from: 'ncr_work_order_org_code'
-      expect { click_on 'Submit for approval' }.to change { Proposal.count }.from(0).to(1)
+      fill_in_selectized("ncr_work_order_approving_official_email", approver.email_address)
+      fill_in_selectized("ncr_work_order_org_code", "P0010091 (192X,192M) VISION 2000")
+      click_on "Submit for approval"
 
-      proposal = Proposal.last
-      expect(proposal.public_id).to have_content("FY")
       expect(page).to have_content("Proposal submitted")
-      expect(current_path).to eq("/proposals/#{proposal.id}")
-
-      expect(proposal.name).to eq(project_title)
-      expect(proposal.flow).to eq('linear')
-      work_order = proposal.client_data
-      expect(work_order.client_slug).to eq("ncr")
-      expect(work_order.expense_type).to eq('BA80')
-      expect(work_order.vendor).to eq('ACME')
-      expect(work_order.amount).to eq(123.45)
-      expect(work_order.direct_pay).to eq(true)
-      expect(work_order.building_number).to eq(Ncr::BUILDING_NUMBERS[0])
-      expect(work_order.org_code).to eq(Ncr::Organization.all[0].to_s)
-      expect(work_order.description).to eq('desc content')
-      expect(proposal.requester).to eq(requester)
-      expect(proposal.approvers.map(&:email_address)).to eq(
-        [approver.email_address, Ncr::Mailboxes.ba80_budget])
-    end
-
-    scenario 'saves a BA60 Proposal with the attributes' do
-      approver = create(:user, client_slug: "ncr")
-      login_as(requester)
-      expect(Dispatcher).to receive(:deliver_new_proposal_emails)
-
-      visit '/ncr/work_orders/new'
-      fill_in 'Project title', with: "blue shells"
-      fill_in 'Description', with: "desc content"
-      choose 'BA60'
-      fill_in 'Vendor', with: 'Yoshi'
-      fill_in 'Amount', with: 123.45
-      select approver.email_address, from: "Approving official's email address"
-      fill_in 'Building number', with: Ncr::BUILDING_NUMBERS[0]
-      select Ncr::Organization.all[0], from: 'ncr_work_order_org_code'
-      expect { click_on 'Submit for approval' }.to change { Proposal.count }.from(0).to(1)
-
-      proposal = Proposal.last
-      work_order = proposal.client_data
-      expect(work_order.expense_type).to eq('BA60')
-      expect(proposal.approvers.map(&:email_address)).to eq [
-        approver.email_address,
-        Ncr::Mailboxes.ba61_tier1_budget,
-        Ncr::Mailboxes.ba61_tier2_budget
-      ]
+      expect(page).to have_content(project_title)
+      expect(page).to have_content("BA80")
+      expect(page).to have_content("ACME")
+      expect(page).to have_content("$123.45")
+      expect(page).to have_content("Test building")
+      expect(page).to have_content("P0010091 (192X,192M) VISION 2000")
+      expect(page).to have_content("desc content")
     end
 
     scenario "flash message on error does not persist" do
-      approver = create(:user, client_slug: "ncr")
       login_as(requester)
 
-      visit '/ncr/work_orders/new'
-      fill_in 'Project title', with: "blue shells"
-      fill_in 'Description', with: "desc content"
-      choose 'BA60'
-      fill_in 'Vendor', with: 'Yoshi'
+      visit new_ncr_work_order_path
+      fill_in "Project title", with: "test"
+      choose "BA60"
+      fill_in_selectized("ncr_work_order_vendor", "ACME")
       fill_in 'Amount', with: 123.45
-      fill_in 'Building number', with: Ncr::BUILDING_NUMBERS[0]
-      select Ncr::Organization.all[0], from: 'ncr_work_order_org_code'
-      click_on 'Submit for approval'
+      click_on "Submit for approval"
 
       expect(page).to have_content("Approving official email can't be blank")
-
-      visit "/proposals"
+      visit proposals_path
       expect(page).to_not have_content("Approving official email can't be blank")
     end
 
-    scenario "inactive users do not appear as potential approvers", :js do
-      approver = create(:user, client_slug: "ncr")
-      inactive_user = create(:user, client_slug: "ncr", active: false)
+    scenario "shows hint text for amount field" do
       login_as(requester)
-      visit '/ncr/work_orders/new'
-      within(".ncr_work_order_approving_official_email") do
-        find(".selectize-control").click
-        expect(page).not_to have_content(inactive_user.email_address)
-      end
-    end
+      visit new_ncr_work_order_path
 
-    scenario 'shows the radio button' do
-      login_as(requester)
-      visit '/ncr/work_orders/new'
-      expect(page).to have_content('BA60')
-      expect(page).to have_content('BA61')
-      expect(page).to have_content('BA80')
-    end
+      focus_field "ncr_work_order_amount"
 
-    scenario "does not show system approver emails as approver options", :js do
-      expect(Ncr::WorkOrder.all_system_approver_emails.size).to eq 4
-      login_as(requester)
-      approving_official = create(:user, client_slug: "ncr")
-      visit "/ncr/work_orders/new"
-      within(".ncr_work_order_approving_official_email") do
-        find(".selectize-control").click
-        expect(page).to have_content(approving_official.email_address)
-        expect(page).not_to have_content(Ncr::WorkOrder.ba61_tier1_budget_mailbox)
-        expect(page).not_to have_content(Ncr::WorkOrder.ba61_tier2_budget_mailbox)
-        expect(page).not_to have_content(Ncr::WorkOrder.ba80_budget_mailbox)
-        expect(page).not_to have_content(Ncr::WorkOrder.ool_ba80_budget_mailbox)
-      end
-    end
-
-    scenario "does not show requester as approver option", :js do
-      login_as(requester)
-      visit "/ncr/work_orders/new"
-      within(".ncr_work_order_approving_official_email") do
-        find(".selectize-control").click
-        expect(page).not_to have_content(requester.email_address)
-      end
-    end
-
-    scenario 'shows hint text for amount field', :js do
-      login_as(requester)
-      visit '/ncr/work_orders/new'
-      focus_field 'ncr_work_order_amount'
-      expect(page).to have_content('$3,500 for supplies')
-      expect(page).to have_content('$2,500 for services')
-      expect(page).to have_content('$2,000 for construction')
-    end
-
-    context "expense type is BA60" do
-      scenario "building id is not required", :js do
-        login_as(requester)
-        visit new_ncr_work_order_path
-        select_expense_type("ba60")
-        find("#ncr_work_order_expense_type_ba60").click
-        expect_building_id_not_to_be_required
-      end
-    end
-
-    context "expense type is not BA60" do
-      scenario "building id is required", :js do
-        login_as(requester)
-        visit new_ncr_work_order_path
-        ["ba61", "ba80"].each do |expense_type|
-          select_expense_type(expense_type)
-          expect_building_id_to_be_required
-        end
-      end
-    end
-
-    context "selects BA60 and then unselects BA60" do
-      scenario "building id is required", :js do
-        login_as(requester)
-        visit new_ncr_work_order_path
-        select_expense_type("ba60")
-        select_expense_type("ba80")
-        expect_building_id_to_be_required
-      end
-    end
-
-    scenario 'defaults to no approver if there was no previous request' do
-      login_as(requester)
-      visit '/ncr/work_orders/new'
-      expect(find_field("Approving official's email address").value).to eq('')
-    end
-
-    scenario 'defaults to the approver from the last request' do
-      login_as(requester)
-      proposal = create(:proposal, :with_serial_approvers, requester: requester, client_slug: "ncr")
-      visit '/ncr/work_orders/new'
-      expect(find_field("Approving official's email address").value).to eq(proposal.approvers.first.email_address)
-    end
-
-    scenario 'requires a project_title' do
-      login_as(requester)
-      visit '/ncr/work_orders/new'
-      expect { click_on 'Submit for approval' }.to_not change { Proposal.count }
-      expect(page).to have_content("Project title can't be blank")
-    end
-
-    scenario "doesn't show the budget fields" do
-      login_as(requester)
-      visit '/ncr/work_orders/new'
-      expect(page).to_not have_field('CL number')
-      expect(page).to_not have_field('Function code')
-      expect(page).to_not have_field('SOC code')
-    end
-
-    scenario "doesn't save when the amount is too high" do
-      login_as(requester)
-      visit '/ncr/work_orders/new'
-      fill_in 'Project title', with: "buying stuff"
-      choose 'BA80'
-      fill_in 'Vendor', with: 'ACME'
-      fill_in 'Amount', with: 10_000
-
-      expect { click_on 'Submit for approval' }.to_not change { Proposal.count }
-      expect(current_path).to eq('/ncr/work_orders')
-      expect(page).to have_content("Amount must be less than or equal to $")
-      expect(find_field('Amount').value).to eq('10000')
+      expect(page).to have_content("$3,500 for supplies")
+      expect(page).to have_content("$2,500 for services")
+      expect(page).to have_content("$2,000 for construction")
     end
 
     scenario "preserve form values on submission error" do
       login_as(requester)
-      work_order = create(:ncr_work_order, :with_approvers)
+      visit new_ncr_work_order_path
 
-      expect(Proposal.count).to eq(1)
-      expect(ncr_helper_class.vendor_options).to eq([work_order.vendor])
+      fill_in "Project title", with: "buying stuff"
+      choose "BA80"
+      fill_in_selectized("ncr_work_order_vendor", "ACME")
+      click_on "Submit for approval"
 
-      visit '/ncr/work_orders/new'
-      fill_in 'Project title', with: "buying stuff"
-      choose 'BA80'
-      fill_in 'Vendor', with: 'ACME'
-      fill_in 'Amount', with: 10_000
-
-      expect { click_on 'Submit for approval' }.to_not change { Proposal.count }
-      expect(ncr_helper_class.vendor_options('zzbar')).to eq([work_order.vendor, 'zzbar'])
-      expect(find_field('Amount').value).to eq('10000')
-      expect(find_field('Vendor').value).to eq('ACME')
-      expect(JSON.parse(find_field('Vendor')['data-initial'])).to eq(['ACME', work_order.vendor])
+      expect_page_to_have_selected_selectize_option(
+        "ncr_work_order_vendor",
+        "ACME"
+      )
     end
 
-    scenario "includes has overwritten field names" do
-      approver = create(:user, client_slug: "ncr")
-      login_as(requester)
-      visit '/ncr/work_orders/new'
-      fill_in 'Project title', with: "buying stuff"
-      choose 'BA80'
-      fill_in 'RWA Number', with: 'B9876543'
-      fill_in 'Vendor', with: 'ACME'
-      fill_in 'Amount', with: 123.45
-      select approver.email_address, from: 'ncr_work_order[approving_official_email]'
-      fill_in 'Building number', with: Ncr::BUILDING_NUMBERS[0]
-      select Ncr::Organization.all[0], from: 'ncr_work_order_org_code'
-      click_on 'Submit for approval'
-      expect(current_path).to eq("/proposals/#{Proposal.last.id}")
-      expect(page).to have_content("RWA Number")
-    end
-
-    scenario 'hides fields based on expense', :js do
-      login_as(requester)
-      visit '/ncr/work_orders/new'
-      expect(page).to have_no_field("RWA Number")
-      expect(page).to have_no_field("Work Order")
-      expect(page).to have_no_field("emergency")
-      choose 'BA61'
-      expect(page).to have_no_field("RWA Number")
-      expect(page).to have_no_field("Work Order")
-      expect(page).to have_field("emergency")
-      expect(find_field("emergency", visible: false)).to be_visible
-      choose 'BA80'
-      expect(page).to have_field("RWA Number")
-      expect(page).to have_field("Work Order")
-      expect(page).to have_no_field("emergency")
-      expect(find_field("RWA Number")).to be_visible
-    end
-
-    scenario 'allows attachments to be added during intake without JS' do
-      login_as(requester)
-      visit '/ncr/work_orders/new'
-      expect(page).to have_content("Attachments")
-      expect(page).not_to have_selector(".js-am-minus")
-      expect(page).not_to have_selector(".js-am-plus")
-      expect(page).to have_selector("input[type=file]", count: 10)
-    end
-
-    scenario 'allows attachments to be added during intake with JS', :js do
-      login_as(requester)
-      visit '/ncr/work_orders/new'
-      expect(page).to have_content("Attachments")
-      first_minus = find(".js-am-minus")
-      first_plus = find(".js-am-plus")
-      expect(first_minus).to be_visible
-      expect(first_plus).to be_visible
-      expect(first_minus).to be_disabled
-      expect(find("input[type=file]")[:name]).to eq("attachments[]")
-      first_plus.click # Adds one row
-      expect(page).to have_selector(".js-am-minus", count: 2)
-      expect(page).to have_selector(".js-am-plus", count: 2)
-      expect(page).to have_selector("input[type=file]", count: 2)
-    end
-
-    scenario 'includes an initial list of buildings', :js do
-      login_as(requester)
-      visit '/ncr/work_orders/new'
-      option = Ncr::BUILDING_NUMBERS.sample
-
-      expect(page).not_to have_selector(".option[data-value='#{option}']")
-
-      find("input[aria-label='Building number']").native.send_keys(option)
-      expect(page).to have_selector("div.option[data-value='#{option}']")
-    end
-
-    scenario 'does not include custom buildings initially', :js do
-      login_as(requester)
-      visit '/ncr/work_orders/new'
-      find("input[aria-label='Building number']").native.send_keys("BillDing")
-      expect(page).not_to have_selector("div.option[data-value='BillDing']")
-    end
-
-    scenario 'includes previously entered buildings, too', :js do
-      login_as(requester)
+    scenario "includes previously entered buildings" do
       create(:ncr_work_order, building_number: "BillDing")
-      visit '/ncr/work_orders/new'
-      find("input[aria-label='Building number']").native.send_keys("BillDing")
-      expect(page).to have_selector("div.option[data-value='BillDing']")
-    end
-
-    context "selected common values on proposal page" do
-      before do
-        approver = create(:user, client_slug: "ncr")
-        login_as(requester)
-        visit '/ncr/work_orders/new'
-
-        fill_in 'Project title', with: "buying stuff"
-        fill_in 'Vendor', with: 'ACME'
-        fill_in 'Amount', with: 123.45
-        select approver.email_address, from: 'ncr_work_order[approving_official_email]'
-        fill_in 'Building number', with: Ncr::BUILDING_NUMBERS[0]
-        select Ncr::Organization.all[0], from: 'ncr_work_order_org_code'
-      end
-
-      scenario 'approves emergencies' do
-        choose 'BA61'
-        check "This request was an emergency and I received a verbal Notice to Proceed (NTP)"
-        expect { click_on 'Submit for approval' }.to change { Proposal.count }.from(0).to(1)
-
-        proposal = Proposal.last
-        expect(page).to have_content("Proposal submitted")
-        expect(current_path).to eq("/proposals/#{proposal.id}")
-        expect(page).to have_content("0 of 0 steps completed")
-
-        expect(proposal.client_data.emergency).to eq(true)
-        expect(proposal.approved?).to eq(true)
-        expect(proposal.approvers).to be_empty
-        expect(proposal.client_data.decorate.current_approver_email_address).to eq(Ncr::WorkOrderDecorator::EMERGENCY_APPROVER_EMAIL)
-        expect(proposal.client_data.decorate.final_approver_email_address).to eq(Ncr::WorkOrderDecorator::EMERGENCY_APPROVER_EMAIL)
-      end
-
-      scenario 'does not set emergencies if form type changes' do
-        choose 'BA61'
-        check 'This request was an emergency and I received a verbal Notice to Proceed (NTP)'
-        choose 'BA80'
-        fill_in 'RWA Number', with: 'R9876543'
-        expect { click_on 'Submit for approval' }.to change { Proposal.count }.from(0).to(1)
-
-        proposal = Proposal.last
-        expect(page).to have_content('Proposal submitted')
-        expect(current_path).to eq("/proposals/#{proposal.id}")
-
-        expect(proposal.client_data.emergency).to eq(false)
-        expect(proposal.approved?).to eq(false)
-      end
-    end
-
-    scenario 'does not disable the emergency field' do
       login_as(requester)
-      visit '/ncr/work_orders/new'
-      expect(find_field('emergency')).not_to be_disabled
+
+      visit new_ncr_work_order_path
+
+      expect_page_to_have_selectized_options("ncr_work_order_building_number", "BillDing")
     end
+  end
+
+  def requester
+    @_requester ||= create(:user, client_slug: "ncr")
   end
 
   def focus_field(field_id)
     execute_script "document.getElementById('#{field_id}').scrollIntoView()"
     execute_script "$('##{field_id}').focus()"
-  end
-
-  def select_expense_type(expense_type)
-    find("#ncr_work_order_expense_type_#{expense_type}").click
-  end
-
-  def expect_building_id_not_to_be_required
-    expect(find('.ncr_work_order_building_number input')['class']).to_not match('required')
-  end
-
-  def expect_building_id_to_be_required
-    expect(find('.ncr_work_order_building_number input')['class']).to match('required')
   end
 end

--- a/spec/features/ncr/work_orders/create_with_attachment_spec.rb
+++ b/spec/features/ncr/work_orders/create_with_attachment_spec.rb
@@ -1,0 +1,33 @@
+feature "Create NCR work order with attachment" do
+  scenario "allows attachments to be added during intake without JS" do
+    login_as(requester)
+    visit new_ncr_work_order_path
+
+    expect(page).to have_content("Attachments")
+    expect(page).not_to have_selector(".js-am-minus")
+    expect(page).not_to have_selector(".js-am-plus")
+    expect(page).to have_selector("input[type=file]", count: 10)
+  end
+
+  scenario "allows attachments to be added during intake with JS", :js do
+    login_as(requester)
+    visit new_ncr_work_order_path
+
+    first_minus = find(".js-am-minus")
+    first_plus = find(".js-am-plus")
+
+    expect(page).to have_content("Attachments")
+    expect(first_minus).to be_visible
+    expect(first_plus).to be_visible
+    expect(first_minus).to be_disabled
+    expect(find("input[type=file]")[:name]).to eq("attachments[]")
+    first_plus.click # Adds one row
+    expect(page).to have_selector(".js-am-minus", count: 2)
+    expect(page).to have_selector(".js-am-plus", count: 2)
+    expect(page).to have_selector("input[type=file]", count: 2)
+  end
+
+  def requester
+    @_requester ||= create(:user, client_slug: "ncr")
+  end
+end

--- a/spec/features/ncr/work_orders/create_with_different_expense_types_spec.rb
+++ b/spec/features/ncr/work_orders/create_with_different_expense_types_spec.rb
@@ -1,0 +1,110 @@
+feature "Create NCR Work orders with different expense types", :js do
+  scenario "hides fields based on expense" do
+    login_as(requester)
+    visit new_ncr_work_order_path
+
+    expect(page).to have_no_field("RWA Number")
+    expect(page).to have_no_field("Work Order")
+    expect(page).to have_no_field("emergency")
+
+    choose "BA61"
+    expect(page).to have_no_field("RWA Number")
+    expect(page).to have_no_field("Work Order")
+    expect(page).to have_field("emergency")
+    expect(find_field("emergency", visible: false)).to be_visible
+
+    choose "BA80"
+    expect(page).to have_field("RWA Number")
+    expect(page).to have_field("Work Order")
+    expect(page).to have_no_field("emergency")
+    expect(find_field("RWA Number")).to be_visible
+  end
+
+  context "BA61 emergency request" do
+    scenario "approves request automatically" do
+      approver = create(:user, client_slug: "ncr")
+      login_as(requester)
+      visit new_ncr_work_order_path
+
+      fill_in "Project title", with: "Test project title"
+      choose "BA61"
+      check "This request was an emergency and I received a verbal Notice to Proceed (NTP)"
+      fill_in_selectized("ncr_work_order_building_number", "Test Building")
+      fill_in_selectized("ncr_work_order_vendor", "Test vendor")
+      fill_in "Amount", with: 123.45
+      fill_in_selectized("ncr_work_order_approving_official_email", approver.email_address)
+      click_on "Submit for approval"
+
+      expect(page).to have_content("Proposal submitted")
+      expect(page).to have_content("0 of 0 steps completed")
+    end
+  end
+
+  context "BA61 emergency request selected and then unselected" do
+    scenario "request is not set as emergency" do
+      approver = create(:user, client_slug: "ncr")
+      login_as(requester)
+      visit new_ncr_work_order_path
+
+      fill_in "Project title", with: "Test project title"
+      choose "BA61"
+      check "This request was an emergency and I received a verbal Notice to Proceed (NTP)"
+      choose "BA60"
+      fill_in_selectized("ncr_work_order_building_number", "Test Building")
+      fill_in_selectized("ncr_work_order_vendor", "Test vendor")
+      fill_in "Amount", with: 123.45
+      fill_in_selectized("ncr_work_order_approving_official_email", approver.email_address)
+      click_on "Submit for approval"
+
+      expect(page).to have_content("Proposal submitted")
+      expect(page).to have_content("0 of 3 steps completed")
+    end
+  end
+
+  context "expense type is BA60" do
+    scenario "building id is not required" do
+      login_as(requester)
+      visit new_ncr_work_order_path
+      select_expense_type("ba60")
+      find("#ncr_work_order_expense_type_ba60").click
+      expect_building_id_not_to_be_required
+    end
+  end
+
+  context "expense type is not BA60" do
+    scenario "building id is required" do
+      login_as(requester)
+      visit new_ncr_work_order_path
+      ["ba61", "ba80"].each do |expense_type|
+        select_expense_type(expense_type)
+        expect_building_id_to_be_required
+      end
+    end
+  end
+
+  context "selects BA60 and then unselects BA60" do
+    scenario "building id is required" do
+      login_as(requester)
+      visit new_ncr_work_order_path
+      select_expense_type("ba60")
+      select_expense_type("ba80")
+      expect_building_id_to_be_required
+    end
+  end
+
+  def requester
+    @_requester ||= create(:user, client_slug: "ncr")
+  end
+
+  def select_expense_type(expense_type)
+    find("#ncr_work_order_expense_type_#{expense_type}").click
+  end
+
+  def expect_building_id_not_to_be_required
+    expect(find('.ncr_work_order_building_number input')['class']).to_not match('required')
+  end
+
+  def expect_building_id_to_be_required
+    expect(find('.ncr_work_order_building_number input')['class']).to match('required')
+  end
+end

--- a/spec/support/feature_spec_helper.rb
+++ b/spec/support/feature_spec_helper.rb
@@ -8,4 +8,44 @@ module FeatureSpecHelper
     setup_mock_auth(:myusa, user)
     visit '/auth/myusa'
   end
+
+  def fill_in_selectized(selectize_class, text)
+    find(".#{selectize_class} .selectize-input input").native.send_keys(text) #fill the input text
+    find(:xpath, "//div[@data-selectable and contains(., '#{text}')]").click #wait for the input and then click on it
+  end
+
+  def expect_page_not_to_have_selectized_options(field, *values)
+    values.each do |value|
+      within(".#{field}") do
+        find(".selectize-control").click
+        expect(page).not_to have_content(value)
+      end
+    end
+  end
+
+  def expect_page_to_have_selectized_options(field, *values)
+    values.each do |value|
+      within(".#{field}") do
+        find(".selectize-control").click
+        expect(page).to have_content(value)
+      end
+    end
+  end
+
+  def expect_page_to_have_selected_selectize_option(field, text)
+    within(".#{field}") do
+      find(".selectize-control").click
+      within(".dropdown-active") do
+        expect(page).to have_content(text)
+      end
+    end
+  end
+  def expect_page_not_to_have_selected_selectize_option(field, text)
+    within(".#{field}") do
+      find(".selectize-control").click
+      within(".dropdown-active") do
+        expect(page).not_to have_content(text)
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Previously, we turned JS on for some and off for others
* The problem with this was that we were not mirroring reality --
  selectize changes the values for certain fields, so params were being
  set differently when javascript was turned off
* This PR moves on JS for all feature specs for creating a work order
* Adds helper methods for setting and viewing values for selectize fields