### PR TITLE
myusa failure sometimes redirects to a non-existent endpoint

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,5 +1,5 @@
 class AuthController < ApplicationController
-  skip_before_action :authenticate_user!, only: [:oauth_callback]
+  skip_before_action :authenticate_user!, only: [:oauth_callback, :failure]
   skip_before_action :check_disabled_client
 
   def oauth_callback
@@ -9,6 +9,9 @@ class AuthController < ApplicationController
     session[:token] = auth.credentials.token
     flash[:success] = "You successfully signed in"
     redirect_to return_to_path || proposals_path
+  end
+
+  def failure
   end
 
   def logout

--- a/app/views/auth/failure.html.haml
+++ b/app/views/auth/failure.html.haml
@@ -4,4 +4,4 @@
 
   %h4
     There was a problem signing you in. Please
-    = link_to 'Try signing in with MyUSA again', auth_path
+    = link_to 'try signing in with MyUSA again.', auth_path

--- a/app/views/auth/failure.html.haml
+++ b/app/views/auth/failure.html.haml
@@ -1,0 +1,7 @@
+.inset
+  %h1 
+    Sign in problem
+
+  %h4
+    There was a problem signing you in. Please
+    = link_to 'Try signing in with MyUSA again', auth_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ C2::Application.routes.draw do
   post "/feedback" => "feedback#create"
 
   match "/auth/:provider/callback" => "auth#oauth_callback", via: [:get]
+  get "/auth/failure" => "auth#failure"
   post "/logout" => "auth#logout"
 
   resources :help, only: [:index, :show]

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -9,4 +9,16 @@ feature "Login" do
       "You are not allowed to login because your account has been deactivated. Please contact an administrator."
     )
   end
+
+  scenario "myusa auth problem" do
+    user = create(:user)
+
+    login_as(user)
+
+    # something went wrong. What? No idea.
+
+    visit "/auth/failure?message=invalid_credentials"
+
+    expect(page).to have_content("There was a problem signing you in")
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/yp6uuxcF

Note that I was not able to duplicate the exact scenario reported in the Trello card, though I have hit that 404 page before via that same URL. This PR at least gets rid of the 404, and should (hopefully) smooth out the UX till we can figure out why it is getting triggered.