### PR TITLE
Add tooltip for direct pay

### DIFF
--- a/app/assets/javascripts/enable_popovers.js.coffee
+++ b/app/assets/javascripts/enable_popovers.js.coffee
@@ -4,4 +4,4 @@
 # UiHelper::popover_data_attrs()
 
 $ ->
-  $('[data-toggle="popover"]').popover()
+  $('[data-toggle="popover"]').popover({ trigger: "hover" })

--- a/app/assets/javascripts/enable_popovers.js.coffee
+++ b/app/assets/javascripts/enable_popovers.js.coffee
@@ -4,4 +4,6 @@
 # UiHelper::popover_data_attrs()
 
 $ ->
-  $('[data-toggle="popover"]').popover({ trigger: "hover" })
+  $('[data-toggle="popover"]').popover({
+    trigger: "hover"
+  })

--- a/app/views/ncr/work_orders/_form.html.haml
+++ b/app/views/ncr/work_orders/_form.html.haml
@@ -37,7 +37,8 @@
       = f.input :not_to_exceed,
         as: :radio_buttons,
         collection: [["Exact", false], ["Not to exceed", true]], label: false
-    = f.input :direct_pay
+    = f.input :direct_pay,
+        input_html: { data: popover_data_attrs("direct_pay") }
     = f.association :approving_official,
       disabled: @client_data_instance.proposal.approver_email_frozen?,
       collection: scoped_approver_options(@client_data_instance.ineligible_approvers),

--- a/app/views/ncr/work_orders/_form.html.haml
+++ b/app/views/ncr/work_orders/_form.html.haml
@@ -38,7 +38,8 @@
         as: :radio_buttons,
         collection: [["Exact", false], ["Not to exceed", true]], label: false
     = f.input :direct_pay,
-        input_html: { data: popover_data_attrs("direct_pay") }
+        label: t("simple_form.labels.ncr_work_order.direct_pay_html"),
+        label_html: { data: popover_data_attrs("direct_pay") }
     = f.association :approving_official,
       disabled: @client_data_instance.proposal.approver_email_frozen?,
       collection: scoped_approver_options(@client_data_instance.ineligible_approvers),

--- a/config/locales/helpers/en.yml
+++ b/config/locales/helpers/en.yml
@@ -9,5 +9,14 @@ en:
         create: "Add"
     popover:
       ncr_amount:
-        title: "Transaction Amount Thresholds"
+        title: "Transaction amount thresholds"
         content: "$3,500 for supplies<br>$2,500 for services<br>$2,000 for construction"
+      direct_pay:
+        title: "Using direct pay"
+        content:
+          "Direct Pay refers to the simplified Pegasys invoice payment processes associated
+          with micro purchases (as defined in the GSA Acquisition Manual (GSAM)) where
+          credit card payments are not applicable. This payment process follows
+          acquisition procedures also referred to as Certified Invoice Procedures, found
+          in GSAM Section 513.370. Specific Pegasys procedures for Direct Pay processes
+          can be found in the Pegasys Finance Users Guide section 3."

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -13,7 +13,7 @@ en:
         additional_info: "Please include any additional information you feel we need to correctly execute the purchase"
       ncr_work_order:
         approving_official: "Approving official's email address"
-        direct_pay: "I am going to be using direct pay for this transaction"
+        direct_pay_html: "I am going to be using <a href='#'>direct pay</a> for this transaction"
         emergency: "This request was an emergency and I received a verbal Notice to Proceed (NTP)"
         ncr_organization: "Org code / Service center"
     placeholders:

--- a/spec/features/ncr/work_orders/create_spec.rb
+++ b/spec/features/ncr/work_orders/create_spec.rb
@@ -43,15 +43,26 @@ feature "Creating an NCR work order", :js do
       expect(page).to_not have_content("Approving official can't be blank")
     end
 
-    scenario "doesn't show the budget fields" do
+    scenario "shows tooltip for amount field" do
       login_as(requester)
       visit new_ncr_work_order_path
 
-      focus_field "ncr_work_order_amount"
+      page.find("#ncr_work_order_amount").trigger(:mouseover)
 
       expect(page).to have_content("$3,500 for supplies")
       expect(page).to have_content("$2,500 for services")
       expect(page).to have_content("$2,000 for construction")
+    end
+
+    scenario "shows tooltip for direct pay field" do
+      login_as(requester)
+      visit new_ncr_work_order_path
+
+      page.find("#ncr_work_order_direct_pay").trigger(:mouseover)
+
+      expect(page).to have_content(
+        I18n.t("helpers.popover.direct_pay.content")
+      )
     end
 
     scenario "preserve form values on submission error" do

--- a/spec/features/ncr/work_orders/create_spec.rb
+++ b/spec/features/ncr/work_orders/create_spec.rb
@@ -58,7 +58,7 @@ feature "Creating an NCR work order", :js do
       login_as(requester)
       visit new_ncr_work_order_path
 
-      page.find("#ncr_work_order_direct_pay").trigger(:mouseover)
+      page.find("a", text: "direct pay").trigger(:mouseover)
 
       expect(page).to have_content(
         I18n.t("helpers.popover.direct_pay.content")


### PR DESCRIPTION
* Use old tooltip style
* Trigger on hover rather than click
* https://trello.com/c/s60xLbnD/28-as-a-user-i-can-read-about-direct-pay-so-that-i-know-whether-or-not-to-indicate-direct-pay-when-making-a-request

![screen shot 2016-02-25 at 11 46 04 am](https://cloud.githubusercontent.com/assets/601515/13332403/aa1e9d5c-dbb6-11e5-8852-c405b55a3ca0.png)
