### PR TITLE
Move `for_fiscal_year` method into mixin

### DIFF
--- a/app/models/concerns/client_data_mixin.rb
+++ b/app/models/concerns/client_data_mixin.rb
@@ -2,6 +2,8 @@ module ClientDataMixin
   extend ActiveSupport::Concern
 
   included do
+    include FiscalYearMixin
+
     Proposal::CLIENT_MODELS << self
 
     has_paper_trail class_name: "C2Version"
@@ -33,6 +35,10 @@ module ClientDataMixin
 
     scope :with_proposal_scope, ->(status) { joins(:proposal).merge(Proposal.send(status)) }
     scope :closed, -> { with_proposal_scope(:closed) }
+    scope :for_fiscal_year, lambda { |year|
+      range = range_for_fiscal_year(year)
+      where(created_at: range[:start_time]...range[:end_time])
+    }
 
     Proposal.statuses.each do |status|
       scope status, -> { with_proposal_scope(status) }

--- a/app/models/concerns/client_data_mixin.rb
+++ b/app/models/concerns/client_data_mixin.rb
@@ -35,10 +35,6 @@ module ClientDataMixin
 
     scope :with_proposal_scope, ->(status) { joins(:proposal).merge(Proposal.send(status)) }
     scope :closed, -> { with_proposal_scope(:closed) }
-    scope :for_fiscal_year, lambda { |year|
-      range = range_for_fiscal_year(year)
-      where(created_at: range[:start_time]...range[:end_time])
-    }
 
     Proposal.statuses.each do |status|
       scope status, -> { with_proposal_scope(status) }

--- a/app/models/concerns/fiscal_year_mixin.rb
+++ b/app/models/concerns/fiscal_year_mixin.rb
@@ -4,13 +4,10 @@ module FiscalYearMixin
   FISCAL_YEAR_START_MONTH = 10 # 1-based
 
   included do
-    def self.which_fiscal_year(year, month)
-      if month >= FISCAL_YEAR_START_MONTH
-        year + 1
-      else
-        year
-      end
-    end
+    scope :for_fiscal_year, ->(year) {
+      range = range_for_fiscal_year(year)
+      where(created_at: range[:start_time]...range[:end_time])
+    }
 
     def self.range_for_fiscal_year(year)
       start_time = Time.zone.local(year - 1, FISCAL_YEAR_START_MONTH, 1)

--- a/app/models/concerns/fiscal_year_mixin.rb
+++ b/app/models/concerns/fiscal_year_mixin.rb
@@ -1,13 +1,21 @@
 module FiscalYearMixin
   extend ActiveSupport::Concern
 
+  FISCAL_YEAR_START_MONTH = 10 # 1-based
+
   included do
     def self.which_fiscal_year(year, month)
-      if month >= 10
+      if month >= FISCAL_YEAR_START_MONTH
         year + 1
       else
         year
       end
+    end
+
+    def self.range_for_fiscal_year(year)
+      start_time = Time.zone.local(year - 1, FISCAL_YEAR_START_MONTH, 1)
+      end_time = start_time + 1.year
+      { start_time: start_time, end_time: end_time }
     end
   end
 end

--- a/app/models/concerns/fiscal_year_mixin.rb
+++ b/app/models/concerns/fiscal_year_mixin.rb
@@ -4,7 +4,7 @@ module FiscalYearMixin
   FISCAL_YEAR_START_MONTH = 10 # 1-based
 
   included do
-    scope :for_fiscal_year, ->(year) {
+    scope :for_fiscal_year, lambda { |year|
       range = range_for_fiscal_year(year)
       where(created_at: range[:start_time]...range[:end_time])
     }

--- a/app/models/concerns/purchase_card_mixin.rb
+++ b/app/models/concerns/purchase_card_mixin.rb
@@ -2,7 +2,6 @@
 # before 'include'-ing this concern
 module PurchaseCardMixin
   extend ActiveSupport::Concern
-  include FiscalYearMixin
 
   included do
     def self.max_amount
@@ -12,7 +11,7 @@ module PurchaseCardMixin
         'default' => 3500,
       }
       now = Time.zone.now
-      this_fiscal = self.which_fiscal_year(now.year, now.month)
+      this_fiscal = FiscalYearFinder.new(now.year, now.month).run
       fiscals[this_fiscal] || fiscals['default']
     end
 

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -47,13 +47,6 @@ module Ncr
       message: "must be three letters or numbers"
     }, allow_blank: true
 
