### PR TITLE
Move database cleaner setup to its own file

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,37 +20,6 @@ RSpec.configure do |config|
     config.include IntegrationSpecHelper, type: type
   end
 
-  config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
-    Rails.application.load_seed
-    Test.setup_models
-  end
-
-  config.before(:each) do
-    if Capybara.current_driver == :rack_test
-      DatabaseCleaner.strategy = :transaction
-    else
-      DatabaseCleaner.strategy = :truncation
-    end
-
-    DatabaseCleaner.start
-  end
-
-  config.after(:each) do
-    DatabaseCleaner.clean
-    ActionMailer::Base.deliveries.clear
-    OmniAuth.config.mock_auth[:myusa] = nil
-    # only need to re-load seeds if the cleaner used truncation
-    if Capybara.current_driver != :rack_test
-      Rails.application.load_seed
-    end
-  end
-
-  config.after(:suite) do
-    Test.teardown_models
-  end
-
   Capybara.default_host = 'http://localhost:3000'
   OmniAuth.config.test_mode = true
   ENV["DISABLE_SANDBOX_WARNING"] = "true"

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,31 @@
+RSpec.configure do |config|
+  config.before(:suite) do
+    DatabaseCleaner.clean_with(:truncation)
+    Test.setup_models
+    Rails.application.load_seed
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, js: true) do
+    DatabaseCleaner.strategy = :truncation
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    ActionMailer::Base.deliveries.clear
+    DatabaseCleaner.clean
+    if Capybara.current_driver != :rack_test
+      Rails.application.load_seed
+    end
+  end
+
+  config.after(:suite) do
+    Test.teardown_models
+  end
+end


### PR DESCRIPTION
* Easier to read / tweak
* We want this in all specs, not just specs the include `rails_helper`
  (even though all of our specs require it now)