### PR TITLE
Move `current_approver` logic out of Ncr::WorkOrder

### DIFF
--- a/app/decorators/ncr/work_order_decorator.rb
+++ b/app/decorators/ncr/work_order_decorator.rb
@@ -20,7 +20,7 @@ module Ncr
     end
 
     def pending_approver_email_address
-      approver_email_address(proposal.currently_awaiting_approvers.first)
+      approver_email_address(proposal.currently_awaiting_step_users.first)
     end
 
     def approver_email_address(approver)

--- a/app/decorators/ncr/work_order_decorator.rb
+++ b/app/decorators/ncr/work_order_decorator.rb
@@ -2,26 +2,26 @@ module Ncr
   class WorkOrderDecorator < Draper::Decorator
     delegate_all
 
-    EMERGENCY_APPROVER_EMAIL = 'Emergency - Verbal Approval'
-    NO_APPROVER_FOUND = 'No Approver Found'
+    EMERGENCY_APPROVER_EMAIL = "Emergency - Verbal Approval"
+    NO_APPROVER_FOUND = "No Approver Found"
 
     def current_approver_email_address
-      approver_email_address(current_approver)
+      if proposal.approved?
+        final_approver_email_address
+      else
+        pending_approver_email_address
+      end
     end
+
+    private
 
     def final_approver_email_address
       approver_email_address(final_approver)
     end
 
-    def status_aware_approver_email_address
-      if proposal.approved?
-        final_approver_email_address
-      else
-        current_approver_email_address
-      end
+    def pending_approver_email_address
+      approver_email_address(proposal.currently_awaiting_approvers.first)
     end
-
-    private
 
     def approver_email_address(approver)
       if approver

--- a/app/views/report_mailer/daily_budget_report.text.erb
+++ b/app/views/report_mailer/daily_budget_report.text.erb
@@ -12,21 +12,21 @@ BA80 approved: <%= Ncr::Reporter.ba80_proposals.count %>
 Approved BA60 requests last week
 -----
 <% Ncr::Reporter.ba60_proposals.each do |p| %>
-  <%= "#{p.public_id} | Requester: #{p.requester.email_address} | Budget Approver: #{p.client_data.decorate.final_approver_email_address} | CL: #{p.client_data.cl_number} | Function code: #{p.client_data.function_code} | Soc code: #{p.client_data.soc_code}" %>
+  <%= "#{p.public_id} | Requester: #{p.requester.email_address} | Budget Approver: #{p.client_data.decorate.current_approver_email_address} | CL: #{p.client_data.cl_number} | Function code: #{p.client_data.function_code} | Soc code: #{p.client_data.soc_code}" %>
 <% end %>
 
 -----
 Approved BA61 requests last week
 -----
 <% Ncr::Reporter.ba61_proposals.each do |p| %>
-  <%= "#{p.public_id} | Requester: #{p.requester.email_address} | Budget Approver: #{p.client_data.decorate.final_approver_email_address} | CL: #{p.client_data.cl_number} | Function code: #{p.client_data.function_code} | Soc code: #{p.client_data.soc_code}" %>
+  <%= "#{p.public_id} | Requester: #{p.requester.email_address} | Budget Approver: #{p.client_data.decorate.current_approver_email_address} | CL: #{p.client_data.cl_number} | Function code: #{p.client_data.function_code} | Soc code: #{p.client_data.soc_code}" %>
 <% end %>
 
 -----
 Approved BA80 requests last week
 -----
 <% Ncr::Reporter.ba80_proposals.each do |p| %>
-  <%= "#{p.public_id} | Requester: #{p.requester.email_address} | Approver: #{p.client_data.decorate.final_approver_email_address} | CL: #{p.client_data.cl_number} | Function code: #{p.client_data.function_code} | Soc code: #{p.client_data.soc_code}" %>
+  <%= "#{p.public_id} | Requester: #{p.requester.email_address} | Approver: #{p.client_data.decorate.current_approver_email_address} | CL: #{p.client_data.cl_number} | Function code: #{p.client_data.function_code} | Soc code: #{p.client_data.soc_code}" %>
 <% end %>
 
 

