### PR TITLE
[Delivers #109219130] Preserve approving official email on Ncr::WorkO…

### DIFF
--- a/app/controllers/ncr/work_orders_controller.rb
+++ b/app/controllers/ncr/work_orders_controller.rb
@@ -14,7 +14,7 @@ module Ncr
     end
 
     def edit
-      @client_data_instance.approving_official_email = @client_data_instance.approvers.first.email_address
+      @client_data_instance.approving_official_email = @client_data_instance.approvers.first.try(:email_address)
 
       if proposal.approved?
         flash.now[:warning] = "You are about to modify a fully approved request. Changes will be logged and sent to approvers, and this request may require re-approval, depending on the change."

--- a/app/controllers/ncr/work_orders_controller.rb
+++ b/app/controllers/ncr/work_orders_controller.rb
@@ -14,7 +14,9 @@ module Ncr
     end
 
     def edit
-      if self.proposal.approved?
+       @client_data_instance.approving_official_email = @client_data_instance.approvers.first.email_address
+
+      if proposal.approved?
         flash.now[:warning] = "You are about to modify a fully approved request. Changes will be logged and sent to approvers, and this request may require re-approval, depending on the change."
       end
 
@@ -44,7 +46,7 @@ module Ncr
         work_order: work_order,
         flash: flash
       )
-      updater.after_update
+      updater.run
     end
 
     def attribute_changes?

--- a/app/controllers/ncr/work_orders_controller.rb
+++ b/app/controllers/ncr/work_orders_controller.rb
@@ -14,7 +14,7 @@ module Ncr
     end
 
     def edit
-       @client_data_instance.approving_official_email = @client_data_instance.approvers.first.email_address
+      @client_data_instance.approving_official_email = @client_data_instance.approvers.first.email_address
 
       if proposal.approved?
         flash.now[:warning] = "You are about to modify a fully approved request. Changes will be logged and sent to approvers, and this request may require re-approval, depending on the change."

--- a/app/helpers/ncr/work_orders_helper.rb
+++ b/app/helpers/ncr/work_orders_helper.rb
@@ -9,13 +9,11 @@ module Ncr
     def building_options
       custom = Ncr::WorkOrder.where.not(building_number: nil).pluck('DISTINCT building_number')
       all = custom + Ncr::BUILDING_NUMBERS
-      # @todo is there a better order? maybe by current_user's use?
       all.uniq.sort
     end
 
     def vendor_options(vendor = nil)
       all_vendors = Ncr::WorkOrder.where.not(vendor: nil).pluck('DISTINCT vendor')
-      # merge in any passed
       if vendor
         all_vendors.push(vendor)
       end

--- a/app/views/ncr/work_orders/_form.html.haml
+++ b/app/views/ncr/work_orders/_form.html.haml
@@ -12,20 +12,39 @@
   = simple_form_for @client_data_instance, html: { multipart: true } do |f|
     = f.input :project_title
     = f.input :description
