### PR TITLE
Show "Purchaser" instead of "Approver" on Proposal detail page

### DIFF
--- a/app/controllers/concerns/token_auth.rb
+++ b/app/controllers/concerns/token_auth.rb
@@ -25,7 +25,7 @@ module TokenAuth
       user_id: current_user, proposal_id: proposal})
     tokens.where(used_at: nil).update_all(used_at: Time.zone.now)
 
-    authorize(proposal, :can_approve!)
+    authorize(proposal, :can_complete!)
 
     if params[:version] && params[:version] != proposal.version.to_s
       raise Pundit::NotAuthorizedError.new(

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -50,9 +50,9 @@ class ProposalsController < ApplicationController
   end
 
   def approve
-    approval = proposal.existing_step_for(current_user)
-    approval.update_attributes!(completer: current_user)
-    approval.approve!
+    step = proposal.existing_step_for(current_user)
+    step.update_attributes!(completer: current_user)
+    step.approve!
     flash[:success] = "You have approved #{proposal.public_id}."
     redirect_to proposal
   end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -50,7 +50,7 @@ class ProposalsController < ApplicationController
   end
 
   def approve
-    approval = proposal.existing_approval_for(current_user)
+    approval = proposal.existing_step_for(current_user)
     approval.update_attributes!(completer: current_user)
     approval.approve!
     flash[:success] = "You have approved #{proposal.public_id}."

--- a/app/decorators/proposal_decorator.rb
+++ b/app/decorators/proposal_decorator.rb
@@ -38,7 +38,7 @@ class ProposalDecorator < Draper::Decorator
   end
 
   def step_text_for_user(key, user)
-    step = existing_approval_for(user)
+    step = existing_step_for(user)
     klass = step.class.name.demodulize.downcase.to_sym
     scope = [:decorators, :steps, klass]
     I18n.t(key, scope: scope)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -44,7 +44,7 @@ class Comment < ActiveRecord::Base
   # This is basically Proposal.users _minus_ future approvers
   def listeners
     users_to_notify = Set.new
-    users_to_notify += proposal.currently_awaiting_approvers
+    users_to_notify += proposal.currently_awaiting_step_users
     users_to_notify += proposal.individual_steps.approved.map(&:user)
     users_to_notify += proposal.observers
     users_to_notify << proposal.requester

--- a/app/models/concerns/client_data_mixin.rb
+++ b/app/models/concerns/client_data_mixin.rb
@@ -11,8 +11,9 @@ module ClientDataMixin
     has_one :proposal, as: :client_data
     has_many :steps, through: :proposal
     has_many :individual_steps, -> { individual }, class_name: "Steps::Individual", through: :proposal
-    has_many :approvers, through: :individual_steps, source: :user
-    has_many :completers, through: :individual_steps, source: :completer
+    has_many :approvers, through: :proposal
+    has_many :purchasers, through: :proposal
+    has_many :completers, through: :proposal
     has_many :observations, through: :proposal
     has_many :observers, through: :observations, source: :user
     has_many :comments, through: :proposal
@@ -25,7 +26,7 @@ module ClientDataMixin
     delegate(
       :add_observer,
       :add_requester,
-      :currently_awaiting_approvers,
+      :currently_awaiting_step_users,
       :ineligible_approvers,
       :set_requester,
       :status,

--- a/app/models/concerns/step_manager.rb
+++ b/app/models/concerns/step_manager.rb
@@ -33,17 +33,17 @@ module StepManager
     individual_steps.actionable
   end
 
-  def currently_awaiting_approvers
-    approvers.merge(currently_awaiting_steps)
+  def currently_awaiting_step_users
+    approvers_and_purchasers.merge(currently_awaiting_steps)
   end
 
-  def awaiting_approver?(user)
-    currently_awaiting_approvers.include?(user)
+  def awaiting_step_user?(user)
+    currently_awaiting_step_users.include?(user)
   end
 
   def approver_email_frozen?
-    approval = individual_steps.first
-    approval && !approval.actionable?
+    step = individual_steps.first
+    step && !step.actionable?
   end
 
   def ineligible_approvers

--- a/app/models/concerns/step_manager.rb
+++ b/app/models/concerns/step_manager.rb
@@ -34,7 +34,7 @@ module StepManager
   end
 
   def currently_awaiting_step_users
-    approvers_and_purchasers.merge(currently_awaiting_steps)
+    step_users.merge(currently_awaiting_steps)
   end
 
   def awaiting_step_user?(user)

--- a/app/models/gsa18f/procurement.rb
+++ b/app/models/gsa18f/procurement.rb
@@ -103,9 +103,7 @@ module Gsa18f
     end
 
     def purchaser
-      if purchase_step
-        purchase_step.user
-      end
+      purchasers.first
     end
 
     def self.approver_email
@@ -123,12 +121,6 @@ module Gsa18f
       end
 
       users.first
-    end
-
-    private
-
-    def purchase_step
-      steps.select{|step| step.is_a?(Steps::Purchase)}.first
     end
   end
 end

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -109,7 +109,7 @@ module Ncr
 
     def current_approver
       if pending?
-        currently_awaiting_approvers.first
+        currently_awaiting_step_users.first
       elsif approving_official
         approving_official
       elsif emergency and approvers.empty?

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -34,7 +34,7 @@ class Proposal < ActiveRecord::Base
   has_many :individual_steps, ->{ individual }, class_name: "Steps::Individual"
   has_many :approval_steps, class_name: "Steps::Approval"
   has_many :purchase_steps, class_name: "Steps::Purchase"
-  has_many :approvers_and_purchasers, through: :individual_steps, source: :user
+  has_many :step_users, through: :individual_steps, source: :user
   has_many :approvers, through: :approval_steps, source: :user
   has_many :purchasers, through: :purchase_steps, source: :user
   has_many :completers, through: :individual_steps, source: :completer

--- a/app/policies/gsa18f/procurement_policy.rb
+++ b/app/policies/gsa18f/procurement_policy.rb
@@ -15,7 +15,7 @@ module Gsa18f
     def can_cancel!
       not_cancelled! && check(
         (approver? || delegate? || requester? || admin?) && !purchaser?,
-        "Sorry, you are neither the requester, approver or delegate"
+        "Sorry, you are neither the requester, approver, or delegate"
       )
     end
     alias_method :can_cancel_form!, :can_cancel!
@@ -24,6 +24,10 @@ module Gsa18f
 
     def purchaser?
       @procurement.purchaser == @user
+    end
+
+    def approver?
+      @procurement.approvers.include?(@user)
     end
   end
 end

--- a/app/policies/ncr/work_order_policy.rb
+++ b/app/policies/ncr/work_order_policy.rb
@@ -9,7 +9,7 @@ module Ncr
 
     def can_edit!
       check(
-        requester? || approver? || observer?,
+        requester? || step_user? || observer?,
         "You must be the requester, approver, or observer to edit"
       )
     end

--- a/app/policies/proposal_policy.rb
+++ b/app/policies/proposal_policy.rb
@@ -67,7 +67,7 @@ class ProposalPolicy
   end
 
   def step_user?
-    @proposal.approvers_and_purchasers.include?(@user) || @proposal.completers.exists?(@user.id)
+    @proposal.step_users.include?(@user) || @proposal.completers.exists?(@user.id)
   end
 
   def delegate?

--- a/app/policies/proposal_policy.rb
+++ b/app/policies/proposal_policy.rb
@@ -6,7 +6,7 @@ class ProposalPolicy
     @proposal = record
   end
 
-  def can_approve!
+  def can_complete!
     step_user! && pending_step! && not_cancelled!
   end
 

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -32,7 +32,6 @@
       %thead
         %tr.header
           %th{colspan: "2"}
-            - # todo: shouldn't need the h5
             %h5 Observers
       %tbody
         - SubscriberList.new(@proposal).triples.each do |user, role_str, observation|

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -121,7 +121,7 @@
     - if @proposal.attachments.empty?
       %p.empty-list-label No attachments have been added yet
 
-- if policy(@proposal).can_approve?
+- if policy(@proposal).can_complete?
   .centered
     = form_tag(approve_proposal_path(@proposal, method: "POST")) do
       = hidden_field_tag :version, @proposal.version

--- a/app/views/shared/formatter/_review_status.html.haml
+++ b/app/views/shared/formatter/_review_status.html.haml
@@ -1,10 +1,10 @@
-- approvers = object.currently_awaiting_approvers
+- users = object.currently_awaiting_step_users
 
-- if object.pending? && approvers.include?(current_user)
+- if object.pending? && users.include?(current_user)
   %p
     %strong Please review
 - elsif object.pending?
   %p
-    %em Waiting for review from: #{approvers.map(&:full_name).join(', ')}
+    %em Waiting for review from: #{users.map(&:full_name).join(', ')}
 - else
   = object.status.titlecase

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -75,7 +75,7 @@ class Dispatcher
   private
 
   def active_step_users(proposal)
-    proposal.approvers_and_purchasers.select do |user|
+    proposal.step_users.select do |user|
       proposal.is_active_step_user?(user)
     end
   end

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -31,16 +31,16 @@ class Dispatcher
 
   def deliver_attachment_emails(proposal)
     proposal.subscribers_except_delegates.each do |user|
-      approval = proposal.steps.find_by(user_id: user.id)
+      step = proposal.steps.find_by(user_id: user.id)
 
-      if user_is_not_approver?(approval) || approver_knows_about_proposal?(approval)
+      if user_is_not_step_user?(step) || step_user_knows_about_proposal?(step)
         Mailer.new_attachment_email(user.email_address, proposal).deliver_later
       end
     end
   end
 
   def deliver_cancellation_emails(proposal, reason = nil)
-    cancellation_notification_recipients = active_approvers(proposal) + active_observers(proposal)
+    cancellation_notification_recipients = active_step_users(proposal) + active_observers(proposal)
 
     cancellation_notification_recipients.each do |recipient|
       CancellationMailer.cancellation_email(recipient.email_address, proposal, reason).deliver_later
@@ -74,9 +74,9 @@ class Dispatcher
 
   private
 
-  def active_approvers(proposal)
-    proposal.approvers.select do |approver|
-      proposal.is_active_approver?(approver)
+  def active_step_users(proposal)
+    proposal.approvers_and_purchasers.select do |user|
+      proposal.is_active_step_user?(user)
     end
   end
 
@@ -94,11 +94,11 @@ class Dispatcher
     Mailer.actions_for_approver(approval).deliver_later
   end
 
-  def user_is_not_approver?(approval)
-    approval.blank?
+  def user_is_not_step_user?(step)
+    step.blank?
   end
 
-  def approver_knows_about_proposal?(approval)
-    !approval.pending?
+  def step_user_knows_about_proposal?(step)
+    !step.pending?
   end
 end

--- a/lib/ncr/approval_manager.rb
+++ b/lib/ncr/approval_manager.rb
@@ -44,7 +44,7 @@ module Ncr
         user = User.for_email(email)
         user.update!(client_slug: "ncr")
         # Reuse existing approvals, if present
-        proposal.existing_approval_for(user) || Steps::Approval.new(user: user)
+        proposal.existing_step_for(user) || Steps::Approval.new(user: user)
       end
       proposal.root_step = Steps::Serial.new(child_approvals: individuals)
     end

--- a/lib/query/proposal/clauses.rb
+++ b/lib/query/proposal/clauses.rb
@@ -26,36 +26,36 @@ module Query
 
       def with_approver_or_delegate(user)
         Arel::Nodes::Exists.new(
-          approvals_for(user)
+          steps_for(user)
         )
       end
 
-      def approvals_for(user)
+      def steps_for(user)
         approvals_with_delegates.where(
           with_matching_proposal.and(
             non_pending.and(
-              where_approver(user).or(where_delegate(user))
+              where_step_user(user).or(where_delegate(user))
             )
           )
         ).ast
       end
 
       def approvals_with_delegates
-        approvals.project(Arel.star).
+        steps.project(Arel.star).
           join(delegates, Arel::Nodes::OuterJoin).
-          on(delegates[:assigner_id].eq(approvals[:user_id]))
+          on(delegates[:assigner_id].eq(steps[:user_id]))
       end
 
       def with_matching_proposal
-        approvals[:proposal_id].eq(proposals[:id])
+        steps[:proposal_id].eq(proposals[:id])
       end
 
       def non_pending
-        approvals[:status].not_eq('pending')
+        steps[:status].not_eq('pending')
       end
 
-      def where_approver(user)
-        approvals[:user_id].eq(user.id)
+      def where_step_user(user)
+        steps[:user_id].eq(user.id)
       end
 
       def where_delegate(user)
@@ -68,7 +68,7 @@ module Query
         )
       end
 
-      def approvals
+      def steps
         Step.arel_table
       end
 

--- a/lib/query/proposal/listing.rb
+++ b/lib/query/proposal/listing.rb
@@ -49,13 +49,13 @@ module Query
 
       def pending_filter
         proc do |proposals|
-          proposals.select { |proposal| !proposal.awaiting_approver?(user) }
+          proposals.select { |proposal| !proposal.awaiting_step_user?(user) }
         end
       end
 
       def pending_review_filter
         proc do |proposals|
-          proposals.select { |proposal| proposal.awaiting_approver?(user) }
+          proposals.select { |proposal| proposal.awaiting_step_user?(user) }
         end
       end
 

--- a/lib/role_picker.rb
+++ b/lib/role_picker.rb
@@ -7,11 +7,11 @@ class RolePicker
   end
 
   def active_observer?
-    observer? && !active_approver? && !requester?
+    observer? && !active_step_user? && !requester?
   end
 
-  def active_approver?
-    proposal.is_active_approver?(user)
+  def active_step_user?
+    proposal.is_active_step_user?(user)
   end
 
   def requester?
@@ -24,6 +24,10 @@ class RolePicker
 
   def approver?
     proposal.approvers.include?(user)
+  end
+
+  def purchaser?
+    proposal.purchasers.include?(user)
   end
 
   private

--- a/lib/subscriber_list.rb
+++ b/lib/subscriber_list.rb
@@ -5,31 +5,50 @@ class SubscriberList
     @proposal = proposal
   end
 
-  # Returns triplets of (user, role name, observation)
   def triples
-    requesters, approvers, observers = partitioned_roles
-    requesters = requesters.map { |role| [role.user, "Requester", nil] }
-    approvers = approvers.map { |role| [role.user, "Approver", nil] }
-    observers = observers.map { |role| [role.user, nil, observation_for(role.user)] }
-
-    requesters + approvers + observers
+    requester_roles + approver_roles + purchaser_roles + observer_roles
   end
 
-  def users
-    triples.map(&:first)
+  private
+
+  def requester_roles
+    requesters.map { |role| [role.user, "Requester", nil] }
   end
 
-  protected
+  def approver_roles
+    approvers.map { |role| [role.user, "Approver", nil] }
+  end
 
-  def partitioned_roles
-    users = proposal.subscribers.sort_by(&:full_name)
-    roles = users.map { |user| RolePicker.new(user, proposal) }
+  def purchaser_roles
+    purchasers.map { |role| [role.user, "Purchaser", nil] }
+  end
 
-    requesters, roles = roles.partition(&:requester?)
-    approvers, roles = roles.partition(&:approver?)
-    observers = roles.select(&:observer?)
+  def observer_roles
+    observers.map { |role| [role.user, nil, observation_for(role.user)] }
+  end
 
-    [requesters, approvers, observers]
+  def requesters
+    @_requesters ||= roles.select(&:requester?)
+  end
+
+  def approvers
+    @_approvers ||= roles.select(&:approver?)
+  end
+
+  def purchasers
+    @_purchasers ||= roles.select(&:purchaser?)
+  end
+
+  def observers
+    @_observers ||= roles.select(&:observer?)
+  end
+
+  def roles
+    @_roles ||= sorted_users.map { |user| RolePicker.new(user, proposal) }
+  end
+
+  def sorted_users
+    @_users ||= proposal.subscribers.sort_by(&:full_name)
   end
 
   def observation_for(user)

--- a/spec/features/archive_link.rb
+++ b/spec/features/archive_link.rb
@@ -11,7 +11,7 @@ describe "archive link" do
       wo = create(:ncr_work_order, project_title: "Work Order #{i}")
       wo.proposal.update(requester: user)
       wo.proposal.individual_steps.create!(user: approver, status: 'actionable')
-      approval = wo.proposal.existing_approval_for(approver)
+      approval = wo.proposal.existing_step_for(approver)
       approval.approve!
       wo.proposal
     end
@@ -24,7 +24,7 @@ describe "archive link" do
       wo = create(:ncr_work_order, project_title: "Work Order #{i}")
       wo.proposal.update(requester: user)
       wo.proposal.individual_steps.create!(user: approver, status: 'actionable')
-      approval = wo.proposal.existing_approval_for(approver)
+      approval = wo.proposal.existing_step_for(approver)
       approval.approve!
       wo.proposal
     end 

--- a/spec/features/incoming_mail_handler_spec.rb
+++ b/spec/features/incoming_mail_handler_spec.rb
@@ -48,7 +48,7 @@ describe "Handles incoming email" do
     mandrill_event[0]['msg']['headers']['Sender'] = my_approval.user.email_address
     handler = IncomingMail::Handler.new
     expect(my_approval.proposal.existing_observation_for(my_approval.user)).not_to be_present
-    expect(my_approval.proposal.existing_approval_for(my_approval.user)).to be_present
+    expect(my_approval.proposal.existing_step_for(my_approval.user)).to be_present
     resp = handler.handle(mandrill_event)
     expect(resp.action).to eq(IncomingMail::Response::COMMENT)
   end
@@ -60,12 +60,12 @@ describe "Handles incoming email" do
     mandrill_event[0]['msg']['from_email'] = my_approval.user.email_address
     handler = IncomingMail::Handler.new
     expect(my_approval.proposal.existing_observation_for(my_approval.user)).not_to be_present
-    expect(my_approval.proposal.existing_approval_for(my_approval.user)).to be_present
+    expect(my_approval.proposal.existing_step_for(my_approval.user)).to be_present
     resp = handler.handle(mandrill_event)
     expect(resp.action).to eq(IncomingMail::Response::COMMENT)
 
     expect(my_approval.proposal.existing_observation_for(my_approval.user)).to be_present
-    expect(my_approval.proposal.existing_approval_for(my_approval.user)).to be_present
+    expect(my_approval.proposal.existing_step_for(my_approval.user)).to be_present
     expect(deliveries.length).to eq(1) # 1 each to requester and approver
   end
 
@@ -78,7 +78,7 @@ describe "Handles incoming email" do
     handler = IncomingMail::Handler.new
 
     expect(my_approval.proposal.existing_observation_for(user)).not_to be_present
-    expect(my_approval.proposal.existing_approval_for(user)).not_to be_present
+    expect(my_approval.proposal.existing_step_for(user)).not_to be_present
 
     resp = handler.handle(mandrill_event)
 

--- a/spec/features/observer_spec.rb
+++ b/spec/features/observer_spec.rb
@@ -1,102 +1,96 @@
-describe "observers" do
-  it "allows observers to be added" do
-    expect(ObserverMailer).to receive_message_chain(:on_observer_added, :deliver_later)
-
+feature "Observers" do
+  scenario "allows observers to be added" do
     work_order = create(:ncr_work_order)
-    observer = create(:user, client_slug: 'ncr')
+    observer = create(:user, client_slug: "ncr")
     proposal = work_order.proposal
     login_as(proposal.requester)
 
-    visit "/proposals/#{proposal.id}"
-    select observer.email_address, from: 'observation_user_email_address'
-    click_on 'Add an Observer'
+    visit proposal_path(proposal)
+    select observer.email_address, from: "observation_user_email_address"
+    click_on "Add an Observer"
 
     expect(page).to have_content("#{observer.full_name} has been added as an observer")
-
-    proposal.reload
-
-    expect(proposal.observers).to include(observer)
   end
 
-  it "allows observers to be added by other observers" do
+  scenario "allows observers to be added by other observers" do
     proposal = create(:proposal, :with_observer)
     observer1 = proposal.observers.first
     observer2 = create(:user, client_slug: nil)
     login_as(observer1)
 
-    visit "/proposals/#{proposal.id}"
-    select observer2.email_address, from: 'observation_user_email_address'
-    click_on 'Add an Observer'
+    visit proposal_path(proposal)
+    select observer2.email_address, from: "observation_user_email_address"
+    click_on "Add an Observer"
 
     expect(page).to have_content("#{observer2.full_name} has been added as an observer")
-
-    proposal.reload
-    expect(proposal.observers.map(&:email_address)).to include(observer2.email_address)
-
-    expect(email_recipients).to eq([observer2.email_address])
   end
 
-  it "allows a user to add a reason when adding an observer" do
+  scenario "allows a user to add a reason when adding an observer" do
     reason = "is the archbishop of banterbury"
     proposal = create(:proposal)
     observer = create(:user, client_slug: nil)
     login_as(proposal.requester)
 
-    visit "/proposals/#{proposal.id}"
-    select observer.email_address, from: 'observation_user_email_address'
+    visit proposal_path(proposal)
+    select observer.email_address, from: "observation_user_email_address"
     fill_in "observation_reason", with: reason
-    click_on 'Add an Observer'
+    click_on "Add an Observer"
 
     expect(page).to have_content("#{observer.full_name} has been added as an observer")
-    proposal.reload
-
-    expect(deliveries.first.body.encoded).to include reason # subscription notification
   end
 
-  it "hides the reason field until a new observer is selected", js: true do
+  scenario "hides the reason field until a new observer is selected", :js do
     proposal = create(:proposal)
     observer = create(:user, client_slug: nil)
     login_as(proposal.requester)
 
-    visit "/proposals/#{proposal.id}"
+    visit proposal_path(proposal)
+
     expect(page).to have_no_field "observation_reason"
-    fill_in_selectized('observation_user_email_address', observer.email_address)
+
+    fill_in_selectized("selectize-control", observer.email_address)
+
     expect(page).to have_field "observation_reason"
     expect(find_field("observation_reason")).to be_visible
   end
 
-  it "disables the submit button until a new observer is selected", js: true do
+  scenario "disables the submit button until a new observer is selected", :js do
     proposal = create(:proposal)
     observer = create(:user, client_slug: nil)
     login_as(proposal.requester)
 
-    visit "/proposals/#{proposal.id}"
+    visit proposal_path(proposal)
     submit_button = find("#add_subscriber")
+
     expect(submit_button).to be_disabled
-    fill_in_selectized('observation_user_email_address', observer.email_address)
+
+    fill_in_selectized("selectize-control", observer.email_address)
+
     expect(submit_button).to_not be_disabled
   end
 
-  it "observer can delete themselves as observer" do
-    proposal = create(:proposal)
+  scenario "observer can delete themselves as observer" do
     observer = create(:user)
-
-    login_as(proposal.requester)
-    visit "/proposals/#{proposal.id}"
-    select observer.email_address, from: 'observation_user_email_address'
-    click_on 'Add an Observer'
-
+    proposal = create(:proposal, observer: observer)
     login_as(observer)
-    visit "/proposals/#{proposal.id}"
+
+    visit proposal_path(proposal)
     delete_button = find('table.observers .button_to input[value="Remove"]')
     delete_button.click
+
     expect(page).to have_content("Removed Observation for ")
   end
 
-  # adapted from http://stackoverflow.com/a/25047358
-  def fill_in_selectized(key, *values)
-    values.flatten.each do |value|
-      page.execute_script("$('##{key}').selectize()[0].selectize.setValue('#{value}')")
+  scenario "shows observer roles next to their names" do
+    proposal = create(:proposal)
+    _procurement = create(:gsa18f_procurement, :with_steps, proposal: proposal)
+    purchaser = User.with_role("gsa18f_purchaser").first
+    login_as(proposal.requester)
+
+    visit proposal_path(proposal)
+
+    within(".observers") do
+      expect(page).to have_content("#{purchaser.email_address} (Purchaser)")
     end
   end
 end

--- a/spec/lib/dispatcher_spec.rb
+++ b/spec/lib/dispatcher_spec.rb
@@ -56,14 +56,17 @@ describe Dispatcher do
   end
 
   describe "#deliver_cancellation_emails" do
-    let (:mock_deliverer) { double('deliverer') }
+    let (:mock_deliverer) { double("deliverer") }
 
-    it "sends an email to each approver" do
+    it "sends an email to the active step users" do
+      proposal = create(:proposal, :with_approval_and_purchase)
+      proposal.approval_steps.first.approve!
       allow(CancellationMailer).to receive(:cancellation_email).and_return(mock_deliverer)
-      expect(proposal.approvers.count).to eq 2
-      expect(mock_deliverer).to receive(:deliver_later).twice
+      allow(mock_deliverer).to receive(:deliver_later).exactly(2).times
 
       dispatcher.deliver_cancellation_emails(proposal)
+
+      expect(mock_deliverer).to have_received(:deliver_later).exactly(2).times
     end
 
     it "sends the reason to the cancellation email" do

--- a/spec/lib/role_picker_spec.rb
+++ b/spec/lib/role_picker_spec.rb
@@ -23,6 +23,18 @@ describe RolePicker do
       end
     end
 
+    describe "#purchaser?" do
+      it "is true when user is connected to proposal through purchase step" do
+        proposal = create(:proposal)
+        purchaser  = create(:user)
+        create(:purchase_step, user: purchaser, proposal: proposal)
+
+        roles = RolePicker.new(purchaser, proposal)
+
+        expect(roles).to be_purchaser
+      end
+    end
+
     describe "#observer?" do
       it "is true if user is proposal observer" do
         observer = create(:user)
@@ -35,7 +47,7 @@ describe RolePicker do
       end
     end
 
-    describe "#active_approver?" do
+    describe "#active_step_user?" do
       it "is true when user is active approver" do
         proposal = create(:proposal)
         approver = create(:user)
@@ -43,7 +55,17 @@ describe RolePicker do
 
         roles = RolePicker.new(approver, proposal)
 
-        expect(roles).to be_active_approver
+        expect(roles).to be_active_step_user
+      end
+
+      it "is true when the user is active purchaser" do
+        proposal = create(:proposal)
+        purchaser = create(:user)
+        create(:purchase_step, user: purchaser, proposal: proposal, status: "actionable")
+
+        roles = RolePicker.new(purchaser, proposal)
+
+        expect(roles).to be_active_step_user
       end
     end
 

--- a/spec/lib/subscriber_list_spec.rb
+++ b/spec/lib/subscriber_list_spec.rb
@@ -1,30 +1,27 @@
 describe SubscriberList do
   describe "#triples" do
-    it "include request, observers, approvers" do
-      proposal = create(:proposal, :with_observers, :with_parallel_approvers)
-      subscriber_list = SubscriberList.new(proposal)
-      triples = subscriber_list.triples
+    it "include request, observers, approvers, and purchasers" do
+      proposal = create(:proposal, :with_observers, :with_approval_and_purchase)
+
+      triples = SubscriberList.new(proposal).triples
       user_ids = triples.map {|result| result[0].id}
       roles = triples.map(&:second)
       observation_ids = triples.map {|result| result[2].try(:id)}
 
-      expect(triples.length).to be 5  # requester + 2 approver + 2 observers
-      # convert to ids
-      expected_users = [proposal.requester] + proposal.approvers + proposal.observers
+      expected_users = [proposal.requester] + proposal.approvers + proposal.purchasers + proposal.observers
       expect(user_ids).to eq(expected_users.map(&:id))
-      expect(roles).to eq ["Requester", "Approver", "Approver", nil, nil]
+      expect(roles).to eq ["Requester", "Approver", "Purchaser", nil, nil]
       expect(observation_ids).to eq([nil, nil, nil] + proposal.observations.map(&:id).sort)
     end
 
     it "sorts by name within each group" do
       proposal = create(:proposal, :with_observers, :with_parallel_approvers)
-      subscriber_list = SubscriberList.new(proposal)
       first_observer = proposal.observers.first
       second_observer = proposal.observers.second
       first_observer.update(first_name: "Bob", last_name: "Bobson")
       second_observer.update(first_name: "Ann", last_name: "Annson")
 
-      triples = subscriber_list.triples
+      triples = SubscriberList.new(proposal).triples
 
       expect(triples[3][0].id).to be second_observer.id
       expect(triples[4][0].id).to be first_observer.id
@@ -32,25 +29,13 @@ describe SubscriberList do
 
     it "removes duplicates" do
       proposal = create(:proposal, :with_observers, :with_parallel_approvers)
-      subscriber_list = SubscriberList.new(proposal)
-      triples = subscriber_list.triples
       user = proposal.approvers.first
+
+      triples = SubscriberList.new(proposal).triples
 
       expect {
         proposal.add_observer(user.email_address)
       }.to_not change { triples }
-    end
-  end
-
-  describe "#users" do
-    it "doesn't include delegates" do
-      proposal = create(:proposal, :with_observers, :with_parallel_approvers)
-      subscriber_list = SubscriberList.new(proposal)
-      approver = proposal.approvers.first
-      delegate = create(:user)
-      approver.add_delegate(delegate)
-
-      expect(subscriber_list.users).to_not include(delegate)
     end
   end
 end

--- a/spec/models/gsa18f/procurement_spec.rb
+++ b/spec/models/gsa18f/procurement_spec.rb
@@ -25,7 +25,8 @@ describe Gsa18f::Procurement do
     DatabaseCleaner.clean_with(:truncation)
     Rails.application.load_seed
     procurement = create(:gsa18f_procurement, :with_steps)
-    expect(procurement.approvers.map(&:email_address)).to eq(["some.approver@example.com", "some.purchaser@example.com"])
+    expect(procurement.approvers.map(&:email_address)).to eq(["some.approver@example.com"])
+    expect(procurement.purchasers.map(&:email_address)).to eq(["some.purchaser@example.com"])
     expect(procurement.observers.map(&:email_address)).to be_empty
     expect(procurement.purchaser.email_address).to eq("some.purchaser@example.com")
   end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -10,6 +10,7 @@ describe Proposal do
     it { should have_many(:purchase_steps) }
     it { should have_many(:purchasers) }
     it { should have_many(:approvers) }
+    it { should have_many(:step_users) }
   end
 
   describe "Validations" do
@@ -80,16 +81,6 @@ describe Proposal do
       proposal = create(:proposal, steps: [create(:parallel_step)])
 
       expect(proposal).not_to be_serial
-    end
-  end
-
-  describe "#approvers_and_purchasers" do
-    it "returns approvers and purchasers" do
-      proposal = create(:proposal, :with_approval_and_purchase)
-
-      approvers_and_purchasers = proposal.approvers_and_purchasers
-
-      expect(approvers_and_purchasers).to eq [proposal.approvers.first, proposal.purchasers.first]
     end
   end
 

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -6,6 +6,10 @@ describe Proposal do
     it { should have_many(:individual_steps) }
     it { should have_many(:attachments).dependent(:destroy) }
     it { should have_many(:comments).dependent(:destroy) }
+    it { should have_many(:approval_steps) }
+    it { should have_many(:purchase_steps) }
+    it { should have_many(:purchasers) }
+    it { should have_many(:approvers) }
   end
 
   describe "Validations" do
@@ -79,23 +83,33 @@ describe Proposal do
     end
   end
 
+  describe "#approvers_and_purchasers" do
+    it "returns approvers and purchasers" do
+      proposal = create(:proposal, :with_approval_and_purchase)
+
+      approvers_and_purchasers = proposal.approvers_and_purchasers
+
+      expect(approvers_and_purchasers).to eq [proposal.approvers.first, proposal.purchasers.first]
+    end
+  end
+
   describe '#currently_awaiting_approvers' do
     it "gives a consistently ordered list when in parallel" do
       proposal = create(:proposal, :with_parallel_approvers)
       approver1, approver2 = proposal.approvers
-      expect(proposal.currently_awaiting_approvers).to eq([approver1, approver2])
+      expect(proposal.currently_awaiting_step_users).to eq([approver1, approver2])
 
       proposal.individual_steps.first.update_attribute(:position, 5)
-      expect(proposal.currently_awaiting_approvers).to eq([approver2, approver1])
+      expect(proposal.currently_awaiting_step_users).to eq([approver2, approver1])
     end
 
     it "gives only the first approver when linear" do
       proposal = create(:proposal, :with_serial_approvers)
       approver1, approver2 = proposal.approvers
-      expect(proposal.currently_awaiting_approvers).to eq([approver1])
+      expect(proposal.currently_awaiting_step_users).to eq([approver1])
 
       proposal.individual_steps.first.approve!
-      expect(proposal.currently_awaiting_approvers).to eq([approver2])
+      expect(proposal.currently_awaiting_step_users).to eq([approver2])
     end
   end
 
@@ -116,14 +130,16 @@ describe Proposal do
   end
 
   describe '#subscribers' do
-    it "returns all approvers, observers, and the requester" do
+    it "returns all approvers, purchasers, observers, and the requester" do
       requester = create(:user)
-      proposal = create(:proposal, :with_parallel_approvers, :with_observers, requester: requester)
+      proposal = create(:proposal, :with_approval_and_purchase, :with_observers, requester: requester)
 
       expect(proposal.subscribers.map(&:id).sort).to eq([
         requester.id,
-        proposal.approvers.first.id, proposal.approvers.second.id,
-        proposal.observers.first.id, proposal.observers.second.id
+        proposal.approvers.first.id,
+        proposal.purchasers.first.id,
+        proposal.observers.first.id,
+        proposal.observers.second.id
       ].sort)
     end
 

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -118,42 +118,42 @@ describe Step do
     it "won't approve Amy and Bob -- needs two branches of the OR" do
       build_approvals
       expect_any_instance_of(Proposal).not_to receive(:approve!)
-      proposal.existing_approval_for(amy).approve!
-      proposal.existing_approval_for(bob).approve!
+      proposal.existing_step_for(amy).approve!
+      proposal.existing_step_for(bob).approve!
     end
 
     it "will approve if Amy, Bob, and Carrie approve -- two branches of the OR" do
       build_approvals
       expect_any_instance_of(Proposal).to receive(:approve!)
-      proposal.existing_approval_for(amy).approve!
-      proposal.existing_approval_for(bob).approve!
-      proposal.existing_approval_for(carrie).approve!
+      proposal.existing_step_for(amy).approve!
+      proposal.existing_step_for(bob).approve!
+      proposal.existing_step_for(carrie).approve!
     end
 
     it "won't approve Amy, Bob, Dan as Erin is also required (to complete the THEN)" do
       build_approvals
       expect_any_instance_of(Proposal).not_to receive(:approve!)
-      proposal.existing_approval_for(amy).approve!
-      proposal.existing_approval_for(bob).approve!
-      proposal.existing_approval_for(dan).approve!
+      proposal.existing_step_for(amy).approve!
+      proposal.existing_step_for(bob).approve!
+      proposal.existing_step_for(dan).approve!
     end
 
     it "will approve Amy, Bob, Dan, Erin -- two branches of the OR" do
       build_approvals
       expect_any_instance_of(Proposal).to receive(:approve!)
-      proposal.existing_approval_for(amy).approve!
-      proposal.existing_approval_for(bob).approve!
-      proposal.existing_approval_for(dan).approve!
-      proposal.existing_approval_for(erin).approve!
+      proposal.existing_step_for(amy).approve!
+      proposal.existing_step_for(bob).approve!
+      proposal.existing_step_for(dan).approve!
+      proposal.existing_step_for(erin).approve!
     end
 
     it "will approve Amy, Bob, Dan, Carrie -- two branches of the OR as Dan is irrelevant" do
       build_approvals
       expect_any_instance_of(Proposal).to receive(:approve!)
-      proposal.existing_approval_for(amy).approve!
-      proposal.existing_approval_for(bob).approve!
-      proposal.existing_approval_for(dan).approve!
-      proposal.existing_approval_for(carrie).approve!
+      proposal.existing_step_for(amy).approve!
+      proposal.existing_step_for(bob).approve!
+      proposal.existing_step_for(dan).approve!
+      proposal.existing_step_for(carrie).approve!
     end
 
     def build_approvals

--- a/spec/policies/proposal_policy_spec.rb
+++ b/spec/policies/proposal_policy_spec.rb
@@ -33,20 +33,34 @@ describe ProposalPolicy do
     end
 
     context "linear proposal" do
-      let(:proposal) {create(:proposal, :with_serial_approvers)}
-      let(:first_approval) { proposal.individual_steps.first }
-      let(:second_approval) { proposal.individual_steps.last }
-
       it "allows when there's a pending approval" do
+        proposal = create(:proposal)
+        first_approval = create(:approval_step, proposal: proposal, status: "actionable")
+
         expect(ProposalPolicy).to permit(first_approval.user, proposal)
       end
 
+      it "allows when there's a pending purchase" do
+        proposal = create(:proposal)
+        _first_approval = create(:approval_step, proposal: proposal, status: "approved")
+        purchase_step = create(:purchase_step, proposal: proposal, status: "actionable")
+
+        expect(ProposalPolicy).to permit(purchase_step.user, proposal)
+      end
+
       it "does not allow when it's not the user's turn" do
+        proposal = create(:proposal)
+        _first_approval = create(:approval_step, proposal: proposal)
+        second_approval = create(:approval_step, proposal: proposal)
+
         expect(ProposalPolicy).not_to permit(second_approval.user, proposal)
       end
 
       it "does not allow when the user's already approved" do
-        first_approval.approve!
+        proposal = create(:proposal)
+        first_approval = create(:approval_step, proposal: proposal, status: "approved")
+        second_approval = create(:approval_step, proposal: proposal, status: "actionable")
+
         expect(ProposalPolicy).not_to permit(first_approval.user, proposal)
         expect(ProposalPolicy).to permit(second_approval.user, proposal)
       end

--- a/spec/policies/proposal_policy_spec.rb
+++ b/spec/policies/proposal_policy_spec.rb
@@ -1,5 +1,5 @@
 describe ProposalPolicy do
-  permissions :can_approve? do
+  permissions :can_complete? do
     it "allows pending delegates" do
       proposal = create(:proposal, :with_parallel_approvers)
 

--- a/spec/support/shared_examples/client_data.rb
+++ b/spec/support/shared_examples/client_data.rb
@@ -8,6 +8,9 @@ shared_examples "client data" do
     it { should have_many(:observers) }
     it { should have_many(:comments) }
     it { should have_one(:requester) }
+    it { should have_many(:approvers) }
+    it { should have_many(:purchasers) }
+    it { should have_many(:completers) }
   end
 
   describe "Validations" do
@@ -17,7 +20,7 @@ shared_examples "client data" do
   describe "Delegations" do
     it { should delegate_method(:add_observer).to(:proposal) }
     it { should delegate_method(:add_requester).to(:proposal) }
-    it { should delegate_method(:currently_awaiting_approvers).to(:proposal) }
+    it { should delegate_method(:currently_awaiting_step_users).to(:proposal) }
     it { should delegate_method(:set_requester).to(:proposal) }
     it { should delegate_method(:status).to(:proposal) }
   end


### PR DESCRIPTION
* Refer to users as `step_users` rather than `approvers` since some are
  users connected to a proposal via a purchase step

![screen shot 2015-12-22 at 2 51 46 pm](https://cloud.githubusercontent.com/assets/601515/11967845/2e704594-a8bb-11e5-88d1-a2dd82522cc5.png)


https://trello.com/c/HDp7pbS7