### PR TITLE
[Refactor] Set approving official as NCR relation instead of attribute

### DIFF
--- a/app/controllers/ncr/work_orders_controller.rb
+++ b/app/controllers/ncr/work_orders_controller.rb
@@ -4,7 +4,7 @@ module Ncr
     MAX_UPLOADS_ON_NEW = 10
 
     def new
-      @client_data_instance.approving_official = suggested_approver_email
+      work_order.approving_official = suggested_approver_email
       super
     end
 

--- a/app/controllers/ncr/work_orders_controller.rb
+++ b/app/controllers/ncr/work_orders_controller.rb
@@ -4,7 +4,7 @@ module Ncr
     MAX_UPLOADS_ON_NEW = 10
 
     def new
-      work_order.approving_official_email = suggested_approver_email
+      @client_data_instance.approving_official = suggested_approver_email
       super
     end
 
@@ -14,8 +14,6 @@ module Ncr
     end
 
     def edit
-      @client_data_instance.approving_official_email = @client_data_instance.approvers.first.try(:email_address)
-
       if proposal.approved?
         flash.now[:warning] = "You are about to modify a fully approved request. Changes will be logged and sent to approvers, and this request may require re-approval, depending on the change."
       end
@@ -37,6 +35,11 @@ module Ncr
       @client_data_instance
     end
 
+    def suggested_approver_email
+      last_proposal = current_user.last_requested_proposal
+      last_proposal.try(:client_data).try(:approving_official)
+    end
+
     def record_changes
       ProposalUpdateRecorder.new(work_order).run
     end
@@ -49,17 +52,8 @@ module Ncr
       updater.run
     end
 
-    def attribute_changes?
-      super || work_order.approver_changed?
-    end
-
     def model_class
       Ncr::WorkOrder
-    end
-
-    def suggested_approver_email
-      last_proposal = current_user.last_requested_proposal
-      last_proposal.try(:approvers).try(:first).try(:email_address) || ''
     end
 
     def permitted_params
@@ -76,7 +70,6 @@ module Ncr
       Ncr::WorkOrderFields.new.relevant(params[:ncr_work_order][:expense_type])
     end
 
-    # @pre: work_order.approving_official_email is set
     def add_steps
       super
       if errors.empty?

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -4,8 +4,9 @@ class ObservationsController < ApplicationController
   rescue_from Pundit::NotAuthorizedError, with: :auth_errors
 
   def create
-    new_observer = @proposal.add_observer(observer_email, current_user, params[:observation][:reason])
-    prep_create_response_msg(new_observer)
+    observer = User.find(observation_params)
+    observation = @proposal.add_observer(observer, current_user, params[:observation][:reason])
+    prep_create_response_msg(observer, observation)
     redirect_to proposal_path(@proposal)
   end
 
@@ -39,16 +40,16 @@ class ObservationsController < ApplicationController
     @cached_observation ||= Observation.find(params[:id])
   end
 
-  def observer_email
-    params.permit(observation: { user: [:email_address] })
-      .require(:observation).require(:user).require(:email_address)
+  def observation_params
+    params.permit(observation: { user: [:id] })
+      .require(:observation).require(:user).require(:id)
   end
 
-  def prep_create_response_msg(observer)
-    if observer
-      flash[:success] = "#{observer.user.full_name} has been added as an observer"
+  def prep_create_response_msg(observer, observation)
+    if observation
+      flash[:success] = "#{observer.full_name} has been added as an observer"
     else
-      flash[:alert] = "#{observer_email} is already an observer for this request"
+      flash[:alert] = "#{observer.email_address} is already an observer for this request"
     end
   end
 

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -46,7 +46,7 @@ class ProposalsController < ApplicationController
   end
 
   def approve
-    step = proposal.existing_step_for(current_user)
+    step = proposal.existing_or_delegated_step_for(current_user)
     step.update_attributes!(completer: current_user)
     step.approve!
     flash[:success] = "You have approved #{proposal.public_id}."

--- a/app/decorators/proposal_decorator.rb
+++ b/app/decorators/proposal_decorator.rb
@@ -49,7 +49,7 @@ class ProposalDecorator < Draper::Decorator
   end
 
   def step_text_for_user(key, user)
-    step = existing_step_for(user)
+    step = existing_or_delegated_step_for(user)
     klass = step.class.name.demodulize.downcase.to_sym
     scope = [:decorators, :steps, klass]
     I18n.t(key, scope: scope)

--- a/app/helpers/ncr/work_orders_helper.rb
+++ b/app/helpers/ncr/work_orders_helper.rb
@@ -1,9 +1,16 @@
 module Ncr
   module WorkOrdersHelper
-    def approver_options(excluded_users = [])
-      excluded_emails = excluded_users.map(&:email_address)
-      User.active.where(client_slug: "ncr").order(:email_address).pluck(:email_address) -
-        Ncr::WorkOrder.all_system_approver_emails - excluded_emails
+    def approver_options(ineligible_approvers = [])
+      approvers = scoped_approver_options(ineligible_approvers)
+      approvers.map do |approver|
+        { name: approver.email_address, id: approver.id }
+      end
+    end
+
+    def scoped_approver_options(ineligible_approvers)
+      User.active.where(client_slug: "ncr").order(:email_address) -
+        Ncr::WorkOrder.all_system_approvers -
+        ineligible_approvers
     end
 
     def building_options

--- a/app/helpers/ncr/work_orders_helper.rb
+++ b/app/helpers/ncr/work_orders_helper.rb
@@ -1,13 +1,6 @@
 module Ncr
   module WorkOrdersHelper
-    def approver_options(ineligible_approvers = [])
-      approvers = scoped_approver_options(ineligible_approvers)
-      approvers.map do |approver|
-        { name: approver.email_address, id: approver.id }
-      end
-    end
-
-    def scoped_approver_options(ineligible_approvers)
+    def scoped_approver_options(ineligible_approvers = [])
       User.active.where(client_slug: "ncr").order(:email_address) -
         Ncr::WorkOrder.all_system_approvers -
         ineligible_approvers

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -37,7 +37,7 @@ class Comment < ActiveRecord::Base
   end
 
   def add_user_as_observer
-    proposal.add_observer(user.email_address)
+    proposal.add_observer(user)
   end
 
   # All of the users who should be notified when a comment is created

--- a/app/models/ncr/mailboxes.rb
+++ b/app/models/ncr/mailboxes.rb
@@ -23,7 +23,7 @@ module Ncr
       if users.empty?
         fail "Missing User with role #{role_name} -- did you run rake db:migrate and rake db:seed?"
       end
-      users.first.email_address
+      users.first
     end
   end
 end

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -175,7 +175,7 @@ module Ncr
 
     def frozen_approving_official_not_changed
       if persisted? && approving_official_id_changed? && approver_email_frozen?
-       errors.add(:approving_official, "Approving official cannot be changed")
+        errors.add(:approving_official, "Approving official cannot be changed")
       end
     end
   end

--- a/app/models/ncr/work_order_fields.rb
+++ b/app/models/ncr/work_order_fields.rb
@@ -17,7 +17,10 @@ module Ncr
     end
 
     def display
-      attributes_for_view.push(["Org code", work_order.organization_code_and_name])
+      attributes_for_view.push(
+        ["Org code", work_order.organization_code_and_name],
+        ["Approving official", work_order.approving_official.try(:email_address)]
+      )
     end
 
     private