-    = field_set_tag "Expense type / Program", class: 'expense-type required' do
-      = expense_type_radio_button(f, 'BA60')
-      = expense_type_radio_button(f, 'BA61')
-      = f.input :emergency, disabled: @client_data_instance.persisted?, wrapper_html: { data: { filter_key: 'expense-type', filter_value: 'BA61' } }
-      = expense_type_radio_button(f, 'BA80')
-      = render partial: 'ba_80_fields', locals: {f: f}
-    = f.input :building_number, input_html: { class: 'js-selectize required', data: { initial: JSON.generate(building_options) } }
-    = f.input :org_code, collection: Ncr::Organization.all, label_method: :to_s, prompt: :translate, input_html: { class: 'js-selectize' }
-    = f.input :vendor, input_html: { class: 'js-selectize required', data: { initial: JSON.generate(vendor_options(@client_data_instance.vendor)) } }
-    = field_set_tag "Amount", class: 'required' do
-      = f.input :amount, as: :currency, label_html: { class: 'sr-only' }, input_html: { data: popover_data_attrs('ncr_amount') }
-      = f.input :not_to_exceed, as: :radio_buttons, collection: [['Exact', false], ['Not to exceed', true]], label: false
+    = field_set_tag "Expense type / Program", class: "expense-type required" do
+      = expense_type_radio_button(f, "BA60")
+      = expense_type_radio_button(f, "BA61")
+      = f.input :emergency,
+        disabled: @client_data_instance.persisted?,
+        wrapper_html: { data: { filter_key: "expense-type", filter_value: "BA61" } }
+      = expense_type_radio_button(f, "BA80")
+      = render partial: "ba_80_fields",
+        locals: { f: f }
+    = f.input :building_number,
+      input_html: { class: "js-selectize required", data: { initial: JSON.generate(building_options) } }
+    = f.input :org_code,
+      collection: Ncr::Organization.all,
+      label_method: :to_s,
+      prompt: :translate,
+      input_html: { class: "js-selectize" }
+    = f.input :vendor,
+      input_html: { class: "js-selectize required", data: { initial: JSON.generate(vendor_options(@client_data_instance.vendor)) } }
+    = field_set_tag "Amount", class: "required" do
+      = f.input :amount,
+        as: :currency,
+        label_html: { class: "sr-only" },
+        input_html: { data: popover_data_attrs("ncr_amount") }
+      = f.input :not_to_exceed,
+        as: :radio_buttons,
+        collection: [["Exact", false], ["Not to exceed", true]], label: false
     = f.input :direct_pay
-    = f.input :approving_official_email, collection: approver_options(@client_data_instance.ineligible_approvers), include_blank: true, disabled: @client_data_instance.proposal.approver_email_frozen?, prompt: :translate, input_html: { class: 'js-selectize required' }, required: true
+    = f.input :approving_official_email,
+      collection: approver_options(@client_data_instance.ineligible_approvers),
+      include_blank: true,
+      disabled: @client_data_instance.proposal.approver_email_frozen?,
+      prompt: :translate,
+      input_html: { class: "js-selectize required" }
     - if @client_data_instance.new_record?
       = render partial: 'attachments'
     - else

--- a/lib/ncr/work_order_updater.rb
+++ b/lib/ncr/work_order_updater.rb
@@ -9,10 +9,13 @@ module Ncr
 
     delegate :proposal, to: :work_order
 
-    def requires_budget_reapproval?
-      checker = Ncr::WorkOrderReapprovalChecker.new(work_order)
-      checker.requires_budget_reapproval?
+    def run
+      work_order.setup_approvals_and_observers
+      reapprove_if_necessary
+      Dispatcher.on_proposal_update(proposal, work_order.modifier)
     end
+
+    private
 
     def reapprove_if_necessary
       if requires_budget_reapproval?
@@ -21,10 +24,9 @@ module Ncr
       end
     end
 
-    def after_update
-      work_order.setup_approvals_and_observers
-      reapprove_if_necessary
-      Dispatcher.on_proposal_update(proposal, work_order.modifier)
+    def requires_budget_reapproval?
+      checker = Ncr::WorkOrderReapprovalChecker.new(work_order)
+      checker.requires_budget_reapproval?
     end
   end
 end

--- a/spec/controllers/ncr/work_orders_controller_spec.rb
+++ b/spec/controllers/ncr/work_orders_controller_spec.rb
@@ -49,10 +49,14 @@ describe Ncr::WorkOrdersController do
       expect(flash[:warning]).to be_present
     end
 
-    it 'does not explode if editing an emergency' do
-      work_order = create(:ncr_work_order, :is_emergency,
-                                      requester: requester)
-      get :edit, {id: work_order.id}
+    it "does not explode if editing an emergency" do
+      work_order = create(
+        :ncr_work_order,
+        :is_emergency,
+        requester: requester
+      )
+
+      get :edit, { id: work_order.id }
     end
   end
 

