### PR TITLE
Wrap es output in check for `ES_DEBUG` var

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -29,7 +29,7 @@ else
 end
 
 # optional verbose logging based on env var, regardless of environment.
-if ENV["ES_DEBUG"].to_i > 0
+if ENV["ES_DEBUG"]
   logger = Logger.new(STDOUT)
   logger.level = Logger::DEBUG
   tracer = Logger.new(STDERR)

--- a/lib/expired_record_cleaner.rb
+++ b/lib/expired_record_cleaner.rb
@@ -61,7 +61,7 @@ class ExpiredRecordCleaner
   end
 
   def notify_no_action_taken_if_non_test_env(proposal)
-    if !Rails.env.test?
+    unless Rails.env.test?
       STDERR.puts "set OK_TO_ACT=true to clean up #{proposal.id}"
     end
   end

--- a/lib/expired_record_cleaner.rb
+++ b/lib/expired_record_cleaner.rb
@@ -37,7 +37,7 @@ class ExpiredRecordCleaner
   end
 
   def handle_no_requester(proposal)
-    if @verbose && ENV["RAILS_ENV"] != "test"
+    if @verbose && !Rails.env.test?
       STDERR.puts "#{proposal.id} <= no Requester defined"
     end
     if @ok_to_act
@@ -48,9 +48,10 @@ class ExpiredRecordCleaner
   end
 
   def handle_cancellation(proposal)
-    if @verbose && ENV["RAILS_ENV"] != "test"
+    if @verbose && !Rails.env.test?
       STDERR.puts "#{proposal.public_id} -> #{proposal.requester.email_address}"
     end
+
     if @ok_to_act
       notify_proposal_requester(proposal)
       proposal.cancel!
@@ -60,7 +61,7 @@ class ExpiredRecordCleaner
   end
 
   def notify_no_action_taken_if_non_test_env(proposal)
-    if ENV["RAILS_ENV"] != "test"
+    if !Rails.env.test?
       STDERR.puts "set OK_TO_ACT=true to clean up #{proposal.id}"
     end
   end

--- a/lib/expired_record_cleaner.rb
+++ b/lib/expired_record_cleaner.rb
@@ -37,24 +37,30 @@ class ExpiredRecordCleaner
   end
 
   def handle_no_requester(proposal)
-    if @verbose
+    if @verbose && ENV["RAILS_ENV"] != "test"
       STDERR.puts "#{proposal.id} <= no Requester defined"
     end
     if @ok_to_act
       proposal.destroy
     else
-      STDERR.puts "set OK_TO_ACT=true to clean up #{proposal.id}"
+      notify_no_action_taken_if_non_test_env(proposal)
     end
   end
 
   def handle_cancellation(proposal)
-    if @verbose
+    if @verbose && ENV["RAILS_ENV"] != "test"
       STDERR.puts "#{proposal.public_id} -> #{proposal.requester.email_address}"
     end
     if @ok_to_act
       notify_proposal_requester(proposal)
       proposal.cancel!
     else
+      notify_no_action_taken_if_non_test_env(proposal)
+    end
+  end
+
+  def notify_no_action_taken_if_non_test_env(proposal)
+    if ENV["RAILS_ENV"] != "test"
       STDERR.puts "set OK_TO_ACT=true to clean up #{proposal.id}"
     end
   end

--- a/spec/lib/query/proposal/search_spec.rb
+++ b/spec/lib/query/proposal/search_spec.rb
@@ -83,7 +83,7 @@ describe Query::Proposal::Search, elasticsearch: true do
       user = create(:user, client_slug: "test")
 
       proposal1 = create(:proposal, id: 199, requester: user)
-      test_client_request1 = create(:test_client_request, proposal: proposal1)
+      create(:test_client_request, proposal: proposal1)
       proposal1.reindex
 
       test_client_request2 = create(:test_client_request, project_title: "199 rolly chairs for 1600 Penn Ave")
@@ -92,7 +92,7 @@ describe Query::Proposal::Search, elasticsearch: true do
       proposal2.reindex
 
       proposal3 = create(:proposal, id: 1600, requester: user)
-      test_client_request3 = create(:test_client_request, proposal: proposal3)
+      create(:test_client_request, proposal: proposal3)
       proposal3.reindex
 
       refresh_index
@@ -115,6 +115,6 @@ end
 def dump_index
   if ENV["ES_DEBUG"]
     puts ANSI.blue{ "----------------- DUMP INDEX ---------------------" }
+    puts Proposal.search( "*" ).results.to_a.pretty_inspect
   end
-  puts Proposal.search( "*" ).results.to_a.pretty_inspect
 end


### PR DESCRIPTION
* To prevent unnecessary output during spec runs