### PR TITLE
Move cancellation email text to I18n

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -28,7 +28,11 @@ module MailerHelper
   end
 
   def cancellation_text(proposal, reason)
-    text = "The request, #{proposal.name} (#{proposal.public_id}), has been cancelled"
+    text = t(
+      "mailer.cancellation_mailer.cancellation_email.body",
+      name: proposal.name,
+      public_id: proposal.public_id
+    )
     add_reason(text, reason)
     text + "."
   end
@@ -48,7 +52,7 @@ module MailerHelper
 
   def add_reason(text, reason)
     if reason.present?
-      text << " with given reason '#{reason}'"
+      text << t("mailer.reason", reason: reason)
     end
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -4,6 +4,7 @@ class ApplicationMailer < ActionMailer::Base
   include ProposalConversationThreading
 
   add_template_helper MailerHelper
+  add_template_helper ValueHelper
   add_template_helper ClientHelper
   add_template_helper MarkdownHelper
 

--- a/app/views/cancellation_mailer/cancellation_confirmation.html.haml
+++ b/app/views/cancellation_mailer/cancellation_confirmation.html.haml
@@ -9,5 +9,4 @@
 
 %p
   %strong
-    = link_to(t("mailer.cancellation_mailer.cancellation_confirmation.link"),
-      proposal_url(@proposal))
+    = link_to(t("mailer.proposal_link"), proposal_url(@proposal))

--- a/app/views/cancellation_mailer/cancellation_email.html.haml
+++ b/app/views/cancellation_mailer/cancellation_email.html.haml
@@ -1,9 +1,10 @@
 %div
   %p
-    Hello,
+    = t("mailer.generic_greeting")
+    ,
     %br
     = cancellation_text(@proposal, @reason)
 
 %p
   %strong
-    = link_to "View This Request", proposal_url(@proposal), {target: 'C2'}
+    = link_to(t("mailer.proposal_link"), proposal_url(@proposal))

--- a/app/views/cancellation_mailer/proposal_fiscal_cancellation.html.haml
+++ b/app/views/cancellation_mailer/proposal_fiscal_cancellation.html.haml
@@ -1,6 +1,4 @@
-All unapproved credit card funding requests from the previous fiscal year are being cancelled. 
-If the need still exists, please submit a new funding request for the current fiscal year.
-
+= t("mailer.cancellation_mailer.proposal_fiscal_cancellation.body")
 %table.reply-section
   = client_partial(@proposal.client_slug, "email_header/" + @alert_partial.to_s)
   %tr

--- a/app/views/cancellation_mailer/proposal_fiscal_cancellation.text.erb
+++ b/app/views/cancellation_mailer/proposal_fiscal_cancellation.text.erb
@@ -1,4 +1,3 @@
-All unapproved credit card funding requests from the previous fiscal year are being cancelled.
-If the need still exists, please submit a new funding request for the current fiscal year.
+<%= t("mailer.cancellation_mailer.proposal_fiscal_cancellation.body") %>
 
 <%= proposal_url(@proposal) %>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -10,7 +10,9 @@
   <%= yield %>
   <hr>
   <div id="footer" class="inset">
-    <p>Find a bug, have a recommendation, or want to provide other feedback? We'd love to <a target="_blank" href="<%= feedback_url %>">hear from you!</a></p>
+    <p>
+    <%= raw t("mailer.feedback_footer", feedback_url: feedback_url) %>
+    </p>
   </div>
 </body>
 </html>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -1,7 +1,19 @@
 en:
   mailer:
-    greeting: Hi %{name}
+    generic_greeting: Hello
+    greeting: "Hi %{name}"
+    proposal_link: "View This Request"
+    feedback_footer:
+      "Find a bug, have a recommendation, or want to provide other feedback?
+      We'd love to <a target='_blank' href=%{feedback_url}>hear from you!</a>"
+    reason: " with given reason '%{reason}'"
     cancellation_mailer:
       cancellation_confirmation:
         body: "This confirms your cancellation of this request: %{name} (%{public_id})"
-        link: "View This Request"
+      cancellation_email:
+        body: "The request, %{name} (%{public_id}), has been cancelled"
+      proposal_fiscal_cancellation:
+        body:
+          "All unapproved credit card funding requests from the previous fiscal
+          year are being cancelled.  If the need still exists, please submit a new funding
+          request for the current fiscal year."

--- a/lib/mail_previews/cancellation_mailer_preview.rb
+++ b/lib/mail_previews/cancellation_mailer_preview.rb
@@ -1,9 +1,21 @@
 class CancellationMailerPreview < ActionMailer::Preview
+  def cancellation_email
+    CancellationMailer.cancellation_email(email, proposal)
+  end
+
   def cancellation_confirmation
     CancellationMailer.cancellation_confirmation(proposal)
   end
 
+  def proposal_fiscal_cancellation
+    CancellationMailer.proposal_fiscal_cancellation(proposal)
+  end
+
   private
+
+  def email
+    "test@example.com"
+  end
 
   def proposal
     Proposal.last

--- a/spec/mailers/cancellation_mailer_spec.rb
+++ b/spec/mailers/cancellation_mailer_spec.rb
@@ -7,9 +7,7 @@ describe CancellationMailer do
 
       mail = CancellationMailer.cancellation_email(user.email_address, proposal, reason)
 
-      expect(mail.body.encoded).to include(
-        "has been cancelled with given reason '#{reason}'."
-      )
+      expect(mail.body.encoded).to include(I18n.t("mailer.reason", reason: reason))
     end
   end
 


### PR DESCRIPTION
* Add preview for all cancellation mailers
* Minor: include helper in mailer because `property_to_s` method was
  previously undefined
* Trucking along on https://trello.com/c/xvL5TN7d