--- a/spec/features/ncr/work_orders/requester_edit_spec.rb
+++ b/spec/features/ncr/work_orders/requester_edit_spec.rb
@@ -1,7 +1,15 @@
-feature 'Requester edits their NCR work order' do
+feature "Requester edits their NCR work order", :js do
   include ProposalSpecHelper
 
-  let(:work_order) { create(:ncr_work_order, org_code: Ncr::Organization.all.first.to_s,  description: 'test') }
+  let(:work_order) do
+    create(
+      :ncr_work_order,
+      building_number: Ncr::BUILDING_NUMBERS[0],
+      org_code: Ncr::Organization.all.first.to_s,
+      vendor: "test vendor",
+      description: "test"
+    )
+  end
   let(:ncr_proposal) { work_order.proposal }
   let(:requester) { work_order.requester }
 
@@ -10,44 +18,55 @@ feature 'Requester edits their NCR work order' do
     login_as(requester)
   end
 
-  scenario 'can be edited if pending' do
-    visit "/ncr/work_orders/#{work_order.id}/edit"
-    expect(find_field("ncr_work_order_building_number").value).to eq(
-      Ncr::BUILDING_NUMBERS[0])
-    fill_in 'Vendor', with: 'New ACME'
-    click_on 'Update'
-    expect(current_path).to eq("/proposals/#{ncr_proposal.id}")
-    expect(page).to have_content("New ACME")
-    expect(page).to have_content("modified")
-    # Verify it is actually saved
-    work_order.reload
-    expect(work_order.vendor).to eq("New ACME")
+  scenario "preserves previously selected values in dropdowns" do
+    visit edit_ncr_work_order_path(work_order)
+
+    expect_page_to_have_selected_selectize_option(
+      "ncr_work_order_building_number",
+      Ncr::BUILDING_NUMBERS[0]
+    )
+    expect_page_to_have_selected_selectize_option(
+      "ncr_work_order_org_code",
+      Ncr::Organization.all.first.to_s
+    )
+    expect_page_to_have_selected_selectize_option(
+      "ncr_work_order_vendor",
+      "test vendor"
+    )
+    expect_page_to_have_selected_selectize_option(
+      "ncr_work_order_approving_official_email",
+      work_order.approving_official_email
+    )
   end
 
-  scenario 'creates a special comment when editing' do
-    visit "/ncr/work_orders/#{work_order.id}/edit"
-    fill_in 'Vendor', with: "New Test Vendor"
-    fill_in 'Description', with: "New Description"
-    click_on 'Update'
+  scenario "creates a comment when editing" do
+    visit edit_ncr_work_order_path(work_order)
+
+    fill_in_selectized("ncr_work_order_building_number", Ncr::BUILDING_NUMBERS[1])
+    fill_in "Description", with: "New Description"
+    click_on "Update"
 
     expect(page).to have_content("Request modified by")
     expect(page).to have_content("Description was changed from test to New Description")
-    expect(page).to have_content("Vendor was changed from Some Vend to New Test Vendor")
+    expect(page).to have_content(
+      "Building number was changed from #{Ncr::BUILDING_NUMBERS[0]} to #{Ncr::BUILDING_NUMBERS[1]}"
+    )
   end
 
-  scenario 'notifies observers of changes' do
+  scenario "notifies observers of changes" do
     work_order.add_observer('observer@example.com')
-    visit "/ncr/work_orders/#{work_order.id}/edit"
-    fill_in 'Description', with: "Observer changes"
-    click_on 'Update'
+    visit edit_ncr_work_order_path(work_order)
+
+    fill_in "Description", with: "Observer changes"
+    click_on "Update"
 
     expect(deliveries.length).to eq(2)
     expect(deliveries.last).to have_content('observer@example.com')
   end
 
   scenario 'does not resave unchanged requests' do
