### PR TITLE
[Delivers #109547738] catch policy exception for already-approved proposal

### DIFF
--- a/app/controllers/concerns/token_auth.rb
+++ b/app/controllers/concerns/token_auth.rb
@@ -45,7 +45,12 @@ module TokenAuth
         redirect_to root_path(return_to: return_to_param), alert: "Please sign in to complete this action."
       end
     when Proposal
-      render "authorization_error", status: 403, locals: { msg: "You are not allowed to see that proposal." }
+      if exception.message == "A response has already been logged for this proposal"
+        flash[:error] = exception.message
+        redirect_to self.proposal
+      else
+        render "authorization_error", status: 403, locals: { msg: "You are not allowed to see that proposal." }
+      end
     else
       flash[:error] = exception.message
       redirect_to self.proposal

--- a/app/policies/proposal_policy.rb
+++ b/app/policies/proposal_policy.rb
@@ -98,7 +98,7 @@ class ProposalPolicy
 
   def pending_approval!
     check(self.pending_approver? || self.pending_delegate?,
-          "A response has already been logged a response for this proposal")
+          "A response has already been logged for this proposal")
   end
 
   def visible_proposals

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -300,7 +300,7 @@ describe ProposalsController do
       post :approve, id: proposal.id
 
       expect(response).to redirect_to(proposal_path(proposal))
-      expect(flash[:error]).not_to be_nil
+      expect(flash[:error]).to eq "A response has already been logged for this proposal"
     end
 
     it "allows a delegate to approve via the web UI" do

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -218,7 +218,7 @@ describe ProposalsController do
       approval = proposal.individual_steps.first
       token = create(:api_token, step: approval)
 
-      post :approve, id: proposal.id, cch: token.access_token
+      get :approve, id: proposal.id, cch: token.access_token
 
       expect(controller.send(:current_user)).to eq(approval.user)
     end

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -229,9 +229,8 @@ describe ProposalsController do
       token = create(:api_token, step: approval)
       approval.user.add_delegate(create(:user))
 
-      post :approve, id: proposal.id, cch: token.access_token
+      get :approve, id: proposal.id, cch: token.access_token
 
-      # TODO simplify this check
       expect(response).to redirect_to(root_path(return_to: self.make_return_to("Previous", request.fullpath)))
     end
 
@@ -279,7 +278,8 @@ describe ProposalsController do
       flash.clear
       post :approve, id: proposal.id
 
-      expect(response.status).to eq(403)
+      expect(response).to redirect_to(proposal_path(proposal))
+      expect(flash[:error]).not_to be_nil
     end
 
     it "won't allow different delegates to approve" do
@@ -299,7 +299,8 @@ describe ProposalsController do
       login_as(delegate2)
       post :approve, id: proposal.id
 
-      expect(response.status).to eq(403)
+      expect(response).to redirect_to(proposal_path(proposal))
+      expect(flash[:error]).not_to be_nil
     end
 
     it "allows a delegate to approve via the web UI" do

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -279,7 +279,7 @@ describe ProposalsController do
       post :approve, id: proposal.id
 
       expect(response).to redirect_to(proposal_path(proposal))
-      expect(flash[:error]).not_to be_nil
+      expect(flash[:error]).to eq "A response has already been logged for this proposal"
     end
 
     it "won't allow different delegates to approve" do


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/109547738

Test:

* Create NCR work order with approver that delegates to 2 or more other users
* Using the Approve link in the email that is sent, approve the work order as one of the delegates. The Proposal should approve as usual.
* Using the same Approve link in a different browser, try to use the link as the other delegate. Instead of an authorization error, you should be redirected to the proposals/:id link and get an error message that "A response has already been logged for this proposal"
![screen shot 2015-12-08 at 10 54 17 am](https://cloud.githubusercontent.com/assets/1205061/11661980/2b97a2d0-9d9a-11e5-9a71-66c409c150b5.png)
