### PR TITLE
remove superflous usage of self. within classes

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -10,7 +10,7 @@ module Api
         users = users.offset(params[:offset].to_i)
       end
 
-      render json: users, root: false, each_serializer: self.serializer
+      render json: users, root: false, each_serializer: serializer
     end
 
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -73,7 +73,7 @@ class ApplicationController < ActionController::Base
   end
 
   def peek_enabled?
-    Rails.env.development? || self.admin?
+    Rails.env.development? || admin?
   end
 
   private

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,10 +1,10 @@
 class AttachmentsController < ApplicationController
-  before_action ->{authorize self.proposal, :can_show!}, only: [:create, :show]
-  before_action ->{authorize self.attachment}, only: [:destroy]
+  before_action ->{authorize proposal, :can_show!}, only: [:create, :show]
+  before_action ->{authorize attachment}, only: [:destroy]
   rescue_from Pundit::NotAuthorizedError, with: :auth_errors
 
   def create
-    attachment = self.proposal.attachments.build(attachments_params)
+    attachment = proposal.attachments.build(attachments_params)
     attachment.user = current_user
     if attachment.save
       flash[:success] = "You successfully added a attachment"
@@ -17,13 +17,13 @@ class AttachmentsController < ApplicationController
   end
 
   def destroy
-    self.attachment.destroy
+    attachment.destroy
     flash[:success] = "Deleted attachment"
     redirect_to proposal_path(attachment.proposal)
   end
 
   def show
-    redirect_to self.attachment.url
+    redirect_to attachment.url
   end
 
   protected

--- a/app/controllers/concerns/token_auth.rb
+++ b/app/controllers/concerns/token_auth.rb
@@ -22,12 +22,12 @@ module TokenAuth
 
     # expire tokens regardless of how user logged in
     tokens = ApiToken.joins(:step).where(steps: {
-      user_id: current_user, proposal_id: self.proposal})
+      user_id: current_user, proposal_id: proposal})
     tokens.where(used_at: nil).update_all(used_at: Time.zone.now)
 
-    authorize(self.proposal, :can_approve!)
+    authorize(proposal, :can_approve!)
 
-    if params[:version] && params[:version] != self.proposal.version.to_s
+    if params[:version] && params[:version] != proposal.version.to_s
       raise Pundit::NotAuthorizedError.new(
         "This request has recently changed. Please review the modified request before approving.")
     end
@@ -40,7 +40,7 @@ module TokenAuth
     when Proposal
       if exception.message == "A response has already been logged for this proposal"
         flash[:error] = exception.message
-        redirect_to self.proposal
+        redirect_to proposal
       else
         render "authorization_error", status: 403, locals: { msg: "You are not allowed to see that proposal." }
       end
@@ -65,7 +65,7 @@ module TokenAuth
       render_disabled_client_message(exception.message)
     else
       flash[:error] = exception.message
-      redirect_to self.proposal
+      redirect_to proposal
     end
   end
 end

--- a/app/controllers/gsa18f/dashboard_controller.rb
+++ b/app/controllers/gsa18f/dashboard_controller.rb
@@ -1,7 +1,7 @@
 module Gsa18f
   class DashboardController < ApplicationController
     def index
-      @rows = self.format_results(self.queryset)
+      @rows = format_results(queryset)
     end
 
     protected
@@ -20,7 +20,7 @@ module Gsa18f
     end
 
     def format_results(results)