-    visit "/ncr/work_orders/#{work_order.id}/edit"
-    click_on 'Update'
+    visit edit_ncr_work_order_path(work_order)
+    click_on "Update"
 
     expect(current_path).to eq("/proposals/#{work_order.proposal.id}")
     expect(page).to have_content("No changes were made to the request")
@@ -59,7 +78,7 @@ feature 'Requester edits their NCR work order' do
     old_approver = ncr_proposal.approvers.first
     expect(Dispatcher).to receive(:on_approver_removal).with(ncr_proposal, [old_approver])
     visit "/ncr/work_orders/#{work_order.id}/edit"
-    select approver.email_address, from: "Approving official's email address"
+    fill_in_selectized("ncr_work_order_approving_official_email", approver.email_address)
     click_on 'Update'
     proposal = Proposal.last
 
@@ -123,19 +142,34 @@ feature 'Requester edits their NCR work order' do
     expect(current_path).to eq("/proposals/#{work_order.proposal.id}")
   end
 
-  scenario 'has a disabled field if first approval is done' do
-    visit "/ncr/work_orders/#{work_order.id}/edit"
-    expect(find('#ncr_work_order_approving_official_email')['disabled']).to be_nil
+
+  scenario "can change approving official email if first approval not done" do
+    visit edit_ncr_work_order_path(work_order)
+
+    within(".ncr_work_order_approving_official_email") do
+      expect(page).not_to have_css(".disabled")
+    end
+  end
+
+  scenario "has a disabled approving official email field if first approval is done" do
     work_order.individual_steps.first.approve!
-    visit "/ncr/work_orders/#{work_order.id}/edit"
-    expect(find('#ncr_work_order_approving_official_email')['disabled']).to eq('disabled')
-    # And we can still submit
-    fill_in 'Vendor', with: 'New ACME'
-    click_on 'Update'
-    expect(current_path).to eq("/proposals/#{ncr_proposal.id}")
-    # Verify it is actually saved
-    work_order.reload
-    expect(work_order.vendor).to eq("New ACME")
+
+    visit edit_ncr_work_order_path(work_order)
+
+    within(".ncr_work_order_approving_official_email") do
+      expect(page).to have_css(".disabled")
+    end
+  end
+
+  scenario "can update other fields if first approval is done" do
+    work_order.individual_steps.first.approve!
+    visit edit_ncr_work_order_path(work_order)
+
+    fill_in_selectized("ncr_work_order_building_number", Ncr::BUILDING_NUMBERS[1])
+    click_on "Update"
+
+    expect(current_path).to eq(proposal_path(ncr_proposal))
+    expect(page).to have_content(Ncr::BUILDING_NUMBERS[1])
   end
 
   scenario 'can be edited if approved' do
@@ -167,8 +201,11 @@ feature 'Requester edits their NCR work order' do
     expect(work_order.soc_code).to eq('789')
   end
 
-  scenario 'disables the emergency field' do
-    visit "/ncr/work_orders/#{work_order.id}/edit"
-    expect(find_field('emergency', disabled: true)).to be_disabled
+  scenario "disables the emergency field" do
+    visit edit_ncr_work_order_path(work_order)
+
+    within(".ncr_work_order_emergency") do
+      expect(page).to have_css(".disabled")
+    end
   end
 end

--- a/spec/support/feature_spec_helper.rb
+++ b/spec/support/feature_spec_helper.rb
@@ -38,14 +38,17 @@ module FeatureSpecHelper
       within(".dropdown-active") do
         expect(page).to have_content(text)
       end
+      find(".selectize-control").click
     end
   end
+
   def expect_page_not_to_have_selected_selectize_option(field, text)
     within(".#{field}") do
       find(".selectize-control").click
       within(".dropdown-active") do
         expect(page).not_to have_content(text)
       end
+      find(".selectize-control").click
     end
   end
 end


### PR DESCRIPTION
…rder#edit

* To QA:
  - create an ncr work order
  - modify work order
  - confirm that previously selected approving official email is
    populated in form

* Story: https://www.pivotaltracker.com/story/show/109219130