### PR TITLE
Remove `flow` from proposals

### DIFF
--- a/app/controllers/client_data_controller.rb
+++ b/app/controllers/client_data_controller.rb
@@ -73,7 +73,7 @@ class ClientDataController < ApplicationController
 
   def build_client_data_instance
     @client_data_instance = model_class.new(filtered_params)
-    @client_data_instance.build_proposal(flow: "linear", requester: current_user)
+    @client_data_instance.build_proposal(requester: current_user)
   end
 
   def find_client_data_instance

--- a/app/decorators/proposal_decorator.rb
+++ b/app/decorators/proposal_decorator.rb
@@ -9,26 +9,8 @@ class ProposalDecorator < Draper::Decorator
     object.individual_steps.count
   end
 
-  def steps_by_status
-    # Override default scope
-    object.individual_steps.with_users.reorder(
-      # http://stackoverflow.com/a/6332081/358804
-      <<-SQL
-        CASE steps.status
-        WHEN 'approved' THEN 1
-        WHEN 'actionable' THEN 2
-        ELSE 3
-        END
-      SQL
-    )
-  end
-
   def steps_in_list_order
-    if object.flow == 'linear'
-      object.individual_steps.with_users
-    else
-      steps_by_status
-    end
+    object.individual_steps.with_users
   end
 
   def display_status

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -1,12 +1,12 @@
 module MailerHelper
-  def status_icon_tag(status, linear_display = false, last_approver = false)
+  def status_icon_tag(status, last_approver = false)
     base_url = root_url.gsub(/\?.*$/, "").chomp("/")
     bg_linear_image = base_url + image_path("bg_#{status}_status.gif")
 
     image_tag(
       base_url + image_path("icon-#{status}.png"),
-      class: "status-icon #{status} #{'linear' if linear_display}",
-      style: ("background-image: url('#{bg_linear_image}');" if linear_display && !last_approver)
+      class: "status-icon #{status} linear",
+      style: ("background-image: url('#{bg_linear_image}');" if !last_approver)
     )
   end
 

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -6,7 +6,7 @@ module MailerHelper
     image_tag(
       base_url + image_path("icon-#{status}.png"),
       class: "status-icon #{status} linear",
-      style: ("background-image: url('#{bg_linear_image}');" if !last_approver)
+      style: ("background-image: url('#{bg_linear_image}');" unless last_approver)
     )
   end
 

--- a/app/models/concerns/client_data_mixin.rb
+++ b/app/models/concerns/client_data_mixin.rb
@@ -26,7 +26,6 @@ module ClientDataMixin
       :add_observer,
       :add_requester,
       :currently_awaiting_approvers,
-      :flow,
       :ineligible_approvers,
       :set_requester,
       :status,

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -7,7 +7,6 @@ class Proposal < ActiveRecord::Base
   has_paper_trail class_name: 'C2Version'
 
   CLIENT_MODELS = []  # this gets populated later
-  FLOWS = %w(parallel linear).freeze
 
   workflow do
     state :pending do
@@ -53,7 +52,6 @@ class Proposal < ActiveRecord::Base
     message: "%{value} is not a valid client model type. Valid client model types are: #{CLIENT_MODELS.inspect}",
     allow_blank: true
   }
-  validates :flow, presence: true, inclusion: {in: FLOWS}
   validates :requester_id, presence: true
   validates :public_id, uniqueness: true, allow_nil: true
 
@@ -65,14 +63,6 @@ class Proposal < ActiveRecord::Base
 
   def root_step
     steps.where(parent: nil).first
-  end
-
-  def parallel?
-    flow == "parallel"
-  end
-
-  def linear?
-    flow == "linear"
   end
 
   def delegate?(user)

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -65,6 +65,14 @@ class Proposal < ActiveRecord::Base
     steps.where(parent: nil).first
   end
 
+  def parallel?
+    root_step.type == "Steps::Parallel"
+  end
+
+  def serial?
+    root_step.type == "Steps::Serial"
+  end
+
   def delegate?(user)
     approval_delegates.exists?(assignee_id: user.id)
   end

