### PR TITLE
Turn off parallel circleci

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,10 +95,6 @@ group :test do
   gem "timecop"
   gem "webmock", require: false
   gem "zonebie"
-
-  # For better test reporting in CircleCI
-  # http://blog.circleci.com/announcing-detailed-test-failure-reporting/
-  gem "rspec_junit_formatter"
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -447,9 +447,6 @@ GEM
       rspec-mocks (~> 3.4.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    rspec_junit_formatter (0.2.3)
-      builder (< 4)
-      rspec-core (>= 2, < 4, != 2.12.0)
     ruby-prof (0.15.9)
     safe_yaml (1.0.4)
     sass (3.4.21)
@@ -590,7 +587,6 @@ DEPENDENCIES
   redcarpet
   roadie-rails
   rspec-rails
-  rspec_junit_formatter
   sass-rails (>= 3.2)
   shoulda-matchers
   simple_form


### PR DESCRIPTION
This can be merged as long as we're comfortable with the slightly slower run time. No testing/measuring has been done on how this affects run time.

This is to try and address the periodic failures at CircleCI.