### PR TITLE
Lazily evaluate logs for expired record cleaner

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -5,5 +5,5 @@ require File.expand_path("../application", __FILE__)
 C2::Application.initialize!
 
 C2::Application.configure do
-  config.logger = Logger.new(STDERR)
+  config.logger = Logger.new(STDOUT)
 end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,7 @@ require File.expand_path("../application", __FILE__)
 
 # Initialize the Rails application.
 C2::Application.initialize!
+
+C2::Application.configure do
+  config.logger = Logger.new(STDERR)
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,6 +8,7 @@ C2::Application.configure do
   config.cache_classes = true
   config.consider_all_requests_local = true
   config.eager_load = false
+  config.log_level = :warn
   config.middleware.use RackSessionAccess::Middleware
   config.serve_static_files = true
   config.static_cache_control = "public, max-age=3600"

--- a/lib/expired_record_cleaner.rb
+++ b/lib/expired_record_cleaner.rb
@@ -36,23 +36,23 @@ class ExpiredRecordCleaner
   end
 
   def handle_no_requester(proposal)
-    Rails.logger.info { puts "#{proposal.id} <= no Requester defined" }
+    Rails.logger.info { "#{proposal.id} <= no Requester defined" }
 
     if @ok_to_act
       proposal.destroy
     else
-      Rails.logger.info { puts "set OK_TO_ACT=true to clean up #{proposal.id}" }
+      Rails.logger.info { "set OK_TO_ACT=true to clean up #{proposal.id}" }
     end
   end
 
   def handle_cancellation(proposal)
-    Rails.logger.info { puts "#{proposal.public_id} -> #{proposal.requester.email_address}" }
+    Rails.logger.info { "#{proposal.public_id} -> #{proposal.requester.email_address}" }
 
     if @ok_to_act
       notify_proposal_requester(proposal)
       proposal.cancel!
     else
-      Rails.logger.info { puts "set OK_TO_ACT=true to clean up #{proposal.id}" }
+      Rails.logger.info { "set OK_TO_ACT=true to clean up #{proposal.id}" }
     end
   end
 end

--- a/lib/expired_record_cleaner.rb
+++ b/lib/expired_record_cleaner.rb
@@ -1,10 +1,9 @@
 class ExpiredRecordCleaner
-  attr_reader :verbose, :fiscal_year_start
+  attr_reader :fiscal_year_start
 
   def initialize(datetime, args = {})
     @fiscal_year_start = calc_fiscal_year_start(datetime)
     @ok_to_act = args[:ok_to_act]
-    @verbose = args[:verbose]
   end
 
   def vacuum_old_proposals
@@ -37,25 +36,23 @@ class ExpiredRecordCleaner
   end
 
   def handle_no_requester(proposal)
-    if @verbose
-      STDERR.puts "#{proposal.id} <= no Requester defined"
-    end
+    Rails.logger.info { puts "#{proposal.id} <= no Requester defined" }
+
     if @ok_to_act
       proposal.destroy
     else
-      STDERR.puts "set OK_TO_ACT=true to clean up #{proposal.id}"
+      Rails.logger.info { puts "set OK_TO_ACT=true to clean up #{proposal.id}" }
     end
   end
 
   def handle_cancellation(proposal)
-    if @verbose
-      STDERR.puts "#{proposal.public_id} -> #{proposal.requester.email_address}"
-    end
+    Rails.logger.info { puts "#{proposal.public_id} -> #{proposal.requester.email_address}" }
+
     if @ok_to_act
       notify_proposal_requester(proposal)
       proposal.cancel!
     else
-      STDERR.puts "set OK_TO_ACT=true to clean up #{proposal.id}"
+      Rails.logger.info { puts "set OK_TO_ACT=true to clean up #{proposal.id}" }
     end
   end
 end

--- a/lib/tasks/vacuum.rake
+++ b/lib/tasks/vacuum.rake
@@ -7,7 +7,7 @@ namespace :vacuum do
     end
 
     cleaner = ExpiredRecordCleaner.new(Time.zone.now, ok_to_act: ok_to_act)
-    Rails.logger.info { puts "Pending proposals created before #{cleaner.fiscal_year_start}" }
+    Rails.logger.info { "Pending proposals created before #{cleaner.fiscal_year_start}" }
     cleaner.vacuum_old_proposals
   end
 

--- a/lib/tasks/vacuum.rake
+++ b/lib/tasks/vacuum.rake
@@ -5,14 +5,9 @@ namespace :vacuum do
     if ENV["OK_TO_ACT"] && ENV["OK_TO_ACT"].match(/^[yt]/i)
       ok_to_act = true
     end