--- a/app/serializers/proposal_serializer.rb
+++ b/app/serializers/proposal_serializer.rb
@@ -3,7 +3,6 @@ class ProposalSerializer < ActiveModel::Serializer
 
   attributes(
     :created_at,
-    :flow,
     :id,
     :status,
     :updated_at

--- a/app/services/client_data_creator.rb
+++ b/app/services/client_data_creator.rb
@@ -6,7 +6,7 @@ class ClientDataCreator
   end
 
   def run
-    client_data.build_proposal(flow: "linear", requester: user)
+    client_data.build_proposal(requester: user)
     client_data.save
     create_attachments
     add_public_id

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -19,15 +19,9 @@
           %strong
             = date_with_tooltip(@proposal.created_at, true)
 
-    - if @proposal.linear?
-      .col-md-12
-        %table.col-md-12.data-container{border: 0}
-          = render partial: "shared/email_status"
-    - else
-      .col-md-4.col-xs-12.communicart_description
-        .purchase-status
-          %h5{class: @proposal.status}
-            = @proposal.display_status
+    .col-md-12
+      %table.col-md-12.data-container{border: 0}
+        = render partial: "shared/email_status"
 
   .row
     = client_partial(@proposal.client_slug,
@@ -74,31 +68,6 @@
   - if current_user.admin?
     %li
       = link_to "View history", history_proposal_path(@proposal)
-
-- # @todo: there are multiple approval-status ids
-- if @proposal.parallel?
-  - if @proposal.individual_steps.approved.any?
-    .approval-status-container
-      #approval-status
-        %h3 Request approved by
-        %ul
-          - @proposal.individual_steps.approved.each do |approval|
-            %li.icon-approved
-              = approval.user_email_address
-              %span.timestamp
-                = "on #{l approval.updated_at}"
-  - if @proposal.individual_steps.pending.any?
-    .approval-status-container
-      #approval-status
-        %h3 Waiting for approval from
-        %ul.left
-          - @proposal.individual_steps.pending.each do |approval|
-            %li.icon-pending
-              = approval.user_email_address
-        %ul.right
-          - @proposal.individual_steps.approved.each do |approval|
-            %li.icon-approved
-              = approval.user_email_address
 
 .comments-container.proposal-submodel-container
   #comments

--- a/app/views/shared/_email_status.html.erb
+++ b/app/views/shared/_email_status.html.erb
@@ -28,7 +28,7 @@
                   </td>
                   <td>
                     <%- last_approver = index == @proposal.steps_in_list_order.count - 1 %>
-                    <%= status_icon_tag(display_status, @proposal.linear?, last_approver) %>
+                    <%= status_icon_tag(display_status, last_approver) %>
                     <span class="approver">
                       <%= mail_to step.completed_by.email_address, step.completed_by.full_name %>
                     </span>

--- a/db/migrate/20151215230732_remove_flow_from_proposals.rb
+++ b/db/migrate/20151215230732_remove_flow_from_proposals.rb
@@ -1,0 +1,9 @@
+class RemoveFlowFromProposals < ActiveRecord::Migration
+  def up
+    remove_column :proposals, :flow
+  end
+
+  def down
+    add_column :proposals, :flow, :string, default: "parallel"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151208143311) do
+ActiveRecord::Schema.define(version: 20151215230732) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -142,7 +142,6 @@ ActiveRecord::Schema.define(version: 20151208143311) do
 
   create_table "proposals", force: :cascade do |t|
     t.string   "status",           limit: 255
-    t.string   "flow",             limit: 255, default: "parallel"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "client_data_id"

--- a/doc/api.md
+++ b/doc/api.md
@@ -43,7 +43,6 @@ Attribute | Type | Note
 --- | --- | ---
 `steps` | [ [Step](#step) ] |
 `created_at` | string (time) |
-`flow` | string | Can be `linear` or `parallel`
 `id` | integer |
 `requester` | [User](#user) |
 `status` | string | Can be `pending`, `approved`, or `cancelled`
@@ -140,7 +139,6 @@ Returns an array of [Work Orders](#ncr-work-order), in descending order of creat
         }
       ],
       "created_at": "2015-02-21T07:05:42.445Z",
-      "flow": "parallel",
       "id": 12,
       "requester": {
         "created_at": "2015-02-10T07:05:42.445Z",

--- a/lib/dispatcher/class_methods_mixin.rb
+++ b/lib/dispatcher/class_methods_mixin.rb
@@ -3,22 +3,13 @@ class Dispatcher
     extend ActiveSupport::Concern
 
     class_methods do
-      # todo: replace with dynamic dispatch
       def initialize_dispatcher(proposal)
-        case proposal.flow
-        when 'parallel'
-          new
-        when 'linear'
-          # @todo: dynamic dispatch for selection
-          if proposal.client_slug == "ncr"
-            NcrDispatcher.new
-          else
-            LinearDispatcher.new
-          end
+        if proposal.client_slug == "ncr"
+          NcrDispatcher.new
+        else
+          LinearDispatcher.new
         end
       end
-
-      # TODO DRY the following up
 
       def deliver_new_proposal_emails(proposal)
         dispatcher = initialize_dispatcher(proposal)

--- a/spec/decorators/proposal_decorator_spec.rb
+++ b/spec/decorators/proposal_decorator_spec.rb
@@ -13,34 +13,6 @@ describe ProposalDecorator do
     end
   end
 
-  describe '#approvals_by_status' do
-    it "orders by approved, actionable, pending" do
-      # make two approvals for each status, in random order
-      statuses = Step.statuses.map(&:to_s)
-      statuses = statuses.dup + statuses.clone
-      statuses = randomize(statuses)
-
-      users = statuses.map do |status|
-        user = create(:user)
-        create(:approval, proposal: proposal, status: status, user: user)
-        user
-      end
-
-      approvals = proposal.steps_by_status
-      expect(approvals.map(&:status)).to eq(%w(
-        approved
-        approved
-        actionable
-        actionable
-        pending
-        pending
-      ))
-      approvers = approvals.map(&:user)
-      expect(approvers).not_to eq(users)
-      expect(approvers.sort).to eq(users.sort)
-    end
-  end
-
   describe "#step_text_for_user" do
     let(:proposal) { create(:proposal).decorate }
     let(:user)     { create(:user) }

--- a/spec/factories/gsa18f/procurements.rb
+++ b/spec/factories/gsa18f/procurements.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
     sequence(:product_name_and_description) {|n| "Proposal #{n}" }
     office Gsa18f::Procurement::OFFICES[0]
     urgency Gsa18f::Procurement::URGENCY[10]
-    association :proposal, flow: 'linear', client_slug: 'gsa18f'
+    association :proposal, client_slug: "gsa18f"
 
     trait :with_steps do
       after(:create) { |procurement| procurement.add_steps }

--- a/spec/factories/ncr/work_orders.rb
+++ b/spec/factories/ncr/work_orders.rb
@@ -8,7 +8,7 @@ FactoryGirl.define do
     emergency false
     project_title "NCR Name"
     sequence(:approving_official_email) {|n| "approver#{User.count}@example.com" }
-    association :proposal, flow: 'linear'
+    association :proposal
 
     factory :ba80_ncr_work_order do
       expense_type "BA80"
@@ -16,7 +16,7 @@ FactoryGirl.define do
     end
 
     trait :with_approvers do
-      association :proposal, :with_serial_approvers, flow: 'linear', client_slug: "ncr"
+      association :proposal, :with_serial_approvers, client_slug: "ncr"
       after :create do |wo|
         wo.approving_official_email = wo.approving_official.email_address
       end
@@ -24,7 +24,7 @@ FactoryGirl.define do
 
     trait :is_emergency do
       emergency true
-      association :proposal, :with_observers, flow: 'linear'
+      association :proposal, :with_observers
     end
   end
 end

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -3,7 +3,6 @@ FactoryGirl.define do
 
   factory :proposal do
     public_id
-    flow 'linear'
     status 'pending'
     association :requester, factory: :user
 
@@ -22,7 +21,6 @@ FactoryGirl.define do
     end
 
     trait :with_serial_approvers do
-      flow 'linear'
       after :create do |proposal, evaluator|
         ind = 2.times.map{ Steps::Approval.new(user: create(:user, client_slug: evaluator.client_slug)) }
         proposal.add_initial_steps(ind)
@@ -30,7 +28,6 @@ FactoryGirl.define do
     end
 
     trait :with_parallel_approvers do
-      flow 'parallel'
       after :create do |proposal, evaluator|
         ind = 2.times.map{ Steps::Approval.new(user: create(:user, client_slug: evaluator.client_slug)) }
         proposal.root_step = Steps::Parallel.new(child_approvals: ind)
@@ -38,7 +35,6 @@ FactoryGirl.define do
     end
 
     trait :with_approval_and_purchase do
-      flow "linear"
       after :create do |proposal, evaluator|
         first_approver = create(:user, client_slug: evaluator.client_slug)
         second_approver = create(:user, client_slug: evaluator.client_slug)

--- a/spec/features/display_status_spec.rb
+++ b/spec/features/display_status_spec.rb
@@ -1,47 +1,49 @@
-describe 'Display status text' do
-  it 'displays approved status' do
-    proposal = create_proposal_with_parallel_approvers
-    proposal.individual_steps.each{ |approval| approval.approve! }
+describe "Display status text" do
+  context "parallel approvals" do
+    it "displays approved status" do
+      proposal = create_proposal_with_parallel_approvers
+      proposal.individual_steps.each{ |approval| approval.approve! }
 
-    login_as(proposal.requester)
-    visit proposals_path
+      login_as(proposal.requester)
+      visit proposals_path
 
-    expect(page).to have_content('Approved')
-  end
+      expect(page).to have_content("Approved")
+    end
 
-  it 'displays outstanding approvers' do
-    proposal = create_proposal_with_parallel_approvers
+    it "displays outstanding approvers" do
+      proposal = create_proposal_with_parallel_approvers
 
-    login_as(proposal.requester)
-    visit proposals_path
+      login_as(proposal.requester)
+      visit proposals_path
 
-    expect(page).not_to have_content('Please review')
-    expect(page).to have_content('Waiting for review from:')
-    proposal.approvers.each do |approver|
-      expect(page).to have_content(approver.full_name)
+      expect(page).not_to have_content("Please review")
+      expect(page).to have_content("Waiting for review from:")
+      proposal.approvers.each do |approver|
+        expect(page).to have_content(approver.full_name)
+      end
+    end
+
+    it "excludes approved approvals" do
+      proposal = create_proposal_with_parallel_approvers
+      first_approval = proposal.individual_steps.first
+      first_approval.approve!
+      first_approver = first_approval.user
+      all_approvers_except_first = proposal.approvers.offset(1)
+
+      login_as(proposal.requester)
+      visit proposals_path
+
+      expect(page).not_to have_content("Please review")
+      expect(page).to have_content("Waiting for review from:")
+      expect(page).not_to have_content(first_approver.full_name)
+      all_approvers_except_first.each do |approver|
+        expect(page).to have_content(approver.full_name)
+      end
     end
   end
 
-  it 'excludes approved approvals' do
-    proposal = create_proposal_with_parallel_approvers
-    first_approval = proposal.individual_steps.first
-    first_approval.approve!
-    first_approver = first_approval.user
-    all_approvers_except_first = proposal.approvers.offset(1)
-
-    login_as(proposal.requester)
-    visit proposals_path
-
-    expect(page).not_to have_content('Please review')
-    expect(page).to have_content('Waiting for review from:')
-    expect(page).not_to have_content(first_approver.full_name)
-    all_approvers_except_first.each do |approver|
-      expect(page).to have_content(approver.full_name)
-    end
-  end
-
-  context 'linear' do
-    it 'displays the first approver' do
+  context "serial approvals" do
+    it "displays the first approver" do
       proposal = create_proposal_with_serial_approvers
       first_approval = proposal.individual_steps.first
       first_approver = first_approval.user
@@ -50,14 +52,14 @@ describe 'Display status text' do
       login_as(proposal.requester)
       visit proposals_path
 
-      expect(page).to have_content('Waiting for review from:')
+      expect(page).to have_content("Waiting for review from:")
       expect(page).to have_content(first_approver.full_name)
       all_approvers_except_first.each do |approver|
         expect(page).not_to have_content(approver.full_name)
       end
     end
 
-    it 'excludes approved approvals' do
+    it "excludes approved approvals" do
       proposal = create_proposal_with_serial_approvers
       first_approval = proposal.individual_steps.first
       first_approval.approve!
@@ -66,7 +68,7 @@ describe 'Display status text' do
       login_as(proposal.requester)
       visit proposals_path
 
-      expect(page).to have_content('Waiting for review from:')
+      expect(page).to have_content("Waiting for review from:")
       expect(page).not_to have_content(first_approver.full_name)
     end
   end
@@ -79,4 +81,3 @@ describe 'Display status text' do
     @proposal ||= create(:proposal, :with_serial_approvers)
   end
 end
-

--- a/spec/features/ncr/work_orders/requester_edit_spec.rb
+++ b/spec/features/ncr/work_orders/requester_edit_spec.rb
@@ -141,6 +141,14 @@ feature "Requester edits their NCR work order", :js do
     expect(page).to have_content("delegate@example.com")
   end
 
+  scenario "has 'Discard Changes' link" do
+    visit edit_ncr_work_order_path(work_order)
+
+    click_link "Discard Changes"
+
+    expect(current_path).to eq(proposal_path(ncr_proposal))
+  end
+
   scenario "can change approving official email if first approval not done" do
     visit edit_ncr_work_order_path(work_order)
 

--- a/spec/features/ncr/work_orders/requester_edit_spec.rb
+++ b/spec/features/ncr/work_orders/requester_edit_spec.rb
@@ -141,14 +141,6 @@ feature "Requester edits their NCR work order", :js do
     expect(page).to have_content("delegate@example.com")
   end
 
-  scenario "has 'Discard Changes' link" do
-    visit edit_ncr_work_order_path(work_order)
-
-    click_link "Discard Changes"
-
-    expect(current_path).to eq(proposal_path(ncr_proposal))
-  end
-
   scenario "can change approving official email if first approval not done" do
     visit edit_ncr_work_order_path(work_order)
 

--- a/spec/features/parallel_approvals_spec.rb
+++ b/spec/features/parallel_approvals_spec.rb
@@ -1,21 +1,21 @@
-describe 'Parallel approvals' do
-  it 'allows either approver to approve' do
+describe "Parallel approvals" do
+  it "allows either approver to approve" do
     proposal = create(:proposal, :with_parallel_approvers)
 
     proposal.individual_steps.each do |approval|
       login_as(approval.user)
       visit proposal_path(proposal)
 
-      expect(page).to have_button('Approve')
+      expect(page).to have_button("Approve")
     end
   end
 
-  it 'does not allow the requester to approve' do
+  it "does not allow the requester to approve" do
     proposal = create(:proposal, :with_parallel_approvers)
 
     login_as(proposal.requester)
     visit proposal_path(proposal)
 
-    expect(page).not_to have_button('Approve')
+    expect(page).not_to have_button("Approve")
   end
 end

--- a/spec/lib/dispatcher_spec.rb
+++ b/spec/lib/dispatcher_spec.rb
@@ -1,9 +1,8 @@
 describe Dispatcher do
   let(:proposal) { create(:proposal) }
 
-  describe '.deliver_new_proposal_emails' do
-    it "uses the LinearDispatcher for linear approvals" do
-      proposal.flow = 'linear'
+  describe ".deliver_new_proposal_emails" do
+    it "uses the LinearDispatcher for non-NCR approvals" do
       expect(proposal).to receive(:client_data).and_return(double(client_slug: "ncr"))
       expect_any_instance_of(LinearDispatcher).to receive(:deliver_new_proposal_emails).with(proposal)
       Dispatcher.deliver_new_proposal_emails(proposal)

--- a/spec/lib/linear_dispatcher_spec.rb
+++ b/spec/lib/linear_dispatcher_spec.rb
@@ -4,13 +4,13 @@ describe LinearDispatcher do
   describe '#next_pending_approval' do
     context "no approvals" do
       it "returns nil" do
-        proposal = create(:proposal, flow: 'linear')
+        proposal = create(:proposal)
         expect(dispatcher.next_pending_approval(proposal)).to eq(nil)
       end
     end
 
     it "returns nil if all are non-pending" do
-      proposal = create(:proposal, :with_approver, flow: 'linear')
+      proposal = create(:proposal, :with_approver)
       proposal.individual_steps.first.approve!
       expect(dispatcher.next_pending_approval(proposal)).to eq(nil)
     end

--- a/spec/models/concerns/step_manager_spec.rb
+++ b/spec/models/concerns/step_manager_spec.rb
@@ -33,7 +33,7 @@ describe StepManager do
       approver1 = create(:user)
       approver2 = create(:user)
       approver3 = create(:user)
-      proposal = create(:proposal, flow: 'parallel')
+      proposal = create(:proposal)
       individuals = [approver1, approver2, approver3].map{ |u| Steps::Approval.new(user: u)}
 
       proposal.root_step = Steps::Parallel.new(child_approvals: individuals)
@@ -48,7 +48,7 @@ describe StepManager do
       approver1 = create(:user)
       approver2 = create(:user)
       approver3 = create(:user)
-      proposal = create(:proposal, flow: 'linear')
+      proposal = create(:proposal)
       individuals = [approver1, approver2, approver3].map{ |u| Steps::Approval.new(user: u)}
 
       proposal.root_step = Steps::Serial.new(child_approvals: individuals)
@@ -63,7 +63,7 @@ describe StepManager do
       approver1 = create(:user)
       approver2 = create(:user)
       approver3 = create(:user)
-      proposal = create(:proposal, flow: 'parallel')
+      proposal = create(:proposal)
       individuals = [Steps::Approval.new(user: approver1)]
       proposal.root_step = Steps::Parallel.new(child_approvals: individuals)
 
@@ -81,7 +81,7 @@ describe StepManager do
       approver1 = create(:user)
       approver2 = create(:user)
       approver3 = create(:user)
-      proposal = create(:proposal, flow: 'linear')
+      proposal = create(:proposal)
       approver1, approver2, approver3 = 3.times.map{ create(:user) }
       individuals = [approver1, approver2].map{ |u| Steps::Approval.new(user: u) }
       proposal.root_step = Steps::Serial.new(child_approvals: individuals)
@@ -102,7 +102,7 @@ describe StepManager do
     it 'does not modify a full approved parallel proposal' do
       approver1 = create(:user)
       approver2 = create(:user)
-      proposal = create(:proposal, flow: 'parallel')
+      proposal = create(:proposal)
       individuals = [approver1, approver2].map{ |u| Steps::Approval.new(user: u)}
       proposal.root_step = Steps::Parallel.new(child_approvals: individuals)
 
@@ -115,7 +115,7 @@ describe StepManager do
     it 'does not modify a full approved linear proposal' do
       approver1 = create(:user)
       approver2 = create(:user)
-      proposal = create(:proposal, flow: 'linear')
+      proposal = create(:proposal)
       individuals = [approver1, approver2].map{ |u| Steps::Approval.new(user: u)}
       proposal.root_step = Steps::Serial.new(child_approvals: individuals)
 

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -51,6 +51,34 @@ describe Proposal do
     end
   end
 
+  describe "#parallel?" do
+    it "is true if the root step is a parallel step" do
+      proposal = create(:proposal, steps: [create(:parallel_step)])
+
+      expect(proposal).to be_parallel
+    end
+
+    it "is false if the root step is not a parallel step" do
+      proposal = create(:proposal, steps: [create(:serial_step)])
+
+      expect(proposal).not_to be_parallel
+    end
+  end
+
+  describe "#serial?" do
+    it "is true if the root step is a serial step" do
+      proposal = create(:proposal, steps: [create(:serial_step)])
+
+      expect(proposal).to be_serial
+    end
+
+    it "is false if the root step is not a serial step" do
+      proposal = create(:proposal, steps: [create(:parallel_step)])
+
+      expect(proposal).not_to be_serial
+    end
+  end
+
   describe '#currently_awaiting_approvers' do
     it "gives a consistently ordered list when in parallel" do
       proposal = create(:proposal, :with_parallel_approvers)

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -161,7 +161,7 @@ describe Proposal do
       approver1 = create(:user)
       approver2 = create(:user)
       approver3 = create(:user)
-      proposal = create(:proposal, flow: 'parallel')
+      proposal = create(:proposal)
       individuals = [approver1, approver2, approver3].map{ |u| Steps::Approval.new(user: u)}
 
       proposal.root_step = Steps::Parallel.new(child_approvals: individuals)
@@ -176,7 +176,7 @@ describe Proposal do
       approver1 = create(:user)
       approver2 = create(:user)
       approver3 = create(:user)
-      proposal = create(:proposal, flow: 'linear')
+      proposal = create(:proposal)
       individuals = [approver1, approver2, approver3].map{ |u| Steps::Approval.new(user: u)}
 
       proposal.root_step = Steps::Serial.new(child_approvals: individuals)
@@ -187,11 +187,11 @@ describe Proposal do
       expect(proposal.steps.actionable.count).to be 2
     end
 
-    it 'fixes modified parallel proposal approvals' do
+    it "fixes modified parallel proposal approvals" do
       approver1 = create(:user)
       approver2 = create(:user)
       approver3 = create(:user)
-      proposal = create(:proposal, flow: 'parallel')
+      proposal = create(:proposal)
       individuals = [Steps::Approval.new(user: approver1)]
       proposal.root_step = Steps::Parallel.new(child_approvals: individuals)
 
@@ -205,11 +205,11 @@ describe Proposal do
       expect(proposal.individual_steps.actionable.count).to be 3
     end
 
-    it 'fixes modified linear proposal approvals' do
+    it "fixes modified proposal approvals with serial steps" do
       approver1 = create(:user)
       approver2 = create(:user)
       approver3 = create(:user)
-      proposal = create(:proposal, flow: 'linear')
+      proposal = create(:proposal)
       approver1, approver2, approver3 = 3.times.map{ create(:user) }
       individuals = [approver1, approver2].map{ |u| Steps::Approval.new(user: u) }
       proposal.root_step = Steps::Serial.new(child_approvals: individuals)
@@ -227,10 +227,10 @@ describe Proposal do
       expect(proposal.individual_steps.actionable.first.user).to eq approver3
     end
 
-    it 'does not modify a full approved parallel proposal' do
+    it "does not modify a fully approved proposal with parallel steps" do
       approver1 = create(:user)
       approver2 = create(:user)
-      proposal = create(:proposal, flow: 'parallel')
+      proposal = create(:proposal)
       individuals = [approver1, approver2].map{ |u| Steps::Approval.new(user: u)}
       proposal.root_step = Steps::Parallel.new(child_approvals: individuals)
 
@@ -240,10 +240,10 @@ describe Proposal do
       expect(proposal.steps.actionable).to be_empty
     end
 
-    it 'does not modify a full approved linear proposal' do
+    it "does not modify a fully approved proposal with serial steps" do
       approver1 = create(:user)
       approver2 = create(:user)
-      proposal = create(:proposal, flow: 'linear')
+      proposal = create(:proposal)
       individuals = [approver1, approver2].map{ |u| Steps::Approval.new(user: u)}
       proposal.root_step = Steps::Serial.new(child_approvals: individuals)
 
@@ -253,7 +253,7 @@ describe Proposal do
       expect(proposal.steps.actionable).to be_empty
     end
 
-    it 'deletes approvals' do
+    it "deletes approvals" do
       proposal = create(:proposal, :with_parallel_approvers)
       approval1, approval2 = proposal.individual_steps
       proposal.root_step = Steps::Serial.new(child_approvals: [approval2])

--- a/spec/requests/api/ncr/work_orders_spec.rb
+++ b/spec/requests/api/ncr/work_orders_spec.rb
@@ -31,7 +31,6 @@ describe 'NCR Work Orders API' do
             "proposal" => {
               "steps" => [],
               "created_at" => time_to_json(proposal.created_at),
-              "flow" => proposal.flow,
               "id" => proposal.id,
               "requester" => {
                 "created_at" => time_to_json(proposal.requester.created_at),

--- a/spec/support/shared_examples/client_data.rb
+++ b/spec/support/shared_examples/client_data.rb
@@ -18,7 +18,6 @@ shared_examples "client data" do
     it { should delegate_method(:add_observer).to(:proposal) }
     it { should delegate_method(:add_requester).to(:proposal) }
     it { should delegate_method(:currently_awaiting_approvers).to(:proposal) }
-    it { should delegate_method(:flow).to(:proposal) }
     it { should delegate_method(:set_requester).to(:proposal) }
     it { should delegate_method(:status).to(:proposal) }
   end


### PR DESCRIPTION
* We do not use this concept for serial or parallel steps
* Steps of type `Serial` or `Parallel` are added to a proposal, instead
* Removing at suggestion of https://github.com/18F/C2/pull/835#issuecomment-161836392