### PR TITLE
Update instructions for importing user information

### DIFF
--- a/doc/import_users.md
+++ b/doc/import_users.md
@@ -38,11 +38,12 @@ rake import_users:one EMAIL=anna.smith@some.gov FIRST=Anna LAST=Smith CLIENT=gsa
 
 ## Team YAML
 
-18f has a repository of team information as YAML files. This script will
-import users from that format. Node that it overrides first name, last name,
-and client_slug if the user is already present. The script has only one
-parameter, `DIR`, which is the path to the "team" directory.
+18f has a repository of team information as YAML files found in the
+[`_data/team` directory of the Team API](https://github.com/18F/team-api.18f.gov/tree/master/_data/team).
+This script will import users from that format. Note that it overrides first
+name, last name, and client_slug if the user is already present. The script
+as only one parameter, `DIR`, which is the path to the "team" directory.
 
 ```
-rake import_users:team_yaml DIR=/path/to/data-private/team
+rake import_users:team_yaml DIR=/path/to/team-api.18f.gov/_data/team
 ```

--- a/lib/tasks/import_users.rake
+++ b/lib/tasks/import_users.rake
@@ -20,7 +20,7 @@ namespace :import_users do
   task team_yaml: :environment do
     dir = ENV['DIR']
     if !dir
-      raise "DIR must be specified. e.g. rake import_users:team_yaml DIR=/path/to/data-private/team/"
+      raise "DIR must be specified. e.g. rake import_users:team_yaml DIR=/path/to/team-api.18f.gov/_data/team"
     elsif !Dir.exists?(dir)
       raise "DIR (#{dir}) is not a directory"
     else


### PR DESCRIPTION
Hi C2 team!  We're trying to help update documentation that references the `data-private` repo as that has been deprecated in favor of the `team-api.18f.gov` repo.  I've created this PR to account for the changes needed in your documentation.

This changeset updates the instructions for importing users to reflect recent changes with the Team API.  The `data-private` repository has been deprecated and the team information is now found in the `team-api.18f.gov` repository.  This update is in reference to https://github.com/18F/team-api.18f.gov/issues/169

If you have any questions, please reach out to the practices team in the #hub Slack channel!