### PR TITLE
Fix path-checking spec by using a waiting matcher

### DIFF
--- a/spec/features/ncr/work_orders/requester_edit_spec.rb
+++ b/spec/features/ncr/work_orders/requester_edit_spec.rb
@@ -146,7 +146,7 @@ feature "Requester edits their NCR work order", :js do
 
     click_link "Discard Changes"
 
-    expect(current_path).to eq(proposal_path(ncr_proposal))
+    expect(page).to have_current_path(proposal_path(ncr_proposal))
   end
 
   scenario "can change approving official email if first approval not done" do


### PR DESCRIPTION
This "Discard Changes" spec keeps breaking when run locally because testing `current_path` doesn't use Capybara's waiting mechanisms to ensure that `click_link` is done. But good news! [There's now a waiting matcher for current_path](https://github.com/jnicklas/capybara/pull/1567), so this fix uses that.