-    FISCAL_YEAR_START_MONTH = 10 # 1-based
-    scope :for_fiscal_year, lambda { |year|
-      start_time = Time.zone.local(year - 1, FISCAL_YEAR_START_MONTH, 1)
-      end_time = start_time + 1.year
-      where(created_at: start_time...end_time)
-    }
-
     def self.all_system_approver_emails
       [
         Ncr::Mailboxes.ba61_tier1_budget,

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -62,10 +62,6 @@ class Proposal < ActiveRecord::Base
   end
   scope :closed, -> { where(status: ['approved', 'cancelled']) } #TODO: Backfill to change approvals in 'reject' status to 'cancelled' status
   scope :cancelled, -> { where(status: 'cancelled') }
-  scope :for_fiscal_year, lambda { |year|
-    range = range_for_fiscal_year(year)
-    where(created_at: range[:start_time]...range[:end_time])
-  }
 
   def root_step
     steps.where(parent: nil).first

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -2,6 +2,7 @@ class Proposal < ActiveRecord::Base
   include WorkflowModel
   include ValueHelper
   include StepManager
+  include FiscalYearMixin
 
   has_paper_trail class_name: 'C2Version'
 
@@ -61,12 +62,9 @@ class Proposal < ActiveRecord::Base
   end
   scope :closed, -> { where(status: ['approved', 'cancelled']) } #TODO: Backfill to change approvals in 'reject' status to 'cancelled' status
   scope :cancelled, -> { where(status: 'cancelled') }
-
-  FISCAL_YEAR_START_MONTH = 10 # 1-based
   scope :for_fiscal_year, lambda { |year|
-    start_time = Time.zone.local(year - 1, FISCAL_YEAR_START_MONTH, 1)
-    end_time = start_time + 1.year
-    where(created_at: start_time...end_time)
+    range = range_for_fiscal_year(year)
+    where(created_at: range[:start_time]...range[:end_time])
   }
 
   def root_step

--- a/app/services/fiscal_year_finder.rb
+++ b/app/services/fiscal_year_finder.rb
@@ -1,0 +1,20 @@
+class FiscalYearFinder
+  FISCAL_YEAR_START_MONTH = 10 # 1-based
+
+  def initialize(year, month)
+    @year = year
+    @month = month
+  end
+
+  def run
+    if month >= FISCAL_YEAR_START_MONTH
+      year + 1
+    else
+      year
+    end
+  end
+
+  private
+
+  attr_reader :year, :month
+end

--- a/lib/client_summarizer.rb
+++ b/lib/client_summarizer.rb
@@ -1,12 +1,10 @@
 class ClientSummarizer
-  include FiscalYearMixin
-
   attr_reader :client_namespace, :fiscal_year
 
   def initialize(args)
     @client_namespace = args[:client_namespace]
     now = Time.zone.now
-    @fiscal_year = (args[:fiscal_year] || self.class.which_fiscal_year(now.year, now.month)).to_i
+    @fiscal_year = (args[:fiscal_year] || FiscalYearFinder.new(now.year, now.month).run).to_i
   end
 
   def run

--- a/lib/clock_tasks.rb
+++ b/lib/clock_tasks.rb
@@ -10,7 +10,7 @@ class ClockTasks
   def self.send_weekly_fiscal_year_ncr_budget_report
     puts "SENDING WEEKLY FISCAL YEAR BUDGET REPORT..."
     now = Time.zone.now
-    fiscal_year = Ncr::WorkOrder.which_fiscal_year(now.year, now.month)
+    fiscal_year = FiscalYearFinder.new(now.year, now.month).run
     ReportMailer.weekly_fiscal_year_report(fiscal_year).deliver_later
     puts "...DONE"
   end

--- a/spec/lib/client_summarizer_spec.rb
+++ b/spec/lib/client_summarizer_spec.rb
@@ -16,7 +16,7 @@ describe ClientSummarizer do
 
   describe "Ncr::WorkOrder" do
     it "builds summary" do
-      wo = create(:ncr_work_order, amount: 123)
+      create(:ncr_work_order, amount: 123)
       summarizer = ClientSummarizer.new(client_namespace: "Ncr")
       summary = summarizer.run
       expect(summary.total).to eq(123)
@@ -27,7 +27,7 @@ describe ClientSummarizer do
 
   describe "Gsa18f::Procurement" do
     it "builds summary" do
-      procurement = create(:gsa18f_procurement, cost_per_unit: 18.50, quantity: 20)
+      create(:gsa18f_procurement, cost_per_unit: 18.50, quantity: 20)
       summarizer = ClientSummarizer.new(client_namespace: "Gsa18f")
       summary = summarizer.run
       expect(summary.total).to eq(370)

--- a/spec/lib/client_summarizer_spec.rb
+++ b/spec/lib/client_summarizer_spec.rb
@@ -3,7 +3,7 @@ describe ClientSummarizer do
     it "defaults to current year" do
       summarizer = ClientSummarizer.new(client_namespace: "test")
       now = Time.zone.now
-      expect(summarizer.fiscal_year).to eq(ClientSummarizer.which_fiscal_year(now.year, now.month))
+      expect(summarizer.fiscal_year).to eq(FiscalYearFinder.new(now.year, now.month).run)
     end
 
     it "uses namespace exactly as passed" do

--- a/spec/services/fiscal_year_finder_spec.rb
+++ b/spec/services/fiscal_year_finder_spec.rb
@@ -1,0 +1,12 @@
+describe FiscalYearFinder do
+  describe "#run" do
+    it "returns the fiscal year for a year and month" do
+      year = 2015
+      month = 10
+
+      finder = FiscalYearFinder.new(year, month).run
+
+      expect(finder).to eq 2016
+    end
+  end
+end


### PR DESCRIPTION
* Part of moving NCR-specific logic out of Ncr::WorkOrder
* Also removes duplication

https://trello.com/c/smBumRFX