-    verbose = false
-    if ENV["VERBOSE"] && ENV["VERBOSE"].match(/^[yt]/i)
-      verbose = true
-    end
-    cleaner = ExpiredRecordCleaner.new(Time.zone.now, ok_to_act: ok_to_act, verbose: verbose)
-    if verbose
-      STDERR.puts "Pending proposals created before #{cleaner.fiscal_year_start}"
-    end
+
+    cleaner = ExpiredRecordCleaner.new(Time.zone.now, ok_to_act: ok_to_act)
+    Rails.logger.info { puts "Pending proposals created before #{cleaner.fiscal_year_start}" }
     cleaner.vacuum_old_proposals
   end
 
@@ -22,13 +17,10 @@ namespace :vacuum do
     if ENV["OK_TO_ACT"] && ENV["OK_TO_ACT"].match(/^[yt]/i)
       ok_to_act = true
     end
-    verbose = false
-    if ENV["VERBOSE"] && ENV["VERBOSE"].match(/^[yt]/i)
-      verbose = true
-    end
+
     proposal_id = ENV["PROPOSAL_ID"] or raise "PROPOSAL_ID required"
     proposal = Proposal.find(proposal_id)
-    cleaner = ExpiredRecordCleaner.new(Time.zone.now, ok_to_act: ok_to_act, verbose: verbose)
+    cleaner = ExpiredRecordCleaner.new(Time.zone.now, ok_to_act: ok_to_act)
     cleaner.vacuum_proposal(proposal)
   end
 end

--- a/spec/lib/expired_record_cleaner_spec.rb
+++ b/spec/lib/expired_record_cleaner_spec.rb
@@ -28,7 +28,7 @@ describe ExpiredRecordCleaner do
         expect(deliveries.length).to eq(1)
         proposal.reload
         expect(proposal.status).to eq("cancelled")
-      end 
+      end
     end
   end
 

--- a/spec/lib/query/proposal/search_spec.rb
+++ b/spec/lib/query/proposal/search_spec.rb
@@ -115,6 +115,6 @@ end
 def dump_index
   if ENV["ES_DEBUG"]
     puts ANSI.blue{ "----------------- DUMP INDEX ---------------------" }
+    puts Proposal.search( "*" ).results.to_a.pretty_inspect
   end
-  puts Proposal.search( "*" ).results.to_a.pretty_inspect
 end

--- a/spec/support/es_spec_helper.rb
+++ b/spec/support/es_spec_helper.rb
@@ -28,7 +28,6 @@ module EsSpecHelper
   def create_es_index(klass)
     errors = []
     completed = 0
-    #puts "Creating Index for class #{klass}"
     klass.__elasticsearch__.create_index! force: true, index: klass.index_name
     klass.__elasticsearch__.refresh_index!
     klass.__elasticsearch__.import(return: "errors", batch_size: 200) do |resp|
@@ -38,15 +37,16 @@ module EsSpecHelper
       #puts "Finished #{completed} items"
       STDERR.flush
       STDOUT.flush
-      if ENV["ES_DEBUG"].to_i > 0 && errors.size > 0
-        STDOUT.puts "ERRORS in #{$$}:"
-        STDOUT.puts errors.pretty_inspect
+      if ENV["ES_DEBUG"].to_i > 0
+        if errors.size > 0
+          STDOUT.puts "ERRORS in #{$$}:"
+          STDOUT.puts errors.pretty_inspect
+        end
+        puts "Refreshing index for class #{klass}"
       end
+      klass.__elasticsearch__.refresh_index!
     end
-    puts "Refreshing index for class #{klass}"
-    klass.__elasticsearch__.refresh_index!
   end
-
 end
 
 RSpec.configure do |config|

--- a/spec/support/es_spec_helper.rb
+++ b/spec/support/es_spec_helper.rb
@@ -31,14 +31,14 @@ module EsSpecHelper
     #puts "Creating Index for class #{klass}"
     klass.__elasticsearch__.create_index! force: true, index: klass.index_name
     klass.__elasticsearch__.refresh_index!
-    klass.__elasticsearch__.import  :return => 'errors', :batch_size => 200    do |resp|
+    klass.__elasticsearch__.import(return: "errors", batch_size: 200) do |resp|
       # show errors immediately (rather than buffering them)
-      errors += resp['items'].select { |k, v| k.values.first['error'] }
-      completed += resp['items'].size
+      errors += resp["items"].select { |k, v| k.values.first["error"] }
+      completed += resp["items"].size
       #puts "Finished #{completed} items"
       STDERR.flush
       STDOUT.flush
-      if errors.size > 0
+      if ENV["ES_DEBUG"].to_i > 0 && errors.size > 0
         STDOUT.puts "ERRORS in #{$$}:"
         STDOUT.puts errors.pretty_inspect
       end


### PR DESCRIPTION
* Will only log if log level is set to `info` or lower
* The default Rails log level is debug in all environments (lowest)
* Log level is set to `warn` in test env so output not shown
* http://guides.rubyonrails.org/debugging_rails_applications.html#the-logger#impact-of-logs-on-performance