@@ -27,7 +30,7 @@ module Ncr
     def default
       [
         :amount,
-        :approving_official_email,
+        :approving_official_id,
         :building_number,
         :cl_number,
         :description,
@@ -43,7 +46,7 @@ module Ncr
     end
 
     def attributes_for_view
-      attributes = relevant(work_order.expense_type) - [:ncr_organization_id]
+      attributes = relevant(work_order.expense_type) - [:ncr_organization_id, :approving_official_id]
       attributes.map do |attribute|
         [
           Ncr::WorkOrder.human_attribute_name(attribute),

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -137,14 +137,17 @@ class Proposal < ActiveRecord::Base
     user_delegates.exists?(assignee_id: user.id)
   end
 
-  def existing_step_for(user)
+  def existing_or_delegated_step_for(user)
     where_clause = <<-SQL
       user_id = :user_id
       OR user_id IN (SELECT assigner_id FROM user_delegates WHERE assignee_id = :user_id)
       OR user_id IN (SELECT assignee_id FROM user_delegates WHERE assigner_id = :user_id)
     SQL
-
     steps.where(where_clause, user_id: user.id).first
+  end
+
+  def existing_step_for(user)
+    steps.where(user: user).first
   end
 
   def subscribers

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -182,9 +182,7 @@ class Proposal < ActiveRecord::Base
     end
   end
 
-  def add_observer(email_address, adder=nil, reason=nil)
-    user = User.for_email_with_slug(email_address, client_slug)
-
+  def add_observer(user, adder=nil, reason=nil)
     # this authz check is here instead of in a Policy because the Policy classes
     # are applied to the current_user, not (as in this case) the user being acted upon.
     if client_data && !client_data.slug_matches?(user) && !user.admin?

--- a/app/services/ncr/work_order_value_normalizer.rb
+++ b/app/services/ncr/work_order_value_normalizer.rb
@@ -8,7 +8,6 @@ module Ncr
       normalize_cl_number
       normalize_function_code
       normalize_soc_code
-      normalize_approving_official_email
     end
 
     private
@@ -39,12 +38,6 @@ module Ncr
         work_order.soc_code = work_order.soc_code.upcase
       else
         work_order.soc_code = nil
-      end
-    end
-
-    def normalize_approving_official_email
-      if work_order.approving_official_email.blank? && work_order.approvers.any?
-        work_order.approving_official_email = work_order.approvers.first.try(:email_address)
       end
     end
 

--- a/app/services/proposal_update_recorder.rb
+++ b/app/services/proposal_update_recorder.rb
@@ -46,19 +46,35 @@ class ProposalUpdateRecorder
   def association_name(key)
     if key == "ncr_organization_id"
       "Org code"
+    elsif key == "approving_official_id"
+      "Approving official"
     end
   end
 
   def former_association_value(key)
     if key == "ncr_organization_id"
-      former_id = former_value(key)
-
-      if former_id.present? && Ncr::Organization.find(former_id)
-        "from #{Ncr::Organization.find(former_id).code_and_name} "
-      else
-        ""
-      end
+      former_ncr_organization(key) || ""
+    elsif key == "approving_official_id"
+      former_approving_official(key) || ""
     end
+  end
+
+  def former_ncr_organization(key)
+    former_id = former_id(key)
+    if former_id.present? && Ncr::Organization.find(former_id)
+      "from #{Ncr::Organization.find(former_id).code_and_name} "
+    end
+  end
+
+  def former_approving_official(key)
+    former_id = former_id(key)
+    if former_id.present? && User.find(former_id)
+      "from #{User.find(former_id).email_address} "
+    end
+  end
+
+  def former_id(key)
+    former_value(key)
   end
 
   def new_association_value(key)

--- a/app/services/proposal_update_recorder.rb
+++ b/app/services/proposal_update_recorder.rb
@@ -78,14 +78,10 @@ class ProposalUpdateRecorder
   end
 
   def new_association_value(key)
-    if key == "ncr_organization_id"
-      organization = client_data.ncr_organization
-
-      if organization.nil?
-        "*empty*"
-      else
-        organization.code_and_name
-      end
+    if key == "approving_official_id"
+      client_data.approving_official.email_address
+    elsif key == "ncr_organization_id"
+      client_data.ncr_organization.try(:code_and_name) || "*empty*"
     end
   end
 

--- a/app/views/ncr/work_orders/_form.html.haml
+++ b/app/views/ncr/work_orders/_form.html.haml
@@ -38,11 +38,14 @@
         as: :radio_buttons,
         collection: [["Exact", false], ["Not to exceed", true]], label: false
     = f.input :direct_pay
-    = f.input :approving_official_email,
-      collection: approver_options(@client_data_instance.ineligible_approvers),
+    = f.association :approving_official,
       disabled: @client_data_instance.proposal.approver_email_frozen?,
+      collection: scoped_approver_options(@client_data_instance.ineligible_approvers),
+      as: :select,
+      label_method: :email_address,
+      value_method: :id,
       prompt: :translate,
-      input_html: { class: "js-selectize required" }
+      input_html: { class: "js-selectize required", data: { initial: JSON.generate(approver_options(@client_data_instance.ineligible_approvers)) }}
     - if @client_data_instance.new_record?
       = render partial: 'attachments'
     - else

--- a/app/views/ncr/work_orders/_form.html.haml
+++ b/app/views/ncr/work_orders/_form.html.haml
@@ -45,7 +45,7 @@
       label_method: :email_address,
       value_method: :id,
       prompt: :translate,
-      input_html: { class: "js-selectize required", data: { initial: JSON.generate(approver_options(@client_data_instance.ineligible_approvers)) }}
+      input_html: { class: "js-selectize required" }
     - if @client_data_instance.new_record?
       = render partial: 'attachments'
     - else

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -48,11 +48,11 @@
               = form_for [@proposal, Observation.new] do |f|
                 = f.fields_for :user do |user_form|
                   .col-md-8.col-xs-12
-                    = user_form.collection_select :email_address, @proposal.eligible_observers, :email_address, :email_address, {include_blank: true}, class: 'js-selectize'
-                    = f.label :reason, "Reason for adding observer (optional): ", data: {'hide-until-select' => 'observation_user_email_address'}
-                    = text_field :observation, :reason, class: 'form-control', data: {'hide-until-select' => 'observation_user_email_address'}
+                    = user_form.collection_select :id, @proposal.eligible_observers, :id, :email_address, { include_blank: true }, class: 'js-selectize'
+                    = f.label :reason, "Reason for adding observer (optional): ", data: {'hide-until-select' => 'observation_user_id'}
+                    = text_field :observation, :reason, class: 'form-control', data: {'hide-until-select' => 'observation_user_id'}
                   .col-md-4.col-xs-12.righted
-                    = user_form.submit "Add an Observer", id: :add_subscriber, data: {'disable-if-empty' => 'observation_user_email_address'}
+                    = user_form.submit "Add an Observer", id: :add_subscriber, data: {'disable-if-empty' => 'observation_user_id'}
 
 
 

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -12,7 +12,7 @@ en:
       gsa18f_procurement:
         additional_info: "Please include any additional information you feel we need to correctly execute the purchase"
       ncr_work_order:
-        approving_official_email: "Approving official's email address"
+        approving_official: "Approving official's email address"
         direct_pay: "I am going to be using direct pay for this transaction"
         emergency: "This request was an emergency and I received a verbal Notice to Proceed (NTP)"
         ncr_organization: "Org code / Service center"
@@ -22,13 +22,10 @@ en:
         project_title: "e.g. \"Blue paint for the Blue Room\""
         vendor: "Type here to search or add"
         ncr_organization: "Type here to search"
+        approving_official: "Type here to search"
     hints:
       gsa18f_procurement:
         link_to_product: "Search <a href='https://www.gsaadvantage.gov/advantage/main/start_page.do' target='_blank'>GSA Advantage</a> first; then <a href='http://www.amazon.com' target='_blank'>Amazon;</a> then other vendor. Paste link here."
         recurring_length: "e.g. Number of Days, Months, Years"
       ncr_work_order:
         description: "Include request details (e.g. Room Number, Estimated number of hours)"
-    # requires `prompt: :translate`
-    prompts:
-      ncr_work_order:
-        approving_official_email: "Type here to search"

--- a/db/chores/populator.rb
+++ b/db/chores/populator.rb
@@ -28,11 +28,12 @@ class Populator
 
   private
 
-  def create_proposal(requester: create(:user), requested_at: Time.zone.now)
+  def create_proposal(requester: create(:user, client_slug: "ncr"), requested_at: Time.zone.now)
     create(
       :proposal,
       :with_serial_approvers,
       :with_observers,
+      client_slug: "ncr",
       requester: requester,
       created_at: requested_at,
       updated_at: requested_at,

--- a/db/migrate/20160208182623_add_approving_official_email_to_work_orders.rb
+++ b/db/migrate/20160208182623_add_approving_official_email_to_work_orders.rb
@@ -7,10 +7,12 @@ class AddApprovingOfficialEmailToWorkOrders < ActiveRecord::Migration
     add_column :ncr_work_orders, :approving_official_id, :integer, index: true
 
     Ncr::WorkOrder.all.each do |work_order|
-      step = work_order.proposal.individual_steps.first
-      if step
-        work_order.approving_official = step.user
-        work_order.save(validate: false)
+      if work_order.proposal
+        step = work_order.proposal.individual_steps.first
+        if step
+          work_order.approving_official = step.user
+          work_order.save(validate: false)
+        end
       end
     end
   end

--- a/db/migrate/20160208182623_add_approving_official_email_to_work_orders.rb
+++ b/db/migrate/20160208182623_add_approving_official_email_to_work_orders.rb
@@ -1,0 +1,21 @@
+class AddApprovingOfficialEmailToWorkOrders < ActiveRecord::Migration
+  class Ncr::WorkOrder < ActiveRecord::Base
+    has_one :proposal, as: :client_data
+  end
+
+  def up
+    add_column :ncr_work_orders, :approving_official_id, :integer, index: true
+
+    Ncr::WorkOrder.all.each do |work_order|
+      step = work_order.proposal.individual_steps.first
+      if step
+        work_order.approving_official = step.user
+        work_order.save(validate: false)
+      end
+    end
+  end
+
+  def down
+    remove_column :ncr_work_orders, :approving_official_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160202210256) do
+ActiveRecord::Schema.define(version: 20160208182623) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,22 +107,23 @@ ActiveRecord::Schema.define(version: 20160202210256) do
 
   create_table "ncr_work_orders", force: :cascade do |t|
     t.decimal  "amount"
-    t.string   "expense_type",        limit: 255
-    t.string   "vendor",              limit: 255
-    t.boolean  "not_to_exceed",                   default: false, null: false
-    t.string   "building_number",     limit: 255
-    t.boolean  "emergency",                       default: false, null: false
-    t.string   "rwa_number",          limit: 255
-    t.string   "code",                limit: 255
-    t.string   "project_title",       limit: 255
+    t.string   "expense_type",          limit: 255
+    t.string   "vendor",                limit: 255
+    t.boolean  "not_to_exceed",                     default: false, null: false
+    t.string   "building_number",       limit: 255
+    t.boolean  "emergency",                         default: false, null: false
+    t.string   "rwa_number",            limit: 255
+    t.string   "code",                  limit: 255
+    t.string   "project_title",         limit: 255
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "direct_pay",                      default: false, null: false
-    t.string   "cl_number",           limit: 255
-    t.string   "function_code",       limit: 255
-    t.string   "soc_code",            limit: 255
+    t.boolean  "direct_pay",                        default: false, null: false
+    t.string   "cl_number",             limit: 255
+    t.string   "function_code",         limit: 255
+    t.string   "soc_code",              limit: 255
     t.integer  "ncr_organization_id"
+    t.integer  "approving_official_id"
   end
 
   add_index "ncr_work_orders", ["ncr_organization_id"], name: "index_ncr_work_orders_on_ncr_organization_id", using: :btree

--- a/spec/controllers/observations_controller_spec.rb
+++ b/spec/controllers/observations_controller_spec.rb
@@ -22,10 +22,10 @@ describe ObservationsController do
       login_as(proposal.requester)
       observer = create(:user, client_slug: nil)
 
-      post :create, proposal_id: proposal.id, observation: {user: {email_address: observer.email_address}}
+      post :create, proposal_id: proposal.id, observation: { user: { id: observer.id } }
       expect(flash[:success]).to eq("#{observer.full_name} has been added as an observer")
 
-      post :create, proposal_id: proposal.id, observation: {user: {email_address: observer.email_address}}
+      post :create, proposal_id: proposal.id, observation: { user: { id: observer.id } }
       expect(flash[:alert]).to eq("#{observer.email_address} is already an observer for this request")
     end
   end

--- a/spec/factories/ncr/organizations.rb
+++ b/spec/factories/ncr/organizations.rb
@@ -1,6 +1,8 @@
 FactoryGirl.define do
+  sequence(:code) { |n| "Code #{n}" }
+
   factory :ncr_organization, class: Ncr::Organization do
-    code "ORGCODE"
+    code
     name "Test Organization"
 
     factory :ool_organization do

--- a/spec/factories/ncr/work_orders.rb
+++ b/spec/factories/ncr/work_orders.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
     building_number Ncr::BUILDING_NUMBERS[0]
     emergency false
     project_title "NCR Name"
-    sequence(:approving_official_email) {|n| "approver#{User.count}@example.com" }
+    association :approving_official, factory: :user, client_slug: "ncr"
     association :proposal, client_slug: "ncr"
 
     factory :ba60_ncr_work_order do
@@ -25,9 +25,6 @@ FactoryGirl.define do
 
     trait :with_approvers do
       association :proposal, :with_serial_approvers, client_slug: "ncr"
-      after :create do |wo|
-        wo.approving_official_email = wo.approving_official.email_address
-      end
     end
 
     trait :is_emergency do

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -49,7 +49,7 @@ FactoryGirl.define do
     trait :with_observer do
       after :create do |proposal, evaluator|
         observer = create(:user, client_slug: evaluator.client_slug)
-        proposal.add_observer(observer.email_address)
+        proposal.add_observer(observer)
       end
     end
 
@@ -57,14 +57,14 @@ FactoryGirl.define do
       after :create do |proposal, evaluator|
         2.times do
           observer = create(:user, client_slug: evaluator.client_slug)
-          proposal.add_observer(observer.email_address)
+          proposal.add_observer(observer)
         end
       end
     end
 
     after(:create) do |proposal, evaluator|
       if evaluator.observer
-        proposal.add_observer(evaluator.observer.email_address)
+        proposal.add_observer(evaluator.observer)
       end
 
       if evaluator.delegate

--- a/spec/features/attachment_spec.rb
+++ b/spec/features/attachment_spec.rb
@@ -50,7 +50,7 @@ describe "Add attachments" do
 
   it "emails everyone involved in the proposal" do
     expect(Dispatcher).to receive(:deliver_attachment_emails)
-    proposal.add_observer("wiley-cat@example.com")
+    proposal.add_observer(create(:user))
     visit proposal_path(proposal)
     page.attach_file('attachment[file]', "#{Rails.root}/app/assets/images/bg_approved_status.gif")
     click_on "Attach a File"

--- a/spec/features/client_slug_authz_spec.rb
+++ b/spec/features/client_slug_authz_spec.rb
@@ -1,23 +1,29 @@
 describe "client_slug confers authz rules" do
   it "rejects requests for user with no client_slug" do
     user = create(:user, client_slug: '')
+
     login_as(user)
-    visit '/ncr/work_orders/new'
+    visit new_ncr_work_order_path
+
     expect(page.status_code).to eq(403)
   end
 
   it "rejects requests for user with different client_slug" do
     user = create(:user, client_slug: 'gsa18f')
+
     login_as(user)
-    visit '/ncr/work_orders/new'
+    visit new_ncr_work_order_path
+
     expect(page.status_code).to eq(403)
   end
 
   it "allows Admin role" do
     user = create(:user, :admin, client_slug: '')
     approver = create(:user, client_slug: "ncr")
+
     login_as(user)
-    visit '/ncr/work_orders/new'
+    visit new_ncr_work_order_path
+
     expect(page.status_code).to eq(200)
     submit_ba60_work_order(approver)
     expect(page).to have_content('Proposal submitted!')
@@ -26,8 +32,10 @@ describe "client_slug confers authz rules" do
   it "allows same client_slug to create" do
     user = create(:user, client_slug: "ncr")
     approver = create(:user, client_slug: "ncr")
+
     login_as(user)
-    visit '/ncr/work_orders/new'
+    visit new_ncr_work_order_path
+
     expect(page.status_code).to eq(200)
     submit_ba60_work_order(approver)
     expect(page).to have_content('Proposal submitted!')
@@ -37,8 +45,9 @@ describe "client_slug confers authz rules" do
     ncr_user = create(:user, client_slug: "ncr")
     nil_user = create(:user, client_slug: '')
     approver = create(:user, client_slug: "ncr")
+
     login_as(ncr_user)
-    visit '/ncr/work_orders/new'
+    visit new_ncr_work_order_path
     submit_ba60_work_order(approver)
     proposal_path = current_path
     login_as(nil_user)
@@ -52,7 +61,7 @@ describe "client_slug confers authz rules" do
     approver = create(:user, client_slug: "ncr")
 
     login_as(ncr_user)
-    visit '/ncr/work_orders/new'
+    visit new_ncr_work_order_path
     submit_ba60_work_order(approver)
     proposal_path = current_path
     login_as(ncr_user2)
@@ -71,7 +80,7 @@ describe "client_slug confers authz rules" do
     submit_ba60_work_order(approver)
 
     expect(page.status_code).to eq(200)
-    expect_to_not_find_amongst_select_tag_options('observation_user_email_address', gsa_user.email_address)
+    expect_to_not_find_amongst_select_tag_options('observation_user_id', gsa_user.email_address)
   end
 
   private
@@ -88,7 +97,7 @@ describe "client_slug confers authz rules" do
   end
 
   def add_as_observer(user)
-    select user.email_address, from: 'observation_user_email_address'
+    select user.email_address, from: 'observation_user_id'
     fill_in "observation_reason", with: "observe thy ways"
     click_on 'Add an Observer'
   end

--- a/spec/features/ncr/work_orders/change_work_oder_to_whsc_spec.rb
+++ b/spec/features/ncr/work_orders/change_work_oder_to_whsc_spec.rb
@@ -21,12 +21,12 @@ feature "Requester switches work order to WHSC", :js do
 
       expect(deliveries.length).to be 3
       removed, approver1, approver2 = deliveries
-      expect(removed.to).to eq([Ncr::Mailboxes.ba61_tier1_budget])
+      expect(removed.to).to eq([Ncr::Mailboxes.ba61_tier1_budget.email_address])
       expect(removed.html_part.body).to include "removed"
 
       expect(approver1.to).to eq([work_order.approvers.first.email_address])
       expect(approver1.html_part.body).not_to include "removed"
-      expect(approver2.to).to eq([Ncr::Mailboxes.ba61_tier2_budget])
+      expect(approver2.to).to eq([Ncr::Mailboxes.ba61_tier2_budget.email_address])
       expect(approver2.html_part.body).not_to include "removed"
     end
   end
@@ -52,7 +52,7 @@ feature "Requester switches work order to WHSC", :js do
 
       expect(ncr_proposal.approvers.map(&:email_address)).to eq([
         approving_official.email_address,
-        Ncr::Mailboxes.ba61_tier2_budget
+        Ncr::Mailboxes.ba61_tier2_budget.email_address
       ])
       expect(work_order.individual_steps.first).to be_approved
     end

--- a/spec/features/ncr/work_orders/create_approver_options_spec.rb
+++ b/spec/features/ncr/work_orders/create_approver_options_spec.rb
@@ -6,7 +6,7 @@ feature "Approver options during create", :js do
     login_as(requester)
     visit new_ncr_work_order_path
 
-    within(".ncr_work_order_approving_official_email") do
+    within(".ncr_work_order_approving_official") do
       find(".selectize-control").click
       expect(page).not_to have_content(inactive_user.email_address)
       expect(page).to have_content(approver.email_address)
@@ -20,7 +20,7 @@ feature "Approver options during create", :js do
     visit new_ncr_work_order_path
 
     expect_page_not_to_have_selectized_options(
-      "ncr_work_order_approving_official_email",
+      "ncr_work_order_approving_official",
       Ncr::Mailboxes.ba61_tier1_budget,
       Ncr::Mailboxes.ba61_tier2_budget,
       Ncr::Mailboxes.ba80_budget,
@@ -33,7 +33,7 @@ feature "Approver options during create", :js do
     visit new_ncr_work_order_path
 
     expect_page_not_to_have_selectized_options(
-      "ncr_work_order_approving_official_email",
+      "ncr_work_order_approving_official",
       requester.email_address
     )
   end
@@ -45,20 +45,21 @@ feature "Approver options during create", :js do
     visit new_ncr_work_order_path
 
     expect_page_not_to_have_selected_selectize_option(
-      "ncr_work_order_approving_official_email",
+      "ncr_work_order_approving_official",
       /@example.com/
     )
   end
 
   scenario "defaults to the approver from the last request" do
-    login_as(requester)
-    proposal = create(:proposal, :with_approver, requester: requester, client_slug: "ncr")
+    client_data = create(:ncr_work_order)
+    create(:proposal, client_data: client_data, requester: requester, client_slug: "ncr")
 
+    login_as(requester)
     visit new_ncr_work_order_path
 
     expect_page_to_have_selected_selectize_option(
-      "ncr_work_order_approving_official_email",
-       proposal.approvers.first.email_address
+      "ncr_work_order_approving_official",
+      client_data.approving_official.email_address
     )
   end
 

--- a/spec/features/ncr/work_orders/create_spec.rb
+++ b/spec/features/ncr/work_orders/create_spec.rb
@@ -14,7 +14,7 @@ feature "Creating an NCR work order", :js do
       fill_in_selectized("ncr_work_order_building_number", "Test building")
       fill_in_selectized("ncr_work_order_vendor", "ACME")
       fill_in 'Amount', with: 123.45
-      fill_in_selectized("ncr_work_order_approving_official_email", approver.email_address)
+      fill_in_selectized("ncr_work_order_approving_official", approver.email_address)
       fill_in_selectized("ncr_work_order_ncr_organization", organization.code_and_name)
       click_on "Submit for approval"
 
@@ -38,9 +38,9 @@ feature "Creating an NCR work order", :js do
       fill_in 'Amount', with: 123.45
       click_on "Submit for approval"
 
-      expect(page).to have_content("Approving official email can't be blank")
+      expect(page).to have_content("Approving official can't be blank")
       visit proposals_path
-      expect(page).to_not have_content("Approving official email can't be blank")
+      expect(page).to_not have_content("Approving official can't be blank")
     end
 
     scenario "doesn't show the budget fields" do

--- a/spec/features/ncr/work_orders/create_with_different_expense_types_spec.rb
+++ b/spec/features/ncr/work_orders/create_with_different_expense_types_spec.rb
@@ -32,7 +32,7 @@ feature "Create NCR Work orders with different expense types", :js do
       fill_in_selectized("ncr_work_order_building_number", "Test Building")
       fill_in_selectized("ncr_work_order_vendor", "Test vendor")
       fill_in "Amount", with: 123.45
-      fill_in_selectized("ncr_work_order_approving_official_email", approver.email_address)
+      fill_in_selectized("ncr_work_order_approving_official", approver.email_address)
       click_on "Submit for approval"
 
       expect(page).to have_content("Proposal submitted")
@@ -53,7 +53,7 @@ feature "Create NCR Work orders with different expense types", :js do
       fill_in_selectized("ncr_work_order_building_number", "Test Building")
       fill_in_selectized("ncr_work_order_vendor", "Test vendor")
       fill_in "Amount", with: 123.45
-      fill_in_selectized("ncr_work_order_approving_official_email", approver.email_address)
+      fill_in_selectized("ncr_work_order_approving_official", approver.email_address)
       click_on "Submit for approval"
 
       expect(page).to have_content("Proposal submitted")

--- a/spec/features/observer_spec.rb
+++ b/spec/features/observer_spec.rb
@@ -6,7 +6,7 @@ feature "Observers" do
     login_as(proposal.requester)
 
     visit proposal_path(proposal)
-    select observer.email_address, from: "observation_user_email_address"
+    select observer.email_address, from: "observation_user_id"
     click_on "Add an Observer"
 
     expect(page).to have_content("#{observer.full_name} has been added as an observer")
@@ -19,7 +19,7 @@ feature "Observers" do
     login_as(observer1)
 
     visit proposal_path(proposal)
-    select observer2.email_address, from: "observation_user_email_address"
+    select observer2.email_address, from: "observation_user_id"
     click_on "Add an Observer"
 
     expect(page).to have_content("#{observer2.full_name} has been added as an observer")
@@ -32,7 +32,7 @@ feature "Observers" do
     login_as(proposal.requester)
 
     visit proposal_path(proposal)
-    select observer.email_address, from: "observation_user_email_address"
+    select observer.email_address, from: "observation_user_id"
     fill_in "observation_reason", with: reason
     click_on "Add an Observer"
 

--- a/spec/features/proposals/approve_spec.rb
+++ b/spec/features/proposals/approve_spec.rb
@@ -17,7 +17,7 @@ describe "Approving a proposal" do
 
   it "doesn't send multiple emails to approvers who are also observers" do
     proposal = create(:proposal, :with_approver)
-    proposal.add_observer(proposal.approvers.first.email_address)
+    proposal.add_observer(proposal.approvers.first)
 
     login_as(proposal.approvers.first)
     visit "/proposals/#{proposal.id}"

--- a/spec/helpers/ncr/work_orders_helper_spec.rb
+++ b/spec/helpers/ncr/work_orders_helper_spec.rb
@@ -3,24 +3,41 @@ describe Ncr::WorkOrdersHelper do
     it 'includes existing users' do
       expect(helper.approver_options.size).to eq(0)
       users = [create(:user, client_slug: "ncr"), create(:user, client_slug: "ncr")]
-      expect(helper.approver_options).to include(*users.map(&:email_address))
+      users.map do |user|
+        expect(helper.approver_options).to include({
+          name: user.email_address,
+          id: user.id
+        })
+      end
     end
 
     it "does not include inactive users" do
       inactive_approving_official = create(:user, :inactive, client_slug: "ncr")
       active_approving_official = create(:user, :active, client_slug: "ncr")
 
-      expect(helper.approver_options).to include(active_approving_official.email_address)
-      expect(helper.approver_options).not_to include(inactive_approving_official.email_address)
+      expect(helper.approver_options).to include({
+        name: active_approving_official.email_address,
+        id: active_approving_official.id
+      })
+      expect(helper.approver_options).not_to include({
+        name: inactive_approving_official.email_address,
+        id: inactive_approving_official.id
+      })
     end
 
     it 'sorts the results' do
-      create(:user, email_address: 'b@example.com', client_slug: "ncr")
-      create(:user, email_address: 'c@example.com', client_slug: "ncr")
-      create(:user, email_address: 'a@example.com', client_slug: "ncr")
-      create(:user, email_address: 'd@example.com', client_slug: 'gsa18f')
-      expect(helper.approver_options).to include(*%w(a@example.com b@example.com c@example.com))
-      expect(helper.approver_options).not_to include(*%w(d@example.com))
+      a_user = create(:user, email_address: 'b@example.com', client_slug: "ncr")
+      b_user = create(:user, email_address: 'c@example.com', client_slug: "ncr")
+      c_user = create(:user, email_address: 'a@example.com', client_slug: "ncr")
+      d_user = create(:user, email_address: 'd@example.com', client_slug: 'gsa18f')
+      expect(helper.approver_options).to include(
+        { name: a_user.email_address, id: a_user.id },
+        { name: b_user.email_address, id: b_user.id },
+        { name: c_user.email_address, id: c_user.id }
+        )
+      expect(helper.approver_options).not_to include(
+        { name: d_user.email_address, id: d_user.id }
+      )
     end
   end
 

--- a/spec/helpers/ncr/work_orders_helper_spec.rb
+++ b/spec/helpers/ncr/work_orders_helper_spec.rb
@@ -1,28 +1,22 @@
 describe Ncr::WorkOrdersHelper do
-  describe '#approver_options' do
+  describe '#scoped_approver_options' do
     it 'includes existing users' do
-      expect(helper.approver_options.size).to eq(0)
-      users = [create(:user, client_slug: "ncr"), create(:user, client_slug: "ncr")]
-      users.map do |user|
-        expect(helper.approver_options).to include({
-          name: user.email_address,
-          id: user.id
-        })
-      end
+      expect(helper.scoped_approver_options.size).to eq(0)
+      users = create_list(:user, 2, client_slug: "ncr")
+
+      expect(helper.scoped_approver_options).to match_array(users)
     end
 
     it "does not include inactive users" do
       inactive_approving_official = create(:user, :inactive, client_slug: "ncr")
       active_approving_official = create(:user, :active, client_slug: "ncr")
 
-      expect(helper.approver_options).to include({
-        name: active_approving_official.email_address,
-        id: active_approving_official.id
-      })
-      expect(helper.approver_options).not_to include({
-        name: inactive_approving_official.email_address,
-        id: inactive_approving_official.id
-      })
+      expect(helper.scoped_approver_options).to include(
+        active_approving_official
+      )
+      expect(helper.scoped_approver_options).not_to include(
+        inactive_approving_official
+      )
     end
 
     it 'sorts the results' do
@@ -30,13 +24,13 @@ describe Ncr::WorkOrdersHelper do
       b_user = create(:user, email_address: 'c@example.com', client_slug: "ncr")
       c_user = create(:user, email_address: 'a@example.com', client_slug: "ncr")
       d_user = create(:user, email_address: 'd@example.com', client_slug: 'gsa18f')
-      expect(helper.approver_options).to include(
-        { name: a_user.email_address, id: a_user.id },
-        { name: b_user.email_address, id: b_user.id },
-        { name: c_user.email_address, id: c_user.id }
-        )
-      expect(helper.approver_options).not_to include(
-        { name: d_user.email_address, id: d_user.id }
+      expect(helper.scoped_approver_options).to match_array([
+        a_user,
+        b_user,
+        c_user
+      ])
+      expect(helper.scoped_approver_options).not_to include(
+        d_user
       )
     end
   end

--- a/spec/mailers/observer_mailer_spec.rb
+++ b/spec/mailers/observer_mailer_spec.rb
@@ -37,7 +37,7 @@ describe ObserverMailer do
       observer = create(:user)
       adder = create(:user)
       reason = 'is an absolute ledge'
-      proposal.add_observer(observer.email_address, adder, reason)
+      proposal.add_observer(observer, adder, reason)
       observation = proposal.observations.first
 
       mail = ObserverMailer.on_observer_added(observation, reason)
@@ -51,14 +51,14 @@ describe ObserverMailer do
       "NOTIFICATION_REPLY_TO" => "replyto@example.com"
     ) do
       let(:proposal) { create(:proposal) }
-      let(:observation) { proposal.add_observer('observer1@example.com') }
-      let(:observer) { observation.user }
+      let(:observer) { create(:user) }
+      let(:observation) { proposal.add_observer(observer) }
       let(:mail) { ObserverMailer.proposal_observer_email(observer.email_address, proposal) }
 
       it_behaves_like "a proposal email"
 
       it "renders the receiver email" do
-        expect(mail.to).to eq(["observer1@example.com"])
+        expect(mail.to).to eq([observer.email_address])
       end
 
       it "uses the default sender name" do

--- a/spec/models/dispatcher_spec.rb
+++ b/spec/models/dispatcher_spec.rb
@@ -24,7 +24,8 @@ describe Dispatcher do
     end
 
     it 'sends a proposal notification email to observers' do
-      proposal.add_observer('observer1@example.com')
+      observer = create(:user)
+      proposal.add_observer(observer)
       expect(ObserverMailer).to receive_message_chain(:proposal_observer_email, :deliver_later)
       dispatcher.deliver_new_proposal_emails(proposal)
     end
@@ -32,7 +33,8 @@ describe Dispatcher do
 
   describe '#deliver_attachment_emails' do
     it "emails everyone currently involved in the proposal" do
-      proposal.add_observer("wiley-cat@example.com")
+      observer = create(:user)
+      proposal.add_observer(observer)
       dispatcher.deliver_attachment_emails(proposal)
       expect(email_recipients).to match_array(proposal.subscribers.map(&:email_address))
     end

--- a/spec/models/ncr/work_order_fields_spec.rb
+++ b/spec/models/ncr/work_order_fields_spec.rb
@@ -5,7 +5,7 @@ describe Ncr::WorkOrderFields do
 
       expect(fields).to eq([
         :amount,
-        :approving_official_email,
+        :approving_official_id,
         :building_number,
         :cl_number,
         :description,
@@ -26,7 +26,7 @@ describe Ncr::WorkOrderFields do
 
       expect(fields).to eq([
         :amount,
-        :approving_official_email,
+        :approving_official_id,
         :building_number,
         :cl_number,
         :code,
@@ -52,7 +52,6 @@ describe Ncr::WorkOrderFields do
 
       expect(fields).to eq([
          ["Amount", work_order.amount],
-         ["Approving official email", work_order.approving_official_email],
          ["Building number", work_order.building_number],
          ["CL number", work_order.cl_number],
          ["Description", work_order.description],
@@ -65,6 +64,7 @@ describe Ncr::WorkOrderFields do
          ["Vendor", work_order.vendor],
          ["Emergency", work_order.emergency],
          ["Org code", work_order.organization_code_and_name],
+         ["Approving official", work_order.approving_official.email_address],
       ])
     end
   end

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -5,6 +5,29 @@ describe Ncr::WorkOrder do
 
   describe "Associations" do
     it { should belong_to(:ncr_organization) }
+    it { should belong_to(:approving_official) }
+  end
+
+  describe "Validations" do
+    it "does not allow approving official to be changed if the first step is not actionable" do
+      work_order = create(:ncr_work_order)
+      work_order.setup_approvals_and_observers
+      approving_official_step = work_order.reload.individual_steps.first
+      approving_official_step.update(status: "approved")
+
+      work_order.approving_official = create(:user, client_slug: "ncr")
+
+      expect(work_order).not_to be_valid
+    end
+
+    it "does allow approving official to be changed if the first step is actionable" do
+      work_order = create(:ncr_work_order)
+      work_order.setup_approvals_and_observers
+
+      work_order.approving_official = create(:user, client_slug: "ncr")
+
+      expect(work_order).to be_valid
+    end
   end
 
   describe "#editable?" do

--- a/spec/models/ncr_dispatcher_spec.rb
+++ b/spec/models/ncr_dispatcher_spec.rb
@@ -62,7 +62,8 @@ describe NcrDispatcher do
     it 'does not notify observer if they are the one making the update' do
       deliveries.clear
       email = 'requester@example.com'
-      proposal.add_observer(email)
+      user = create(:user, client_slug: "ncr", email_address: email)
+      proposal.add_observer(user)
       ncr_dispatcher.on_proposal_update(proposal, proposal.observers.first)
       expect(email_recipients).to_not include(email)
     end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -142,14 +142,14 @@ describe Proposal do
     it "includes observers" do
       observer = create(:user)
       proposal = create(:proposal, requester: observer)
-      proposal.add_observer(observer.email_address)
+      proposal.add_observer(observer)
       expect(proposal.subscribers).to eq [observer]
     end
 
     it "removes duplicates" do
       requester = create(:user)
       proposal = create(:proposal, requester: requester)
-      proposal.add_observer(requester.email_address)
+      proposal.add_observer(requester)
       expect(proposal.subscribers).to eq [requester]
     end
   end
@@ -387,7 +387,7 @@ describe Proposal do
         observer_adder: nil
       ).and_return(observation_creator_double)
 
-      proposal.add_observer(observer.email_address)
+      proposal.add_observer(observer)
 
       expect(observation_creator_double).to have_received(:run)
     end

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -118,42 +118,42 @@ describe Step do
     it "won't approve Amy and Bob -- needs two branches of the OR" do
       build_approvals
       expect_any_instance_of(Proposal).not_to receive(:approve!)
-      proposal.existing_step_for(amy).approve!
-      proposal.existing_step_for(bob).approve!
+      proposal.existing_or_delegated_step_for(amy).approve!
+      proposal.existing_or_delegated_step_for(bob).approve!
     end
 
     it "will approve if Amy, Bob, and Carrie approve -- two branches of the OR" do
       build_approvals
       expect_any_instance_of(Proposal).to receive(:approve!)
-      proposal.existing_step_for(amy).approve!
-      proposal.existing_step_for(bob).approve!
-      proposal.existing_step_for(carrie).approve!
+      proposal.existing_or_delegated_step_for(amy).approve!
+      proposal.existing_or_delegated_step_for(bob).approve!
+      proposal.existing_or_delegated_step_for(carrie).approve!
     end
 
     it "won't approve Amy, Bob, Dan as Erin is also required (to complete the THEN)" do
       build_approvals
       expect_any_instance_of(Proposal).not_to receive(:approve!)
-      proposal.existing_step_for(amy).approve!
-      proposal.existing_step_for(bob).approve!
-      proposal.existing_step_for(dan).approve!
+      proposal.existing_or_delegated_step_for(amy).approve!
+      proposal.existing_or_delegated_step_for(bob).approve!
+      proposal.existing_or_delegated_step_for(dan).approve!
     end
 
     it "will approve Amy, Bob, Dan, Erin -- two branches of the OR" do
       build_approvals
       expect_any_instance_of(Proposal).to receive(:approve!)
-      proposal.existing_step_for(amy).approve!
-      proposal.existing_step_for(bob).approve!
-      proposal.existing_step_for(dan).approve!
-      proposal.existing_step_for(erin).approve!
+      proposal.existing_or_delegated_step_for(amy).approve!
+      proposal.existing_or_delegated_step_for(bob).approve!
+      proposal.existing_or_delegated_step_for(dan).approve!
+      proposal.existing_or_delegated_step_for(erin).approve!
     end
 
     it "will approve Amy, Bob, Dan, Carrie -- two branches of the OR as Dan is irrelevant" do
       build_approvals
       expect_any_instance_of(Proposal).to receive(:approve!)
-      proposal.existing_step_for(amy).approve!
-      proposal.existing_step_for(bob).approve!
-      proposal.existing_step_for(dan).approve!
-      proposal.existing_step_for(carrie).approve!
+      proposal.existing_or_delegated_step_for(amy).approve!
+      proposal.existing_or_delegated_step_for(bob).approve!
+      proposal.existing_or_delegated_step_for(dan).approve!
+      proposal.existing_or_delegated_step_for(carrie).approve!
     end
 
     def build_approvals

--- a/spec/policies/ncr/work_order_policy_spec.rb
+++ b/spec/policies/ncr/work_order_policy_spec.rb
@@ -24,7 +24,7 @@ describe Ncr::WorkOrderPolicy do
 
     it "allows an observer to edit it" do
       observer = create(:user, client_slug: "ncr")
-      proposal.add_observer(observer.email_address)
+      proposal.add_observer(observer)
       expect(subject).to permit(observer, work_order)
     end
 

--- a/spec/presenters/subscriber_list_spec.rb
+++ b/spec/presenters/subscriber_list_spec.rb
@@ -34,7 +34,7 @@ describe SubscriberList do
       triples = SubscriberList.new(proposal).triples
 
       expect {
-        proposal.add_observer(user.email_address)
+        proposal.add_observer(user)
       }.to_not change { triples }
     end
   end

--- a/spec/queries/proposal_search_query_spec.rb
+++ b/spec/queries/proposal_search_query_spec.rb
@@ -87,7 +87,7 @@ describe ProposalSearchQuery, elasticsearch: true do
 
       test_client_request2 = create(:test_client_request, project_title: "199 rolly chairs for 1600 Penn Ave")
       proposal2 = test_client_request2.proposal
-      test_client_request2.add_observer(user.email_address)
+      test_client_request2.add_observer(user)
       proposal2.reindex
 
       proposal3 = create(:proposal, id: 1600, requester: user)

--- a/spec/services/ncr/approval_manager_spec.rb
+++ b/spec/services/ncr/approval_manager_spec.rb
@@ -1,17 +1,17 @@
 describe Ncr::ApprovalManager do
   describe '#setup_approvals_and_observers' do
-    let (:ba61_tier_one_email) { Ncr::Mailboxes.ba61_tier1_budget }
-    let (:ba61_tier_two_email) { Ncr::Mailboxes.ba61_tier2_budget }
+    let (:ba61_tier_one) { Ncr::Mailboxes.ba61_tier1_budget }
+    let (:ba61_tier_two) { Ncr::Mailboxes.ba61_tier2_budget }
 
     it "creates approvers when not an emergency" do
       wo = create(:ncr_work_order, expense_type: 'BA61')
       manager = Ncr::ApprovalManager.new(wo)
       manager.setup_approvals_and_observers
       expect(wo.observations.length).to eq(0)
-      expect(wo.approvers.map(&:email_address)).to eq([
-        wo.approving_official_email,
-        ba61_tier_one_email,
-        ba61_tier_two_email
+      expect(wo.approvers).to eq([
+        wo.approving_official,
+        ba61_tier_one,
+        ba61_tier_two
       ])
       wo.reload
       expect(wo.approved?).to eq(false)
@@ -31,10 +31,10 @@ describe Ncr::ApprovalManager do
       wo = create(:ncr_work_order, expense_type: 'BA61', emergency: true)
       manager = Ncr::ApprovalManager.new(wo)
       manager.setup_approvals_and_observers
-      expect(wo.observers.map(&:email_address)).to match_array([
-        wo.approving_official_email,
-        ba61_tier_one_email,
-        ba61_tier_two_email
+      expect(wo.observers).to match_array([
+        wo.approving_official,
+        ba61_tier_one,
+        ba61_tier_two
       ].uniq)
       expect(wo.steps.length).to eq(0)
       wo.clear_association_cache
@@ -42,51 +42,54 @@ describe Ncr::ApprovalManager do
     end
 
     it "accounts for approver transitions when nothing's approved" do
+      email = "ao@example.com"
+      approving_official = create(:user, email_address: email)
       organization = create(:whsc_organization)
-      ba80_budget_email = Ncr::Mailboxes.ba80_budget
+      ba80_budget = Ncr::Mailboxes.ba80_budget
       wo = create(
         :ncr_work_order,
-        approving_official_email: "ao@example.com",
+        approving_official: approving_official,
         expense_type: "BA61",
       )
       manager = Ncr::ApprovalManager.new(wo)
       manager.setup_approvals_and_observers
-      expect(wo.approvers.map(&:email_address)).to eq [
-        "ao@example.com",
-        ba61_tier_one_email,
-        ba61_tier_two_email
+      expect(wo.approvers).to eq [
+        approving_official,
+        ba61_tier_one,
+        ba61_tier_two
       ]
       wo.update(ncr_organization: organization)
       manager.setup_approvals_and_observers
-      expect(wo.reload.approvers.map(&:email_address)).to eq [
-        "ao@example.com",
-        ba61_tier_two_email
+      expect(wo.reload.approvers).to eq [
+        approving_official,
+        ba61_tier_two
       ]
 
-      wo.approving_official_email = "ao2@example.com"
+      approving_official_2 = create(:user, email_address: "ao2@example.com")
+      wo.update(approving_official: approving_official_2)
       manager.setup_approvals_and_observers
-      expect(wo.reload.approvers.map(&:email_address)).to eq [
-        "ao2@example.com",
-        ba61_tier_two_email
+      expect(wo.reload.approvers).to eq [
+        approving_official_2,
+        ba61_tier_two
       ]
 
-      wo.approving_official_email = "ao@example.com"
+      wo.update(approving_official: approving_official)
       wo.update(expense_type: "BA80")
       manager.setup_approvals_and_observers
-      expect(wo.reload.approvers.map(&:email_address)).to eq [
-        "ao@example.com",
-        ba80_budget_email
+      expect(wo.reload.approvers).to eq [
+        approving_official,
+        ba80_budget
       ]
     end
 
     it "unsets the approval status" do
-      ba80_budget_email = Ncr::Mailboxes.ba80_budget
+      ba80_budget = Ncr::Mailboxes.ba80_budget
       wo = create(:ba80_ncr_work_order)
       manager = Ncr::ApprovalManager.new(wo)
       manager.setup_approvals_and_observers
-      expect(wo.approvers.map(&:email_address)).to eq [
-        wo.approving_official_email,
-        ba80_budget_email
+      expect(wo.approvers).to eq [
+        wo.approving_official,
+        ba80_budget
       ]
 
       wo.individual_steps.first.approve!
@@ -130,10 +133,10 @@ describe Ncr::ApprovalManager do
     end
   end
 
-  describe '#system_approver_emails' do
+  describe '#system_approvers' do
     context "for a BA61 request" do
-      let (:ba61_tier_one_email) { Ncr::Mailboxes.ba61_tier1_budget }
-      let (:ba61_tier_two_email) { Ncr::Mailboxes.ba61_tier2_budget }
+      let (:ba61_tier_one) { Ncr::Mailboxes.ba61_tier1_budget }
+      let (:ba61_tier_two) { Ncr::Mailboxes.ba61_tier2_budget }
 
       it "skips the Tier 1 budget approver for WHSC" do
         ncr_organization =  create(:whsc_organization)
@@ -143,36 +146,36 @@ describe Ncr::ApprovalManager do
           ncr_organization: ncr_organization
         )
         manager = Ncr::ApprovalManager.new(work_order)
-        expect(manager.system_approver_emails).to eq([
-          ba61_tier_two_email
+        expect(manager.system_approvers).to eq([
+          ba61_tier_two
         ])
       end
 
       it "includes the Tier 1 budget approver for an unknown organization" do
-        work_order = create(:ncr_work_order, expense_type: 'BA61')
-        _manager = Ncr::ApprovalManager.new(work_order)
-        expect(work_order.system_approver_emails).to eq([
-          ba61_tier_one_email,
-          ba61_tier_two_email
+        work_order = create(:ncr_work_order, expense_type: "BA61")
+        manager = Ncr::ApprovalManager.new(work_order)
+        expect(manager.system_approvers).to eq([
+          ba61_tier_one,
+          ba61_tier_two
         ])
       end
     end
 
     context "for a BA80 request" do
       it "uses the general budget email" do
-        ba80_budget_email = Ncr::Mailboxes.ba80_budget
+        ba80_budget = Ncr::Mailboxes.ba80_budget
         work_order = create(:ba80_ncr_work_order)
         manager = Ncr::ApprovalManager.new(work_order)
-        expect(manager.system_approver_emails).to eq([ba80_budget_email])
+        expect(manager.system_approvers).to eq([ba80_budget])
       end
 
       it "uses the OOL budget email for their org code" do
-        budget_email = Ncr::Mailboxes.ool_ba80_budget
+        budget = Ncr::Mailboxes.ool_ba80_budget
         ool_organization = create(:ool_organization)
         work_order = create(:ba80_ncr_work_order, ncr_organization: ool_organization)
 
         manager = Ncr::ApprovalManager.new(work_order)
-        expect(manager.system_approver_emails).to eq([budget_email])
+        expect(manager.system_approvers).to eq([budget])
       end
     end
   end

--- a/spec/services/proposal_update_recorder_spec.rb
+++ b/spec/services/proposal_update_recorder_spec.rb
@@ -1,15 +1,51 @@
 describe ProposalUpdateRecorder do
   describe "#run" do
-    it "adds a change comment" do
-      description = "some text"
-      work_order = create(:ncr_work_order, description: description)
+    context "attribute changed" do
+      it "adds a change comment" do
+        description = "some text"
+        work_order = create(:ncr_work_order, description: description)
 
-      work_order.description = ""
-      ProposalUpdateRecorder.new(work_order).run
+        work_order.description = ""
+        ProposalUpdateRecorder.new(work_order).run
 
-      comment = work_order.proposal.comments.last
-      expect(comment).to be_update_comment
-      expect(comment.comment_text).to eq("*Description* was changed from #{description} to *empty*")
+        comment = work_order.proposal.comments.last
+        expect(comment).to be_update_comment
+        expect(comment.comment_text).to eq("*Description* was changed from #{description} to *empty*")
+      end
+    end
+
+    context "approving official value changed" do
+      it "adds a change comment" do
+        approver = create(:user)
+        second_approver = create(:user)
+        work_order = create(:ncr_work_order, approving_official: approver)
+        work_order.approving_official = second_approver
+
+        ProposalUpdateRecorder.new(work_order).run
+
+        comment = work_order.proposal.comments.last
+        expect(comment).to be_update_comment
+        expect(comment.comment_text).to eq(
+          "*Approving official* was changed from #{approver.email_address} to #{second_approver.email_address}"
+        )
+      end
+    end
+
+    context "ncr organization changed" do
+      it "adds a change comment" do
+        org = create(:ncr_organization)
+        second_org = create(:ncr_organization)
+        work_order = create(:ncr_work_order, ncr_organization: org)
+        work_order.ncr_organization = second_org
+
+        ProposalUpdateRecorder.new(work_order).run
+
+        comment = work_order.proposal.comments.last
+        expect(comment).to be_update_comment
+        expect(comment.comment_text).to eq(
+          "*Org code* was changed from #{org.code_and_name} to #{second_org.code_and_name}"
+        )
+      end
     end
 
     it "includes extra information if modified post approval" do

--- a/spec/services/proposal_update_recorder_spec.rb
+++ b/spec/services/proposal_update_recorder_spec.rb
@@ -50,7 +50,7 @@ describe ProposalUpdateRecorder do
 
     it "attributes the update comment to someone set explicitly" do
       work_order = create(:ncr_work_order, vendor: "old")
-      modifier = create(:user)
+      modifier = create(:user, client_slug: "ncr")
       work_order.modifier = modifier
 
       work_order.vendor = "VenVenVen"
@@ -63,7 +63,7 @@ describe ProposalUpdateRecorder do
     it "does not send a comment email for the update comment to proposal listeners" do
       work_order = create(:ncr_work_order, vendor: "old")
       listener = create(:user, client_slug: "ncr")
-      work_order.proposal.add_observer(listener.email_address)
+      work_order.proposal.add_observer(listener)
 
       work_order.vendor = "VenVenVen"
 


### PR DESCRIPTION
* This enables us to more easily do validations and assign steps for NCR
  Work Orders
* This will make it easier to set up steps as belonging to a user or a
  system approver
* Step 0 of https://trello.com/c/hHfzNgSu