### PR TITLE
add elasticsearch:true tag to specs that require it

### DIFF
--- a/spec/features/return_to_spec.rb
+++ b/spec/features/return_to_spec.rb
@@ -1,9 +1,9 @@
-describe "the return_to url option" do
+describe "the return_to url option", elasticsearch: true do
   include ReturnToHelper
 
   it 'defaults to the proposals listing' do
     login_as(create(:user))
-    visit '/proposals/query?text=test'
+    visit query_proposals_path(text: "test")
     expect(page).to have_content('Back to main portal')
     click_on('Back to main portal')
     expect(current_path).to eq('/proposals')


### PR DESCRIPTION
since specs run in a random order, it's hard to know if we've added the necessary `elasticsearch: true` tag to all relevant specs. Let's leave this PR open and add to it as CI reveals more that need it.