### PR TITLE
Fix org-reassigner migration to not run AR validations

### DIFF
--- a/db/chores/ncr_work_order_organization_reassigner.rb
+++ b/db/chores/ncr_work_order_organization_reassigner.rb
@@ -6,7 +6,8 @@ module Ncr
 
         if code
           organization = Ncr::Organization.find_or_create_by(code: code)
-          work_order.update(ncr_organization: organization)
+          work_order.ncr_organization = organization
+          work_order.save(validate: false)
         end
       end
     end
@@ -16,7 +17,8 @@ module Ncr
         if work_order.ncr_organization
           organization = work_order.ncr_organization
           code = "#{organization.code} #{organization.name}"
-          work_order.update(org_code: code)
+          work_order.org_code = code
+          work_order.save(validate: false)
         end
       end
     end

--- a/spec/db/chores/ncr_work_order_organization_reassigner_spec.rb
+++ b/spec/db/chores/ncr_work_order_organization_reassigner_spec.rb
@@ -6,16 +6,18 @@ describe Ncr::WorkOrderOrganizationReassigner do
       work_order = double(org_code: "P04T0003 (192X,192M) BRANCH B")
       allow(Ncr::WorkOrder).to receive(:all).and_return([work_order])
       ncr_organization = create(:ncr_organization, code: "P04T0003", name: "(192X, 192M) BRANCH B")
-      allow(work_order).to receive(:update).with(ncr_organization: ncr_organization)
+      allow(work_order).to receive(:ncr_organization=).with(ncr_organization)
+      allow(work_order).to receive(:save).with(validate: false)
 
       Ncr::WorkOrderOrganizationReassigner.new.run
 
-      expect(work_order).to have_received(:update).with(ncr_organization: ncr_organization)
+      expect(work_order).to have_received(:ncr_organization=).with(ncr_organization)
+      expect(work_order).to have_received(:save).with(validate: false)
     end
 
     it "does not assign an organization to work orders without an org code" do
-      work_order_with_empty_string = double(org_code: "", update: true)
-      work_order_with_nil = double(org_code: nil, update: true)
+      work_order_with_empty_string = double(org_code: "", 'ncr_organization=': true)
+      work_order_with_nil = double(org_code: nil, 'ncr_organization=': true)
       allow(Ncr::WorkOrder).to receive(:all).and_return([
         work_order_with_empty_string,
         work_order_with_nil
@@ -23,8 +25,8 @@ describe Ncr::WorkOrderOrganizationReassigner do
 
       Ncr::WorkOrderOrganizationReassigner.new.run
 
-      expect(work_order_with_empty_string).not_to have_received(:update)
-      expect(work_order_with_nil).not_to have_received(:update)
+      expect(work_order_with_empty_string).not_to have_received(:ncr_organization=)
+      expect(work_order_with_nil).not_to have_received(:ncr_organization=)
     end
   end
 
@@ -34,20 +36,22 @@ describe Ncr::WorkOrderOrganizationReassigner do
       ncr_organization = create(:ncr_organization, code: "P04T0003", name: "(192X,192M) BRANCH B")
       work_order = double(ncr_organization: ncr_organization)
       allow(Ncr::WorkOrder).to receive(:all).and_return([work_order])
-      allow(work_order).to receive(:update).with(org_code: org_code)
+      allow(work_order).to receive(:org_code=).with(org_code)
+      allow(work_order).to receive(:save).with(validate: false)
 
       Ncr::WorkOrderOrganizationReassigner.new.unrun
 
-      expect(work_order).to have_received(:update).with(org_code: org_code)
+      expect(work_order).to have_received(:org_code=).with(org_code)
+      expect(work_order).to have_received(:save).with(validate: false)
     end
 
     it "does not assign an org_code for work orders without an organization" do
-      work_order = double(ncr_organization: nil, update: true)
+      work_order = double(ncr_organization: nil, 'org_code=': true)
       allow(Ncr::WorkOrder).to receive(:all).and_return([work_order])
 
       Ncr::WorkOrderOrganizationReassigner.new.unrun
 
-      expect(work_order).not_to have_received(:update)
+      expect(work_order).not_to have_received(:org_code=)
     end
   end
 end


### PR DESCRIPTION
If you were running this migration in a world where the NCR work order
approving official is not yet a relation, the validation will fail, but we
want the update to happen anyway.

Fixes https://trello.com/c/XSbWulQS/166-update-migration-to-not-fail

Paired with @jessieay 