### PR TITLE
Remove duplicate mailbox methods from Ncr::WorkOrder

### DIFF
--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -56,37 +56,11 @@ module Ncr
 
     def self.all_system_approver_emails
       [
-        self.ba61_tier1_budget_mailbox,
-        self.ba61_tier2_budget_mailbox,
-        self.ba80_budget_mailbox,
-        self.ool_ba80_budget_mailbox,
+        Ncr::Mailboxes.ba61_tier1_budget,
+        Ncr::Mailboxes.ba61_tier2_budget,
+        Ncr::Mailboxes.ba80_budget,
+        Ncr::Mailboxes.ool_ba80_budget,
       ]
-    end
-
-    def self.ba61_tier1_budget_mailbox
-      self.approver_with_role("BA61_tier1_budget_approver")
-    end
-
-    def self.ba61_tier2_budget_mailbox
-      self.approver_with_role("BA61_tier2_budget_approver")
-    end
-
-    def self.ba80_budget_mailbox
-      self.approver_with_role("BA80_budget_approver")
-    end
-
-    def self.ool_ba80_budget_mailbox
-      self.approver_with_role("OOL_BA80_budget_approver")
-    end
-
-    def self.approver_with_role(role_name)
-      users = User.with_role(role_name).where(client_slug: "ncr")
-
-      if users.empty?
-        fail "Missing User with role #{role_name} -- did you run rake db:migrate and rake db:seed?"
-      end
-
-      users.first.email_address
     end
 
     def self.relevant_fields(expense_type)

--- a/spec/features/ncr/work_orders/create_approver_options_spec.rb
+++ b/spec/features/ncr/work_orders/create_approver_options_spec.rb
@@ -21,10 +21,10 @@ feature "Approver options during create", :js do
 
     expect_page_not_to_have_selectized_options(
       "ncr_work_order_approving_official_email",
-      Ncr::WorkOrder.ba61_tier1_budget_mailbox,
-      Ncr::WorkOrder.ba61_tier2_budget_mailbox,
-      Ncr::WorkOrder.ba80_budget_mailbox,
-      Ncr::WorkOrder.ool_ba80_budget_mailbox
+      Ncr::Mailboxes.ba61_tier1_budget,
+      Ncr::Mailboxes.ba61_tier2_budget,
+      Ncr::Mailboxes.ba80_budget,
+      Ncr::Mailboxes.ool_ba80_budget
     )
   end
 


### PR DESCRIPTION
* Same logic lives in `Ncr::Mailboxes`
* Part of https://trello.com/c/smBumRFX/38-move-non-ncr-specific-logic-out-of-workorders