### PR TITLE
switch to downloading activeadmin via HTTPS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 ruby "2.2.3" # this should match `.ruby-version` and docs/setup.md
 
 gem "active_model_serializers"
-gem "activeadmin", github: "activeadmin"
+gem "activeadmin", git: "https://github.com/activeadmin/activeadmin.git"
 gem "acts_as_list"
 gem "acts-as-taggable-on", "~> 3.4"
 gem "ar_outer_joins"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,13 @@
 GIT
-  remote: git://github.com/activeadmin/activeadmin.git
+  remote: https://github.com/18F/omniauth-myusa.git
+  revision: abff3f44871a377a7000ce458898db17553d9b79
+  specs:
+    omniauth-myusa (0.0.4)
+      omniauth (~> 1.0)
+      omniauth-oauth2 (= 1.3.1)
+
+GIT
+  remote: https://github.com/activeadmin/activeadmin.git
   revision: ca94d1ccb1894ccbaedc40f6a6b948d1423b90bb
   specs:
     activeadmin (1.0.0.pre2)
@@ -15,14 +23,6 @@ GIT
       rails (>= 3.2, < 5.0)
       ransack (~> 1.3)
       sass-rails
-
-GIT
-  remote: https://github.com/18F/omniauth-myusa.git
-  revision: abff3f44871a377a7000ce458898db17553d9b79
-  specs:
-    omniauth-myusa (0.0.4)
-      omniauth (~> 1.0)
-      omniauth-oauth2 (= 1.3.1)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
Should solve the problem brought up [in Slack](https://18f.slack.com/archives/cap-public/p1454536738000051):

> When running $ ./script/bootstrap, the port for Git is blocked by the firewall team here at [agency]
> 
> "Retrying git clone 'git://github.com/activeadmin/activeadmin.git' "/usr/local/rvm/gems/ruby-2.2.3/cache/bundler/git/activeadmin-c24fcef949b2f1bbdf6b5a17650dcd86d73f2528" --bare --no-hardlinks --quiet due to error (2/4): Bundler::Source::Git::GitCommandError Git error: command `git clone 'git://github.com/activeadmin/activeadmin.git' "/usr/local/rvm/gems/ruby-2.2.3/cache/bundler/git/activeadmin-c24fcef949b2f1bbdf6b5a17650dcd86d73f2528" --bare --no-hardlinks --quiet` in directory /root/C2 has failed."
> 
> So in general, I can get to ports 80, 443... but even 21 (ftp) is blocked, so is 9418 (git plain-text)