-      return_params = self.make_return_to("Dashboard", gsa18f_dashboard_path)
+      return_params = make_return_to("Dashboard", gsa18f_dashboard_path)
       results.map{|row|
         start_date = Time.zone.local(row["year"].to_i, row["month"].to_i, 1)
         end_date = start_date + 1.month

--- a/app/controllers/gsa18f/procurements_controller.rb
+++ b/app/controllers/gsa18f/procurements_controller.rb
@@ -21,7 +21,7 @@ module Gsa18f
 
     def add_steps
       super
-      if self.errors.empty?
+      if errors.empty?
         @client_data_instance.add_steps
       end
     end

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -4,13 +4,13 @@ class HelpController < ApplicationController
   skip_before_action :check_disabled_client
 
   def index
-    @pages = self.page_names.sort
+    @pages = page_names.sort
   end
 
   def show
     page = params[:id]
     # prevent rendering of any non-help template
-    if self.page_names.include?(page)
+    if page_names.include?(page)
       render "help/#{page}"
     else
       raise ActionController::RoutingError.new('Not Found')

--- a/app/controllers/ncr/dashboard_controller.rb
+++ b/app/controllers/ncr/dashboard_controller.rb
@@ -1,7 +1,7 @@
 module Ncr
   class DashboardController < ApplicationController
     def index
-      @rows = self.format_results(self.queryset)
+      @rows = format_results(queryset)
     end
 
     protected
@@ -20,7 +20,7 @@ module Ncr
     end
 
     def format_results(results)
-      return_params = self.make_return_to("Dashboard", ncr_dashboard_path)
+      return_params = make_return_to("Dashboard", ncr_dashboard_path)
       results.map{|row|
         start_date = Time.zone.local(row["year"].to_i, row["month"].to_i, 1)
         end_date = start_date + 1.month

--- a/app/controllers/ncr/work_orders_controller.rb
+++ b/app/controllers/ncr/work_orders_controller.rb
@@ -4,7 +4,7 @@ module Ncr
     MAX_UPLOADS_ON_NEW = 10
 
     def new
-      work_order.approving_official_email = self.suggested_approver_email
+      work_order.approving_official_email = suggested_approver_email
       super
     end
 
@@ -79,7 +79,7 @@ module Ncr
     # @pre: work_order.approving_official_email is set
     def add_steps
       super
-      if self.errors.empty?
+      if errors.empty?
         work_order.setup_approvals_and_observers
       end
     end

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -1,6 +1,6 @@
 class ObservationsController < ApplicationController
   before_action :find_proposal
-  before_action -> { authorize self.observation_for_auth }
+  before_action -> { authorize observation_for_auth }
   rescue_from Pundit::NotAuthorizedError, with: :auth_errors
 
   def create
@@ -31,7 +31,7 @@ class ObservationsController < ApplicationController
     if params[:action] == 'create'
       Observation.new(proposal: @proposal)
     else
-      self.observation
+      observation
     end
   end
 

--- a/app/decorators/c2_version_decorator.rb
+++ b/app/decorators/c2_version_decorator.rb
@@ -2,9 +2,9 @@ class C2VersionDecorator < BaseDecorator
   def to_html
     case object.event
     when 'create'
-      self.creation_html
+      creation_html
     when 'update'
-      self.update_html
+      update_html
     end
   end
 
@@ -27,7 +27,7 @@ class C2VersionDecorator < BaseDecorator
     when Steps::Individual
       "#{user_name} was added as an approver."
     when Attachment
-      self.new_attachment_html
+      new_attachment_html
     when Comment
       "Commented: \"#{object.item.comment_text}\""
     when Observation

--- a/app/decorators/hash_diff_decorator/modified.rb
+++ b/app/decorators/hash_diff_decorator/modified.rb
@@ -1,11 +1,11 @@
 module HashDiffDecorator
   class Modified < HashDiffDecorator::Base
     def prev_val
-      self.diff_val(change[2])
+      diff_val(change[2])
     end
 
     def current_val
-      self.diff_val(change[3])
+      diff_val(change[3])
     end
 
     def to_html

--- a/app/decorators/proposal_decorator.rb
+++ b/app/decorators/proposal_decorator.rb
@@ -27,7 +27,7 @@ class ProposalDecorator < Draper::Decorator
     if object.flow == 'linear'
       object.individual_steps.with_users
     else
-      self.steps_by_status
+      steps_by_status
     end
   end
 

--- a/app/helpers/return_to_helper.rb
+++ b/app/helpers/return_to_helper.rb
@@ -17,7 +17,7 @@ module ReturnToHelper
   def return_to
     if params[:return_to] || session[:return_to]
       return_to = return_to_value
-      proper_sig = self.make_return_to(return_to.require(:name),
+      proper_sig = make_return_to(return_to.require(:name),
                                        return_to.require(:path))[:sig]
       if return_to.require(:sig) == proper_sig
         session.delete(:return_to)

--- a/app/helpers/return_to_helper.rb
+++ b/app/helpers/return_to_helper.rb
@@ -17,8 +17,7 @@ module ReturnToHelper
   def return_to
     if params[:return_to] || session[:return_to]
       return_to = return_to_value
-      proper_sig = make_return_to(return_to.require(:name),
-                                       return_to.require(:path))[:sig]
+      proper_sig = make_return_to(return_to.require(:name), return_to.require(:path))[:sig]
       if return_to.require(:sig) == proper_sig
         session.delete(:return_to)
         return_to.permit([:path, :name])

--- a/app/mailers/feedback_mailer.rb
+++ b/app/mailers/feedback_mailer.rb
@@ -1,6 +1,6 @@
 class FeedbackMailer < ApplicationMailer
   def feedback(sending_user, form_values)
-    from = sending_user.try(:email_address) || form_values[:email] || self.default_sender_email
+    from = sending_user.try(:email_address) || form_values[:email] || default_sender_email
 
     # ensure each new feedback email is in its own thread
     self.thread_id = SecureRandom.hex
@@ -11,7 +11,7 @@ class FeedbackMailer < ApplicationMailer
       from: from,
       cc: from,
       reply_to: from,
-      body: self.body_for(form_values)
+      body: body_for(form_values)
     )
   end
 

--- a/app/models/api_token.rb
+++ b/app/models/api_token.rb
@@ -32,7 +32,7 @@ class ApiToken < ActiveRecord::Base
   end
 
   def expire!
-    self.update(expires_at: Time.zone.now)
+    update(expires_at: Time.zone.now)
   end
 
   private

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -15,6 +15,6 @@ class Attachment < ActiveRecord::Base
 
   # Default url for attachments expires after 10 minutes
   def url
-    self.file.expiring_url(10*60)
+    file.expiring_url(10*60)
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -18,10 +18,10 @@ class Comment < ActiveRecord::Base
   # match .attributes
   def to_a
     [
-      self.user_email_address,
-      self.comment_text,
-      self.updated_at,
-      I18n.l(self.updated_at)
+      user_email_address,
+      comment_text,
+      updated_at,
+      I18n.l(updated_at)
     ]
   end
 
@@ -37,19 +37,19 @@ class Comment < ActiveRecord::Base
   end
 
   def add_user_as_observer
-    self.proposal.add_observer(self.user.email_address)
+    proposal.add_observer(user.email_address)
   end
 
   # All of the users who should be notified when a comment is created
   # This is basically Proposal.users _minus_ future approvers
   def listeners
     users_to_notify = Set.new
-    users_to_notify += self.proposal.currently_awaiting_approvers
-    users_to_notify += self.proposal.individual_steps.approved.map(&:user)
-    users_to_notify += self.proposal.observers
-    users_to_notify << self.proposal.requester
+    users_to_notify += proposal.currently_awaiting_approvers
+    users_to_notify += proposal.individual_steps.approved.map(&:user)
+    users_to_notify += proposal.observers
+    users_to_notify << proposal.requester
     # Creator of comment doesn't need to be notified
-    users_to_notify.delete(self.user)
+    users_to_notify.delete(user)
     users_to_notify
   end
 end

--- a/app/models/concerns/client_data_mixin.rb
+++ b/app/models/concerns/client_data_mixin.rb
@@ -44,7 +44,7 @@ module ClientDataMixin
     end
 
     def self.client_slug
-      self.to_s.deconstantize.downcase
+      to_s.deconstantize.downcase
     end
 
     def client_slug

--- a/app/models/concerns/purchase_card_mixin.rb
+++ b/app/models/concerns/purchase_card_mixin.rb
@@ -12,7 +12,7 @@ module PurchaseCardMixin
         'default' => 3500,
       }
       now = Time.zone.now
-      this_fiscal = self.which_fiscal_year(now.year, now.month)
+      this_fiscal = which_fiscal_year(now.year, now.month)
       fiscals[this_fiscal] || fiscals['default']
     end
 

--- a/app/models/concerns/step_manager.rb
+++ b/app/models/concerns/step_manager.rb
@@ -6,7 +6,7 @@ module StepManager
   end
 
   def root_step=(root)
-    old_steps = self.steps.to_a
+    old_steps = steps.to_a
     step_list = root.pre_order_tree_traversal
     step_list.each { |a| a.proposal = self }
     self.steps = step_list
@@ -15,10 +15,10 @@ module StepManager
       step.set_list_position(idx + 1) # start with 1
     end
 
-    self.clean_up_old_steps(old_steps, step_list)
+    clean_up_old_steps(old_steps, step_list)
 
     root.initialize!
-    self.reset_status
+    reset_status
   end
 
   def clean_up_old_steps(old_steps, step_list)
@@ -30,19 +30,19 @@ module StepManager
 
   # Steps in which someone can take action
   def currently_awaiting_steps
-    self.individual_steps.actionable
+    individual_steps.actionable
   end
 
   def currently_awaiting_approvers
-    self.approvers.merge(self.currently_awaiting_steps)
+    approvers.merge(currently_awaiting_steps)
   end
 
   def awaiting_approver?(user)
-    self.currently_awaiting_approvers.include?(user)
+    currently_awaiting_approvers.include?(user)
   end
 
   def approver_email_frozen?
-    approval = self.individual_steps.first
+    approval = individual_steps.first
     approval && !approval.actionable?
   end
 

--- a/app/models/concerns/workflow_model.rb
+++ b/app/models/concerns/workflow_model.rb
@@ -9,20 +9,20 @@ module WorkflowModel
 
     workflow_column :status
 
-    validates :status, presence: true, inclusion: {in: lambda{ |wf| self.statuses.map(&:to_s)}}
+    validates :status, presence: true, inclusion: {in: lambda{ |wf| statuses.map(&:to_s)}}
   end
 
   module ClassMethods
     # returns an array of symbols
     def statuses
-      self.workflow_spec.state_names
+      workflow_spec.state_names
     end
 
     # returns a set of symbols
     def events
       results = Set.new
       # collect events from every state
-      self.workflow_spec.states.each do |state_name, state|
+      workflow_spec.states.each do |state_name, state|
         state.events.each do |event_name, event|
           results << event_name
         end

--- a/app/models/gsa18f/procurement.rb
+++ b/app/models/gsa18f/procurement.rb
@@ -49,7 +49,7 @@ module Gsa18f
     validates :recurring_interval, presence: true, if: :recurring
 
     def self.relevant_fields(recurring)
-      fields = self.default_fields
+      fields = default_fields
 
       if recurring
         fields += [:recurring_interval, :recurring_length]
@@ -59,13 +59,13 @@ module Gsa18f
     end
 
     def self.default_fields
-      fields = self.column_names.map(&:to_sym)
+      fields = column_names.map(&:to_sym)
       fields - [:recurring_interval, :recurring_length, :created_at, :updated_at, :id]
     end
 
     def fields_for_display
       attributes = self.class.relevant_fields(recurring)
-      attributes_for_view = attributes.map { |key| [Procurement.human_attribute_name(key), self.send(key)] }
+      attributes_for_view = attributes.map { |key| [Procurement.human_attribute_name(key), send(key)] }
       attributes_for_view.push(["Total Price", total_price])
     end
 
@@ -78,12 +78,12 @@ module Gsa18f
     end
 
     def total_price
-      (self.cost_per_unit * self.quantity) || 0.0
+      (cost_per_unit * quantity) || 0.0
     end
 
     # may be replaced with paper-trail or similar at some point
     def version
-      self.updated_at.to_i
+      updated_at.to_i
     end
 
     def name
@@ -109,11 +109,11 @@ module Gsa18f
     end
 
     def self.approver_email
-      self.user_with_role('gsa18f_approver').email_address
+      user_with_role('gsa18f_approver').email_address
     end
 
     def self.purchaser_email
-      self.user_with_role('gsa18f_purchaser').email_address
+      user_with_role('gsa18f_purchaser').email_address
     end
 
     def self.user_with_role(role_name)

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -64,7 +64,7 @@ module Ncr
     end
 
     def self.relevant_fields(expense_type)
-      fields = self.default_fields
+      fields = default_fields
 
       if expense_type == "BA61"
         fields << :emergency
@@ -76,21 +76,21 @@ module Ncr
     end
 
     def self.default_fields
-      fields = self.column_names.map(&:to_sym) + [:approving_official_email]
+      fields = column_names.map(&:to_sym) + [:approving_official_email]
       fields - [:emergency, :rwa_number, :code, :created_at, :updated_at, :id]
     end
 
     def approver_email_frozen?
-      approval = self.individual_steps.first
+      approval = individual_steps.first
       approval && !approval.actionable?
     end
 
     def approver_changed?
-      self.approving_official && self.approving_official.email_address != approving_official_email
+      approving_official && approving_official.email_address != approving_official_email
     end
 
     def requires_approval?
-      !self.emergency
+      !emergency
     end
 
     def for_whsc_organization?
@@ -133,7 +133,7 @@ module Ncr
     end
 
     def budget_approvals
-      self.individual_steps.offset(1)
+      individual_steps.offset(1)
     end
 
     def budget_approvers
@@ -147,7 +147,7 @@ module Ncr
     # Methods for Client Data interface
     def fields_for_display
       attributes = self.class.relevant_fields(expense_type)
-      attributes.map { |attribute| [WorkOrder.human_attribute_name(attribute), self.send(attribute)] }
+      attributes.map { |attribute| [WorkOrder.human_attribute_name(attribute), send(attribute)] }
     end
 
     def ba80?
@@ -159,12 +159,12 @@ module Ncr
     end
 
     def total_price
-      self.amount || 0.0
+      amount || 0.0
     end
 
     # may be replaced with paper-trail or similar at some point
     def version
-      self.updated_at.to_i
+      updated_at.to_i
     end
 
     def system_approver_emails
@@ -190,8 +190,8 @@ module Ncr
     end
 
     def fiscal_year
-      year = self.created_at.nil? ? Time.zone.now.year : self.created_at.year
-      month = self.created_at.nil? ? Time.zone.now.month : self.created_at.month
+      year = created_at.nil? ? Time.zone.now.year : created_at.year
+      month = created_at.nil? ? Time.zone.now.month : created_at.month
       if month >= 10
         year += 1
       end
@@ -199,9 +199,9 @@ module Ncr
     end
 
     def restart_budget_approvals
-      self.budget_approvals.each(&:restart!)
-      self.proposal.reset_status
-      self.proposal.root_step.initialize!
+      budget_approvals.each(&:restart!)
+      proposal.reset_status
+      proposal.root_step.initialize!
     end
 
     private

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -11,14 +11,14 @@ class Observation < ProposalRole
   after_initialize :init
 
   def init
-    self.role_id ||= Role.find_or_create_by(name: 'observer').id
+    role_id ||= Role.find_or_create_by(name: 'observer').id
   end
 
   def creation_version
-    self.versions.find_by(event: 'create')
+    versions.find_by(event: 'create')
   end
 
   def created_by
-    self.creation_version.try(:user)
+    creation_version.try(:user)
   end
 end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -11,7 +11,7 @@ class Observation < ProposalRole
   after_initialize :init
 
   def init
-    role_id ||= Role.find_or_create_by(name: 'observer').id
+    self.role_id ||= Role.find_or_create_by(name: 'observer').id
   end
 
   def creation_version

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -48,7 +48,7 @@ class Proposal < ActiveRecord::Base
   delegate :client_slug, to: :client_data, allow_nil: true
 
   validates :client_data_type, inclusion: {
-    in: ->(_) { self.client_model_names },
+    in: ->(_) { client_model_names },
     message: "%{value} is not a valid client model type. Valid client model types are: #{CLIENT_MODELS.inspect}",
     allow_blank: true
   }
@@ -56,7 +56,7 @@ class Proposal < ActiveRecord::Base
   validates :requester_id, presence: true
   validates :public_id, uniqueness: true, allow_nil: true
 
-  self.statuses.each do |status|
+  statuses.each do |status|
     scope status, -> { where(status: status) }
   end
   scope :closed, -> { where(status: ['approved', 'cancelled']) } #TODO: Backfill to change approvals in 'reject' status to 'cancelled' status

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -22,7 +22,7 @@ class Step < ActiveRecord::Base
   # @TODO: Auto-generate list of subclasses
   scope :individual, -> { where(type: ["Steps::Approval", "Steps::Purchase"]).order("position ASC") }
 
-  self.statuses.each do |status|
+  statuses.each do |status|
     scope status, -> { where(status: status) }
   end
   scope :non_pending, -> { where.not(status: "pending") }
@@ -31,7 +31,7 @@ class Step < ActiveRecord::Base
   default_scope { order("position ASC") }
 
   def pre_order_tree_traversal
-    [self] + self.child_approvals.flat_map(&:pre_order_tree_traversal)
+    [self] + child_approvals.flat_map(&:pre_order_tree_traversal)
   end
 
   def completed_by
@@ -41,20 +41,20 @@ class Step < ActiveRecord::Base
   protected
 
   def restart
-    if self.parent
-      self.parent.restart!
+    if parent
+      parent.restart!
     end
   end
 
   def notify_parent_approved
-    if self.parent
-      self.parent.child_approved!(self)
+    if parent
+      parent.child_approved!(self)
     else
-      self.proposal.approve!
+      proposal.approve!
     end
   end
 
   def children_approved?
-    self.child_approvals.outstanding.empty?
+    child_approvals.outstanding.empty?
   end
 end

--- a/app/models/steps/individual.rb
+++ b/app/models/steps/individual.rb
@@ -15,7 +15,7 @@ module Steps
     self.abstract_class = true
 
     workflow do
-      on_transition { self.touch } # sets updated_at; https://github.com/geekq/workflow/issues/96
+      on_transition { touch } # sets updated_at; https://github.com/geekq/workflow/issues/96
 
       state :pending do
         event :initialize, transitions_to: :actionable
@@ -32,13 +32,13 @@ module Steps
 
       state :approved do
         on_entry do
-          self.update(approved_at: Time.zone.now)
-          self.notify_parent_approved
+          update(approved_at: Time.zone.now)
+          notify_parent_approved
           Dispatcher.on_approval_approved(self)
         end
 
         event :initialize, transitions_to: :actionable do
-          self.notify_parent_approved
+          notify_parent_approved
           halt  # prevent state transition
         end
 
@@ -49,7 +49,7 @@ module Steps
     protected
 
     def restart
-      self.api_token.try(:expire!)
+      api_token.try(:expire!)
       super
     end
 

--- a/app/models/steps/parallel.rb
+++ b/app/models/steps/parallel.rb
@@ -5,7 +5,7 @@ module Steps
     validates :min_children_needed, numericality: { allow_blank: true }
 
     workflow do
-      on_transition { self.touch } # sets updated_at; https://github.com/geekq/workflow/issues/96
+      on_transition { touch } # sets updated_at; https://github.com/geekq/workflow/issues/96
 
       state :pending do
         event :initialize, transitions_to: :actionable
@@ -19,17 +19,17 @@ module Steps
           halt  # prevent state transition
         end
         event :child_approved, transitions_to: :approved do |_|
-          halt unless self.children_approved?
+          halt unless children_approved?
         end
         event :force_approve, transitions_to: :approved
         event :restart, transitions_to: :pending
       end
 
       state :approved do
-        on_entry { self.notify_parent_approved }
+        on_entry { notify_parent_approved }
 
         event :initialize, transitions_to: :approved do
-          self.notify_parent_approved
+          notify_parent_approved
           halt  # prevent state transition
         end
 
@@ -42,10 +42,10 @@ module Steps
     end
 
     def on_actionable_entry(_, _)
-      if self.child_approvals.any?
-        self.child_approvals.each(&:initialize!)
+      if child_approvals.any?
+        child_approvals.each(&:initialize!)
       else
-        self.force_approve!
+        force_approve!
       end
     end
 
@@ -53,8 +53,8 @@ module Steps
     # approvals, and min_children_needed is set to 2, only 2 of the 3 must
     # approve. When min_children_needed is 1, we create an "OR" situation
     def children_approved?
-      needed = self.min_children_needed || self.child_approvals.count
-      self.child_approvals.approved.count >= needed
+      needed = min_children_needed || child_approvals.count
+      child_approvals.approved.count >= needed
     end
   end
 end

--- a/app/models/steps/serial.rb
+++ b/app/models/steps/serial.rb
@@ -2,7 +2,7 @@
 module Steps
   class Serial < Step
     workflow do
-      on_transition { self.touch } # sets updated_at; https://github.com/geekq/workflow/issues/96
+      on_transition { touch } # sets updated_at; https://github.com/geekq/workflow/issues/96
 
       state :pending do
         event :initialize, transitions_to: :actionable
@@ -16,18 +16,18 @@ module Steps
           halt  # prevent state transition
         end
         event :child_approved, transitions_to: :approved do |child|
-          self.init_child_after(child)
-          halt unless self.children_approved?
+          init_child_after(child)
+          halt unless children_approved?
         end
         event :force_approve, transitions_to: :approved
         event :restart, transitions_to: :pending
       end
 
       state :approved do
-        on_entry { self.notify_parent_approved }
+        on_entry { notify_parent_approved }
 
         event :initialize, transitions_to: :approved do
-          self.notify_parent_approved
+          notify_parent_approved
           halt  # prevent state transition
         end
 
@@ -40,18 +40,18 @@ module Steps
     end
 
     def on_actionable_entry(_, _)
-      first_approval = self.child_approvals.first
+      first_approval = child_approvals.first
       if first_approval
         first_approval.initialize!
       else
-        self.force_approve!
+        force_approve!
       end
     end
 
     # enforce initialization of children in sequence. If we hit one which is
     # already approved, it will notify us, and then  we'll notify the next
     def init_child_after(approval)
-      child_after = self.child_approvals.find_by("position > ?", approval.position)
+      child_after = child_approvals.find_by("position > ?", approval.position)
       if child_after
         child_after.initialize!
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@ class User < ActiveRecord::Base
   end
 
   def self.sql_for_role_slug(role_name, slug)
-    self.with_role(role_name).select(:id).where(client_slug: slug).to_sql
+    with_role(role_name).select(:id).where(client_slug: slug).to_sql
   end
 
   def self.with_role(role_name)
@@ -53,7 +53,7 @@ class User < ActiveRecord::Base
 
   def self.from_oauth_hash(auth_hash)
     user_data = auth_hash.extra.raw_info.to_hash
-    user = self.for_email(user_data["email"])
+    user = for_email(user_data["email"])
     user.update_names_if_present(user_data)
     user
   end
@@ -110,7 +110,7 @@ class User < ActiveRecord::Base
   def update_names_if_present(user_data)
     %w(first_name last_name).each do |field|
       attr = field.to_sym
-      if user_data[field].present? && self.send(attr).blank?
+      if user_data[field].present? && send(attr).blank?
         update_attributes(attr => user_data[field])
       end
     end

--- a/app/policies/concerns/gsa_policy.rb
+++ b/app/policies/concerns/gsa_policy.rb
@@ -6,10 +6,10 @@ module GsaPolicy
   end
 
   def gsa!
-    check(self.gsa_email?, "You must be logged in with a GSA email address to create")
+    check(gsa_email?, "You must be logged in with a GSA email address to create")
   end
 
   def gsa_if_restricted!
-    !self.restricted? || self.gsa!
+    !restricted? || gsa!
   end
 end

--- a/app/policies/exception_policy.rb
+++ b/app/policies/exception_policy.rb
@@ -13,7 +13,7 @@ module ExceptionPolicy
     if method_str.end_with?("?")
       exc_method = method_str[0..-2] + "!"
       begin
-        self.send(exc_method, *arguments, &block)
+        send(exc_method, *arguments, &block)
       rescue Pundit::NotAuthorizedError
         false
       end

--- a/app/policies/gsa18f/procurement_policy.rb
+++ b/app/policies/gsa18f/procurement_policy.rb
@@ -8,7 +8,7 @@ module Gsa18f
     end
 
     def can_create!
-      super && self.gsa_if_restricted!
+      super && gsa_if_restricted!
     end
     alias_method :can_new!, :can_create!
 

--- a/app/policies/ncr/work_order_policy.rb
+++ b/app/policies/ncr/work_order_policy.rb
@@ -9,7 +9,7 @@ module Ncr
 
     def can_edit!
       check(
-        self.requester? || self.approver? || self.observer?,
+        requester? || approver? || observer?,
         "You must be the requester, approver, or observer to edit"
       )
     end
@@ -17,7 +17,7 @@ module Ncr
     alias_method :can_update!, :can_edit!
 
     def can_create!
-      super && self.gsa_if_restricted!
+      super && gsa_if_restricted!
     end
     alias_method :can_new!, :can_create!
   end

--- a/app/policies/observation_policy.rb
+++ b/app/policies/observation_policy.rb
@@ -7,11 +7,11 @@ class ObservationPolicy
   end
 
   def can_create!
-    self.can_show_proposal!
+    can_show_proposal!
   end
 
   def can_destroy!
-    self.can_show_proposal! || user_is_observer!
+    can_show_proposal! || user_is_observer!
   end
 
   protected

--- a/app/policies/proposal_policy.rb
+++ b/app/policies/proposal_policy.rb
@@ -16,7 +16,7 @@ class ProposalPolicy
   alias_method :can_update!, :can_edit!
 
   def can_show!
-    check(self.visible_proposals.exists?(@proposal.id), "You are not allowed to see this proposal")
+    check(visible_proposals.exists?(@proposal.id), "You are not allowed to see this proposal")
   end
   alias_method :can_history!, :can_show!
 
@@ -50,7 +50,7 @@ class ProposalPolicy
   end
 
   def requester!
-    check(self.requester?, "You are not the requester")
+    check(requester?, "You are not the requester")
   end
 
   def not_approved!
@@ -78,7 +78,7 @@ class ProposalPolicy
 
   def approver!
     check(
-      self.approver? || self.delegate?,
+      approver? || delegate?,
       "Sorry, you're not an approver on this proposal"
     )
   end
@@ -97,7 +97,7 @@ class ProposalPolicy
   end
 
   def pending_approval!
-    check(self.pending_approver? || self.pending_delegate?,
+    check(pending_approver? || pending_delegate?,
           "A response has already been logged for this proposal")
   end
 

--- a/app/policies/proposal_policy/scope.rb
+++ b/app/policies/proposal_policy/scope.rb
@@ -10,7 +10,7 @@ class ProposalPolicy
       if @user.admin?
         @scope.all
       elsif @user.client_admin?
-        self.for_client_admin
+        for_client_admin
       else
         @scope.where(Query::Proposal::Clauses.new.which_involve(@user))
       end

--- a/lib/c2_version.rb
+++ b/lib/c2_version.rb
@@ -2,24 +2,24 @@ class C2Version < PaperTrail::Version
   self.table_name = :versions
 
   def user
-    User.find_by(id: self.whodunnit.to_i)
+    User.find_by(id: whodunnit.to_i)
   end
 
   def attributes
-    if self.object
-      YAML.load(self.object)
+    if object
+      YAML.load(object)
     else
       {}
     end
   end
 
   def diff
-    case self.event
+    case event
     when 'create'
-      HashDiff.diff({}, self.attributes)
+      HashDiff.diff({}, attributes)
     when 'update'
-      prev = self.previous
-      HashDiff.diff(prev.attributes, self.attributes)
+      prev = previous
+      HashDiff.diff(prev.attributes, attributes)
     else
       # not sure what makes the most sense here...
       nil

--- a/lib/client_summary.rb
+++ b/lib/client_summary.rb
@@ -40,6 +40,6 @@ class ClientSummary
   end
 
   def status_percent(status)
-    (self.status(status).to_f / status_sum) * 100
+    (status(status).to_f / status_sum) * 100
   end
 end

--- a/lib/cloud_foundry.rb
+++ b/lib/cloud_foundry.rb
@@ -4,8 +4,8 @@ module CloudFoundry
   end
 
   def self.vcap_data
-    if self.is_environment?
-      JSON.parse(self.raw_vcap_data)
+    if is_environment?
+      JSON.parse(raw_vcap_data)
     else
       nil
     end
@@ -13,12 +13,12 @@ module CloudFoundry
 
   # returns `true` if this app is running in Cloud Foundry
   def self.is_environment?
-    !!self.raw_vcap_data
+    !!raw_vcap_data
   end
 
   def self.instance_index
-    if self.is_environment?
-      self.vcap_data['instance_index']
+    if is_environment?
+      vcap_data['instance_index']
     else
       nil
     end

--- a/lib/csv_user_importer.rb
+++ b/lib/csv_user_importer.rb
@@ -11,18 +11,18 @@ class CsvUserImporter
   end
 
   def process_rows
-    if !self.first_name_col || !self.last_name_col || !self.email_col
+    if !first_name_col || !last_name_col || !email_col
       raise "Couldn't determine one or more of first name, last name, email: #{@csv.headers()}"
     end
 
     @csv.each do |row|
-      email = row[self.email_col]
+      email = row[email_col]
       if email.blank?
         warn "Email is empty: " + row.inspect
       else
         User.for_email(email).update(   # for_email will standardize
-          first_name: row[self.first_name_col].try(:titleize),
-          last_name: row[self.last_name_col].try(:titleize),
+          first_name: row[first_name_col].try(:titleize),
+          last_name: row[last_name_col].try(:titleize),
           client_slug: @client
         )
       end

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -54,7 +54,7 @@ class Dispatcher
       Mailer.approval_reply_received_email(approval).deliver_later
     end
 
-    self.email_observers(approval.proposal)
+    email_observers(approval.proposal)
   end
 
   def on_comment_created(comment)

--- a/lib/dispatcher/class_methods_mixin.rb
+++ b/lib/dispatcher/class_methods_mixin.rb
@@ -7,7 +7,7 @@ class Dispatcher
       def initialize_dispatcher(proposal)
         case proposal.flow
         when 'parallel'
-          self.new
+          new
         when 'linear'
           # @todo: dynamic dispatch for selection
           if proposal.client_slug == "ncr"
@@ -21,42 +21,42 @@ class Dispatcher
       # TODO DRY the following up
 
       def deliver_new_proposal_emails(proposal)
-        dispatcher = self.initialize_dispatcher(proposal)
+        dispatcher = initialize_dispatcher(proposal)
         dispatcher.deliver_new_proposal_emails(proposal)
       end
 
       def on_approval_approved(approval)
-        dispatcher = self.initialize_dispatcher(approval.proposal)
+        dispatcher = initialize_dispatcher(approval.proposal)
         dispatcher.on_approval_approved(approval)
       end
 
       def on_comment_created(comment)
-        dispatcher = self.initialize_dispatcher(comment.proposal)
+        dispatcher = initialize_dispatcher(comment.proposal)
         dispatcher.on_comment_created(comment)
       end
 
       def email_approver(approval)
-        dispatcher = self.initialize_dispatcher(approval.proposal)
+        dispatcher = initialize_dispatcher(approval.proposal)
         dispatcher.email_approver(approval)
       end
 
       def on_proposal_update(proposal, modifier = nil)
-        dispatcher = self.initialize_dispatcher(proposal)
+        dispatcher = initialize_dispatcher(proposal)
         dispatcher.on_proposal_update(proposal, modifier)
       end
 
       def on_approver_removal(proposal, approvers)
-        dispatcher = self.initialize_dispatcher(proposal)
+        dispatcher = initialize_dispatcher(proposal)
         dispatcher.on_approver_removal(proposal, approvers)
       end
 
       def on_observer_added(observation, reason)
-        dispatcher = self.initialize_dispatcher(observation.proposal)
+        dispatcher = initialize_dispatcher(observation.proposal)
         dispatcher.on_observer_added(observation, reason)
       end
 
       def deliver_attachment_emails(proposal)
-        dispatcher = self.initialize_dispatcher(proposal)
+        dispatcher = initialize_dispatcher(proposal)
         dispatcher.deliver_attachment_emails(proposal)
       end
     end

--- a/lib/linear_dispatcher.rb
+++ b/lib/linear_dispatcher.rb
@@ -9,8 +9,8 @@ class LinearDispatcher < Dispatcher
   end
 
   def on_approval_approved(approval)
-    if next_approval = self.next_pending_approval(approval.proposal)
-      self.email_approver(next_approval)
+    if next_approval = next_pending_approval(approval.proposal)
+      email_approver(next_approval)
     end
     super
   end

--- a/lib/ncr/reporter.rb
+++ b/lib/ncr/reporter.rb
@@ -27,7 +27,7 @@ module Ncr
 
     def self.make_csv_row(proposal)
       [
-        self.proposal_public_url(proposal),
+        proposal_public_url(proposal),
         proposal.requester.email_address,
         proposal.client_data.decorate.status_aware_approver_email_address,
         proposal.client_data.cl_number,
@@ -41,7 +41,7 @@ module Ncr
       CSV.generate do |csv|
         csv << ['URL', 'Requester', 'Approver', 'CL', 'Function Code', 'Soc Code', 'Created']
         proposals.each do |p|
-          csv << self.make_csv_row(p)
+          csv << make_csv_row(p)
         end
       end
     end

--- a/lib/policy_finder.rb
+++ b/lib/policy_finder.rb
@@ -14,7 +14,7 @@ module PolicyFinder
   end
 
   def self.policy_for(user, record)
-    record = self.authorizing_object(record)
+    record = authorizing_object(record)
     Pundit.policy(user, record)
   end
 end

--- a/lib/query/proposal/listing.rb
+++ b/lib/query/proposal/listing.rb
@@ -84,7 +84,7 @@ module Query
 
       def param_date(sym)
         begin
-          Date.strptime(self.params[sym].to_s)
+          Date.strptime(params[sym].to_s)
         rescue ArgumentError
           nil
         end

--- a/lib/query/proposal/search.rb
+++ b/lib/query/proposal/search.rb
@@ -47,12 +47,12 @@ module Query
       end
 
       def joined
-        self.relation.joins(JOIN)
+        relation.joins(JOIN)
       end
 
       def execute(query)
         sanitized = ActiveRecord::Base.sanitize(query)
-        self.joined.
+        joined.
           where('p_search.document @@ plainto_tsquery(?)', query).
           order("ts_rank(p_search.document, plainto_tsquery(#{sanitized})) DESC")
       end

--- a/lib/tabular_data/column.rb
+++ b/lib/tabular_data/column.rb
@@ -18,7 +18,7 @@ module TabularData
     end
 
     def sort(dir)
-      if self.can_sort?
+      if can_sort?
         @sort_dir = dir
         if dir
           @db_expr.send(dir)

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -231,7 +231,7 @@ describe ProposalsController do
 
       get :approve, id: proposal.id, cch: token.access_token
 
-      expect(response).to redirect_to(root_path(return_to: self.make_return_to("Previous", request.fullpath)))
+      expect(response).to redirect_to(root_path(return_to: make_return_to("Previous", request.fullpath)))
     end
 
     it "won't allow a missing token when using GET" do

--- a/spec/requests/proposals_spec.rb
+++ b/spec/requests/proposals_spec.rb
@@ -44,7 +44,7 @@ describe 'proposals' do
       proposal = create(:proposal, :with_approver)
       post "/proposals/#{proposal.id}/approve"
 
-      expect(response.status).to redirect_to(root_path(return_to: self.make_return_to("Previous", request.fullpath)))
+      expect(response.status).to redirect_to(root_path(return_to: make_return_to("Previous", request.fullpath)))
       expect_status(proposal, 'pending', 'actionable')
     end
 
@@ -127,7 +127,7 @@ describe 'proposals' do
 
         get "/proposals/#{proposal.id}/approve", cch: token.access_token
 
-        expect(response).to redirect_to(root_path(return_to: self.make_return_to("Previous", request.fullpath)))
+        expect(response).to redirect_to(root_path(return_to: make_return_to("Previous", request.fullpath)))
 
         login_as(delegate)
 


### PR DESCRIPTION
This is a style change only. No ego here.

For posterity, this was a few Perl one-liners:
```bash
perl -pi -e '!m/def self\./ && !m/self\..+ =/ && !m/self\.class/ && s/self\.//g' app/*/*rb
```

and repeat for each path. A couple manual clean up cases, but that regex sequence gets most of it.