--- a/lib/ncr/reporter.rb
+++ b/lib/ncr/reporter.rb
@@ -29,7 +29,7 @@ module Ncr
       [
         proposal_public_url(proposal),
         proposal.requester.email_address,
-        proposal.client_data.decorate.status_aware_approver_email_address,
+        proposal.client_data.decorate.current_approver_email_address,
         proposal.client_data.cl_number,
         proposal.client_data.function_code,
         proposal.client_data.soc_code,

--- a/spec/decorators/ncr_work_order_decorator_spec.rb
+++ b/spec/decorators/ncr_work_order_decorator_spec.rb
@@ -1,34 +1,30 @@
 describe Ncr::WorkOrderDecorator do
-  it "returns NOT FOUND string when WorkOrder has no approvers" do
-    wo = create(:ncr_work_order).decorate
-    expect(wo.current_approver_email_address).to eq(Ncr::WorkOrderDecorator::NO_APPROVER_FOUND)
-  end
+  describe "#current_approver_email_address" do
+    it "returns NOT FOUND string when WorkOrder has no approvers" do
+      wo = create(:ncr_work_order).decorate
+      expect(wo.current_approver_email_address).to eq(Ncr::WorkOrderDecorator::NO_APPROVER_FOUND)
+    end
 
-  it "returns EMERGENCY string when WorkOrder is emergency" do
-    wo = create(:ncr_work_order, emergency: true).decorate
-    expect(wo.current_approver_email_address).to eq(Ncr::WorkOrderDecorator::EMERGENCY_APPROVER_EMAIL)
-  end
+    it "returns EMERGENCY string when WorkOrder is emergency" do
+      wo = create(:ncr_work_order, emergency: true).decorate
+      expect(wo.current_approver_email_address).to eq(Ncr::WorkOrderDecorator::EMERGENCY_APPROVER_EMAIL)
+    end
 
-  it "returns final approver email address" do
-    wo = create(:ncr_work_order, :with_approvers).decorate
-    expect(wo.final_approver_email_address).to eq(wo.approvers.last.email_address)
-  end
+    it "returns pending (current) approver email address" do
+      wo = create(:ncr_work_order, :with_approvers).decorate
+      expect(wo.current_approver_email_address).to eq(wo.approvers.first.email_address)
+    end
 
-  it "returns pending (current) approver email address" do
-    wo = create(:ncr_work_order, :with_approvers).decorate
-    expect(wo.current_approver_email_address).to eq(wo.approvers.first.email_address)
-  end
+    it "returns current approver email address when status is pending" do
+      wo = create(:ncr_work_order, :with_approvers).decorate
+      expect(wo.current_approver_email_address).to eq(wo.current_approver_email_address)
+    end
 
-  it "returns current approver email address when status is pending" do
-    wo = create(:ncr_work_order, :with_approvers).decorate
-    expect(wo.pending?).to be_truthy
-    expect(wo.status_aware_approver_email_address).to eq(wo.current_approver_email_address)
-  end
-
-  it "returns final approver when status is approved" do
-    wo = create(:ncr_work_order, :with_approvers).decorate
-    wo.proposal.approve!
-    expect(wo.approved?).to be_truthy
-    expect(wo.status_aware_approver_email_address).to eq(wo.final_approver_email_address)
+    it "returns final approver when status is approved" do
+      wo = create(:ncr_work_order, :with_approvers).decorate
+      wo.proposal.approve!
+      expect(wo.approved?).to be_truthy
+      expect(wo.current_approver_email_address).to eq(wo.approvers.last.email_address)
+    end
   end
 end

--- a/spec/lib/ncr/reporter_spec.rb
+++ b/spec/lib/ncr/reporter_spec.rb
@@ -55,7 +55,7 @@ describe Ncr::Reporter do
       expect(proposal).to be_approved
       expect(work_order.final_approver).to eq(work_order.approvers.last)
       csv = Ncr::Reporter.as_csv([proposal])
-      expect(csv).to include(",#{work_order.decorate.final_approver_email_address}")
+      expect(csv).to include(",#{work_order.decorate.current_approver_email_address}")
     end
 
     it "shows current approver for pending work orders" do

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -237,21 +237,6 @@ describe Ncr::WorkOrder do
     end
   end
 
-  describe "#current_approver" do
-    it "returns the first pending approver" do
-      wo = create(:ncr_work_order, :with_approvers)
-      expect(wo.current_approver).to eq(wo.approvers.first)
-      wo.individual_steps.first.approve!
-      expect(wo.current_approver).to eq(wo.approvers.second)
-    end
-
-    it "returns the first approver when fully approved" do
-      wo = create(:ncr_work_order, :with_approvers)
-      fully_approve(wo.proposal)
-      expect(wo.reload.current_approver).to eq(wo.approvers.first)
-    end
-  end
-
   describe "#final_approver" do
     it "returns the final approver" do
       wo = create(:ncr_work_order, :with_approvers)

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -84,7 +84,7 @@ describe Proposal do
     end
   end
 
-  describe '#currently_awaiting_approvers' do
+  describe '#currently_awaiting_step_users' do
     it "gives a consistently ordered list when in parallel" do
       proposal = create(:proposal, :with_parallel_approvers)
       approver1, approver2 = proposal.approvers


### PR DESCRIPTION
* We already have the concept of `currently_awaiting_approvers` in
  StepManager
* Part of https://trello.com/c/smBumRFX