### PR TITLE
search for associated records

### DIFF
--- a/app/admin/proposal.rb
+++ b/app/admin/proposal.rb
@@ -11,4 +11,14 @@ ActiveAdmin.register Proposal do
     column :requester
     actions
   end
+
+  action_item :reindex, only: [:show] do
+    link_to "Re-index", reindex_admin_proposal_path(proposal), "data-method" => :post, title: "Re-index this proposal"
+  end
+
+  member_action :reindex, method: :post do
+    resource.delay.reindex
+    flash[:alert] = "Re-index scheduled!"
+    redirect_to admin_proposal_path(resource)
+  end
 end

--- a/app/models/concerns/client_data_mixin.rb
+++ b/app/models/concerns/client_data_mixin.rb
@@ -98,7 +98,7 @@ module ClientDataMixin
     end
 
     def as_indexed_json
-      as_json({ include: self.class.foreign_key_to_method_map.values })
+      as_json(include: self.class.foreign_key_to_method_map.values)
     end
   end
 end

--- a/app/models/concerns/client_data_mixin.rb
+++ b/app/models/concerns/client_data_mixin.rb
@@ -98,7 +98,7 @@ module ClientDataMixin
     end
 
     def as_indexed_json
-      as_json
+      as_json({ include: self.class.foreign_key_to_method_map.values })
     end
   end
 end

--- a/app/models/concerns/client_data_mixin.rb
+++ b/app/models/concerns/client_data_mixin.rb
@@ -72,5 +72,9 @@ module ClientDataMixin
     def csv_fields
       self.class.column_names.sort.map { |attribute| send(attribute) }
     end
+
+    def as_indexed_json
+      as_json
+    end
   end
 end

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -31,8 +31,17 @@ module Searchable
     end
 
     def self.rebuild_index
-      __elasticsearch__.create_index! force: true
-      __elasticsearch__.import
+      stager = Elasticsearch::Rails::HA::IndexStager.new(self.to_s)
+      indexer = Elasticsearch::Rails::HA::ParallelIndexer.new(
+        klass: self.to_s,
+        idx_name: stager.tmp_index_name,
+        nprocs: ENV.fetch("NPROCS", 1),
+        batch_size: ENV.fetch("BATCH", 100),
+        force: true,
+        verbose: false,
+      )
+      indexer.run
+      stager.alias_stage_to_tmp_index && stager.promote
       __elasticsearch__.refresh_index!
     end
 

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -59,6 +59,13 @@ module Ncr
       ]
     end
 
+    def as_indexed_json
+      hashed = as_json
+      hashed[:ncr_organization] = ncr_organization.as_json
+      hashed[:approving_official] = approving_official.display_name
+      hashed
+    end
+
     def fields_for_display
       Ncr::WorkOrderFields.new(self).display
     end

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -59,13 +59,6 @@ module Ncr
       ]
     end
 
