### PR TITLE
Purchase delegate bugfix

### DIFF
--- a/app/models/approval_delegate.rb
+++ b/app/models/approval_delegate.rb
@@ -13,7 +13,7 @@ class ApprovalDelegate < ActiveRecord::Base
 
   def assigner_and_assignee_are_different_users
     if assigner == assignee
-      errors.add(:assingee, "cannot be same user as assigner")
+      errors.add(:assignee, "cannot be same user as assigner")
     end
   end
 end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -40,7 +40,7 @@ class Proposal < ActiveRecord::Base
   has_many :completers, through: :individual_steps, source: :completer
   has_many :api_tokens, through: :individual_steps
   has_many :attachments, dependent: :destroy
-  has_many :approval_delegates, through: :approvers, source: :outgoing_delegations
+  has_many :approval_delegates, through: :step_users, source: :outgoing_delegations
   has_many :comments, dependent: :destroy
   has_many :delegates, through: :approval_delegates, source: :assignee
 

--- a/spec/policies/proposal_policy_spec.rb
+++ b/spec/policies/proposal_policy_spec.rb
@@ -69,6 +69,18 @@ describe ProposalPolicy do
         user = create(:user)
         expect(ProposalPolicy).not_to permit(user, proposal)
       end
+
+      it "allows pending delegates" do
+        proposal = create(:proposal)
+        approval = create(:approval_step, proposal: proposal, status: "approved")
+        purchase = create(:purchase_step, proposal: proposal, status: "actionable")
+
+        delegate = create(:user)
+        purchaser = purchase.user
+        purchaser.add_delegate(delegate)
+
+        expect(ProposalPolicy).to permit(delegate, proposal)
+      end
     end
   end
 


### PR DESCRIPTION
Fixes the bug wherein purchase delegates weren't getting the "mark as purchased" button, per https://trello.com/c/ymdHIPMF .

(and no I can't spell 'assignee' either).
