### PR TITLE
Refactor query objects

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -66,7 +66,7 @@ class ProposalsController < ApplicationController
   end
 
   def history
-    @container = Query::Proposal::Versions.container(proposal)
+    @container = Query::Proposal::Versions.new(proposal).container
     @container.set_state_from_params(params)
   end
 

--- a/app/policies/proposal_policy/scope.rb
+++ b/app/policies/proposal_policy/scope.rb
@@ -12,7 +12,7 @@ class ProposalPolicy
       elsif @user.client_admin?
         self.for_client_admin
       else
-        @scope.where(Query::Proposal::Clauses.which_involve(@user))
+        @scope.where(Query::Proposal::Clauses.new.which_involve(@user))
       end
     end
 
@@ -20,8 +20,8 @@ class ProposalPolicy
 
     def for_client_admin
       @scope.where(
-        Query::Proposal::Clauses.for_client_slug(@user.client_slug).or(
-          Query::Proposal::Clauses.which_involve(@user)
+        Query::Proposal::Clauses.new.for_client_slug(@user.client_slug).or(
+          Query::Proposal::Clauses.new.which_involve(@user)
         )
       )
     end

--- a/lib/query/proposal/clauses.rb
+++ b/lib/query/proposal/clauses.rb
@@ -1,98 +1,92 @@
-# returns Arel nodes for composing in ActiveRecord queries
 module Query
   module Proposal
-    module Clauses
-      def self.for_client_slug(client_slug)
+    class Clauses
+      def for_client_slug(client_slug)
         namespace = client_slug.classify.constantize
         proposals[:client_data_type].matches("#{namespace}::%")
       end
 
-      def self.with_requester(user)
-        proposals[:requester_id].eq(user.id)
-      end
-
-      def self.approvals_with_delegates
-        approvals.project(Arel.star).
-          join(delegates, Arel::Nodes::OuterJoin).
-          on(delegates[:assigner_id].eq(approvals[:user_id]))
-      end
-
-      def self.with_approver_or_delegate(user)
-        Arel::Nodes::Exists.new(
-          self.approvals_for(user)
-        )
-      end
-
-      def self.with_observer(user)
-        Arel::Nodes::Exists.new(
-          self.observations_for(user)
-        )
-      end
-
-      def self.which_involve(user)
-        self.with_requester(user).or(
-          self.with_approver_or_delegate(user).or(
-            self.with_observer(user)
+      def which_involve(user)
+        with_requester(user).or(
+          with_approver_or_delegate(user).or(
+            with_observer(user)
           )
         )
       end
 
-      protected
+      private
 
-      def self.approvals
-        Step.arel_table
-      end
-
-      def self.delegates
-        ApprovalDelegate.arel_table
-      end
-
-      def self.observations
-        Observation.arel_table
-      end
-
-      def self.proposals
+      def proposals
         ::Proposal.arel_table
       end
 
-      def self.with_matching_proposal
-        approvals[:proposal_id].eq(proposals[:id])
+      def with_requester(user)
+        proposals[:requester_id].eq(user.id)
       end
 
-      def self.non_pending
-        approvals[:status].not_eq('pending')
+      def with_approver_or_delegate(user)
+        Arel::Nodes::Exists.new(
+          approvals_for(user)
+        )
       end
 
-      def self.where_approver(user)
-        approvals[:user_id].eq(user.id)
-      end
-
-      def self.where_delegate(user)
-        delegates[:assignee_id].eq(user.id)
-      end
-
-      ## subselects to be used alongside the proposals table ##
-      # Subselects are used instead of left joins to avoid an explicit duplication-removal step.
-
-      def self.approvals_for(user)
-        self.approvals_with_delegates.where(
-          self.with_matching_proposal.and(
-            self.non_pending.and(
-              self.where_approver(user).or(self.where_delegate(user))
+      def approvals_for(user)
+        approvals_with_delegates.where(
+          with_matching_proposal.and(
+            non_pending.and(
+              where_approver(user).or(where_delegate(user))
             )
           )
         ).ast
       end
 
-      def self.observations_for(user)
+      def approvals_with_delegates
+        approvals.project(Arel.star).
+          join(delegates, Arel::Nodes::OuterJoin).
+          on(delegates[:assigner_id].eq(approvals[:user_id]))
+      end
+
+      def with_matching_proposal
+        approvals[:proposal_id].eq(proposals[:id])
+      end
+
+      def non_pending
+        approvals[:status].not_eq('pending')
+      end
+
+      def where_approver(user)
+        approvals[:user_id].eq(user.id)
+      end
+
+      def where_delegate(user)
+        delegates[:assignee_id].eq(user.id)
+      end
+
+      def with_observer(user)
+        Arel::Nodes::Exists.new(
+          observations_for(user)
+        )
+      end
+
+      def approvals
+        Step.arel_table
+      end
+
+      def delegates
+        ApprovalDelegate.arel_table
+      end
+
+      def observations
+        Observation.arel_table
+      end
+
+      def observations_for(user)
         observations.project(Arel.star).where(
           observations[:proposal_id].eq(proposals[:id]).and(
             observations[:user_id].eq(user.id)
           )
         ).ast
       end
-
-      #########################################################
     end
   end
 end

--- a/lib/query/proposal/listing.rb
+++ b/lib/query/proposal/listing.rb
@@ -48,11 +48,15 @@ module Query
       protected
 
       def pending_filter
-        proc { |proposals| proposals.select { |p| !p.awaiting_approver?(user) } }
+        proc do |proposals|
+          proposals.select { |proposal| !proposal.awaiting_approver?(user) }
+        end
       end
 
       def pending_review_filter
-        proc { |proposals| proposals.select { |p| p.awaiting_approver?(user) } }
+        proc do |proposals|
+          proposals.select { |proposal| proposal.awaiting_approver?(user) }
+        end
       end
 
       def proposals_container(name, extra_config = {})
@@ -60,10 +64,10 @@ module Query
         config = config.merge(extra_config)
         container = TabularData::Container.new(name, config)
 
-        container.alter_query do |p|
-          ProposalPolicy::Scope.new(self.user, p).resolve.includes(:client_data)
+        container.alter_query do |proposal|
+          ProposalPolicy::Scope.new(user, proposal).resolve.includes(:client_data)
         end
-        container.set_state_from_params(self.params)
+        container.set_state_from_params(params)
 
         container
       end
@@ -73,7 +77,7 @@ module Query
         container = proposals_container(name, config)
 
         container.alter_query do |rel|
-          condition = Query::Proposal::Clauses.which_involve(self.user)
+          condition = Query::Proposal::Clauses.new.which_involve(user)
           rel.where(condition)
         end
       end
@@ -97,27 +101,25 @@ module Query
 
       def apply_date_filters(proposals_data)
         if start_date
-          proposals_data.alter_query { |p| p.where("proposals.created_at >= ?", start_date) }
+          proposals_data.alter_query { |proposal| proposal.where("proposals.created_at >= ?", start_date) }
         end
 
         if end_date
-          proposals_data.alter_query { |p| p.where("proposals.created_at < ?", end_date) }
+          proposals_data.alter_query { |proposal| proposal.where("proposals.created_at < ?", end_date) }
         end
       end
 
       def apply_text_filter(proposals_data)
-        text = params[:text]
-
-        if text
-          proposals_data.alter_query do |p|
-            Query::Proposal::Search.new(p).execute(text)
+        if params[:text]
+          proposals_data.alter_query do |proposal|
+            Query::Proposal::Search.new(proposal).execute(params[:text])
           end
         end
       end
 
       def apply_status_filter(proposals_data)
         if params[:status]
-          proposals_data.alter_query { |p| p.where("proposals.status = ?", params[:status]) }
+          proposals_data.alter_query { |proposal| proposal.where(status: params[:status]) }
         end
       end
     end

--- a/lib/tabular_data/container.rb
+++ b/lib/tabular_data/container.rb
@@ -46,7 +46,7 @@ module TabularData
       relevant = params.permit(tables: {@name => [:sort]})
       config = relevant.fetch(:tables, {}).fetch(@name, {}) || {}
       if config.key? :sort
-        self.set_sort(config[:sort])
+        set_sort(config[:sort])
       end
       self
     end

--- a/lib/tabular_data/container.rb
+++ b/lib/tabular_data/container.rb
@@ -4,12 +4,21 @@ module TabularData
 
     def initialize(name, config)
       @name = name
-      # useful if the sort is set via alter_query
       @frozen_sort = config.fetch(:frozen_sort, false)
       @filter = config.fetch(:filter, false)
-      self.init_query(config[:engine].constantize, config.fetch(:joins, []))
-      self.init_columns(config.fetch(:column_configs, {}), config.fetch(:columns, {}))
-      self.set_sort(config[:sort])
+      init_query(config[:engine].constantize, config.fetch(:joins, []))
+      init_columns(config.fetch(:column_configs, {}), config.fetch(:columns, {}))
+      set_sort(config[:sort])
+    end
+
+    def self.config_for_client(container_name, client_name)
+      filename = "#{Rails.root}/config/tables/#{container_name}.yml"
+      container_yaml = YAML.load_file(filename)
+      key = "default"
+      if container_yaml.key?(client_name)
+        key = client_name
+      end
+      container_yaml[key].deep_symbolize_keys
     end
 
     def alter_query
@@ -17,7 +26,6 @@ module TabularData
       self
     end
 
-    # @todo filtering, paging, etc.
     def rows
       results = @query
       if @sort && !@frozen_sort
@@ -51,18 +59,7 @@ module TabularData
       end
     end
 
-    def self.config_for_client(container_name, client_name)
-      # TODO load once
-      filename = "#{Rails.root}/config/tables/#{container_name}.yml"
-      container_yaml = YAML.load_file(filename)
-      key = "default"
-      if container_yaml.key?(client_name)
-        key = client_name
-      end
-      container_yaml[key].deep_symbolize_keys
-    end
-
-    protected
+    private
 
     def set_sort(field)
       field = field || ''

--- a/spec/lib/query/proposal/versions_spec.rb
+++ b/spec/lib/query/proposal/versions_spec.rb
@@ -1,18 +1,17 @@
 describe Query::Proposal::Versions do
-  describe '.container' do
+  describe '#container' do
     it "limits to the specified Proposal" do
       prop1 = create(:proposal)
-      prop2 = create(:proposal)
+      _prop2 = create(:proposal)
 
-      container = Query::Proposal::Versions.container(prop1)
+      container = Query::Proposal::Versions.new(prop1).container
       expect(container.rows).to eq(prop1.versions.reverse)
     end
 
     it "includes approvals" do
       prop1 = create(:proposal, :with_approver)
-      prop2 = create(:proposal, :with_approver)
 
-      container = Query::Proposal::Versions.container(prop1)
+      container = Query::Proposal::Versions.new(prop1).container
       approval = prop1.steps.first
       expect(container.rows).to include(approval.versions.first)
     end


### PR DESCRIPTION
* Privatize methods that are unused outside of class to minimize API of
  objects
* Prep for https://www.pivotaltracker.com/story/show/105014352 (uses
  `Versions` query object, which I was having a hard time wrapping my
  head around with previous organization)