-    def as_indexed_json
-      hashed = as_json
-      hashed[:ncr_organization] = ncr_organization.as_json
-      hashed[:approving_official] = approving_official.display_name
-      hashed
-    end
-
     def fields_for_display
       Ncr::WorkOrderFields.new(self).display
     end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -68,7 +68,6 @@ class Proposal < ActiveRecord::Base
   paginates_per MAX_SEARCH_RESULTS
   DEFAULT_INDEXED = {
     include: {
-      client_data: {},
       comments: {
         include: {
           user: { methods: [:display_name], only: [:display_name] }
@@ -113,6 +112,7 @@ class Proposal < ActiveRecord::Base
 
   def as_indexed_json(params = {})
     as_json(params.reverse_merge(DEFAULT_INDEXED)).tap do |json|
+      json[:client_data] = client_data.as_indexed_json
       json[:subscribers] = subscribers.map { |user| { id: user.id, name: user.display_name } }
     end
   end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -112,7 +112,9 @@ class Proposal < ActiveRecord::Base
 
   def as_indexed_json(params = {})
     as_json(params.reverse_merge(DEFAULT_INDEXED)).tap do |json|
-      json[:client_data] = client_data.as_indexed_json
+      if client_data
+        json[:client_data] = client_data.as_indexed_json
+      end
       json[:subscribers] = subscribers.map { |user| { id: user.id, name: user.display_name } }
     end
   end

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -30,6 +30,19 @@ describe Ncr::WorkOrder do
     end
   end
 
+  describe "#as_indexed_json" do
+    it "serializes associations" do
+      whsc_org = create(:whsc_organization)
+      work_order = create(:ncr_work_order, ncr_organization: whsc_org)
+
+      indexable = work_order.as_json
+      indexable[:ncr_organization] = whsc_org.as_json
+      indexable[:approving_official] = work_order.approving_official.display_name
+
+      expect(work_order.as_indexed_json).to eq(indexable)
+    end
+  end
+
   describe "#editable?" do
     it "is true" do
       work_order = build(:ncr_work_order)

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -35,9 +35,7 @@ describe Ncr::WorkOrder do
       whsc_org = create(:whsc_organization)
       work_order = create(:ncr_work_order, ncr_organization: whsc_org)
 
-      indexable = work_order.as_json
-      indexable[:ncr_organization] = whsc_org.as_json
-      indexable[:approving_official] = work_order.approving_official.display_name
+      indexable = work_order.as_json({include: [:ncr_organization, :approving_official]})
 
       expect(work_order.as_indexed_json).to eq(indexable)
     end

--- a/spec/models/test/client_request_spec.rb
+++ b/spec/models/test/client_request_spec.rb
@@ -8,4 +8,14 @@ describe Test::ClientRequest do
     end
   end
 
+  describe "#as_indexed_json" do
+    it "serializes associations automatically" do
+      client_request = build(:test_client_request)
+
+      indexable = client_request.as_json
+      indexable[:approving_official] = client_request.approving_official.as_json
+
+      expect(client_request.as_indexed_json).to eq(indexable)
+    end
+  end
 end

--- a/spec/models/test/client_request_spec.rb
+++ b/spec/models/test/client_request_spec.rb
@@ -12,7 +12,7 @@ describe Test::ClientRequest do
     it "serializes associations automatically" do
       client_request = build(:test_client_request)
 
-      indexable = client_request.as_json({include: [:approving_official]})
+      indexable = client_request.as_json(include: [:approving_official])
 
       expect(client_request.as_indexed_json).to eq(indexable)
     end

--- a/spec/models/test/client_request_spec.rb
+++ b/spec/models/test/client_request_spec.rb
@@ -12,8 +12,7 @@ describe Test::ClientRequest do
     it "serializes associations automatically" do
       client_request = build(:test_client_request)
 
-      indexable = client_request.as_json
-      indexable[:approving_official] = client_request.approving_official.as_json
+      indexable = client_request.as_json({include: [:approving_official]})
 
       expect(client_request.as_indexed_json).to eq(indexable)
     end

--- a/spec/queries/proposal_search_query_spec.rb
+++ b/spec/queries/proposal_search_query_spec.rb
@@ -76,6 +76,30 @@ describe ProposalSearchQuery, elasticsearch: true do
           end
         end
       end
+
+      it "returns the Proposal when searching ncr_organization by name" do
+        whsc_org = create(:whsc_organization)
+        work_order = create(:ncr_work_order, ncr_organization: whsc_org)
+        work_order.proposal.reindex
+        refresh_index
+        es_execute_with_retries 3 do
+          results = ProposalSearchQuery.new(current_user: work_order.requester).execute(whsc_org.code)
+          expect(results.to_a).to eq([work_order.proposal])
+        end
+      end
+
+      it "returns the Proposal when searching approving_official by name" do
+        work_order = create(:ncr_work_order)
+        work_order.proposal.reindex
+        refresh_index
+        approving_official = work_order.approving_official
+        es_execute_with_retries 3 do
+          results = ProposalSearchQuery.new(current_user: work_order.requester).execute(approving_official.email_address)
+          expect(results.to_a).to eq([work_order.proposal])
+          results = ProposalSearchQuery.new(current_user: work_order.requester).execute(approving_official.full_name)
+          expect(results.to_a).to eq([work_order.proposal])
+        end
+      end
     end
 
     context Gsa18f::Procurement do


### PR DESCRIPTION
Now that NCR uses foreign keys rather than strings for related organization, searches for org code fail. This PR fixes that.

trello: https://trello.com/c/a6SjKfiH

Also included:

* zero downtime for rebuilding the Proposals index
* re-index a single Proposal via the /admin UI