### PR TITLE
Updates to email 22

### DIFF
--- a/app/mailers/observer_mailer.rb
+++ b/app/mailers/observer_mailer.rb
@@ -15,17 +15,16 @@ class ObserverMailer < ApplicationMailer
     )
   end
 
-  def observer_removed_confirmation(observation)
-    @observation = observation
-    proposal = observation.proposal.decorate
+  def observer_removed_notification(observation)
+    @proposal = observation.proposal.decorate
 
-    assign_threading_headers(proposal)
+    assign_threading_headers(@proposal)
 
     mail(
       to: email_to_user(observation.user),
-      subject: subject(proposal),
+      subject: subject(@proposal),
       from: default_sender_email,
-      reply_to: reply_email(proposal)
+      reply_to: reply_email(@proposal)
     )
   end
 

--- a/app/models/dispatcher.rb
+++ b/app/models/dispatcher.rb
@@ -8,7 +8,7 @@ class Dispatcher
   end
 
   def on_observer_removed(observation)
-    ObserverMailer.observer_removed_confirmation(observation).deliver_later
+    ObserverMailer.observer_removed_notification(observation).deliver_later
   end
 
   def deliver_new_proposal_emails

--- a/app/views/observer_mailer/observer_removed_confirmation.text.erb
+++ b/app/views/observer_mailer/observer_removed_confirmation.text.erb
@@ -1,5 +1,0 @@
-<%= t("mailer.observer_mailer.observer_removed_confirmation.header") %>
-
-<%= t("mailer.observer_mailer.observer_removed_confirmation.body") %>
-
-<%= t("mailer.footer", feedback_url: feedback_url) %>

--- a/app/views/observer_mailer/observer_removed_notification.html.haml
+++ b/app/views/observer_mailer/observer_removed_notification.html.haml
@@ -1,6 +1,7 @@
 - content_for :header_icon, "emails/icon-pencil-circle.png"
-- top_head = t("mailer.observer_mailer.observer_removed_confirmation.header")
-- cta_subheader = t("mailer.observer_mailer.observer_removed_confirmation.body")
+- top_head = t("mailer.observer_mailer.observer_removed_notification.header")
+- cta_subheader = t("mailer.observer_mailer.observer_removed_notification.body_html",
+    public_id: @proposal.public_id, full_name: @proposal.requester.full_name)
 
 %table.container
   = render partial: "mail_shared/email_header/hero_text",

--- a/app/views/observer_mailer/observer_removed_notification.text.erb
+++ b/app/views/observer_mailer/observer_removed_notification.text.erb
@@ -1,0 +1,7 @@
+<%= t("mailer.observer_mailer.observer_removed_notification.header") %>
+
+<%= t("mailer.observer_mailer.observer_removed_notification.body",
+      public_id: @proposal.public_id,
+      full_name: @proposal.requester.full_name) %>
+
+<%= t("mailer.footer", feedback_url: feedback_url) %>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -128,8 +128,11 @@ en:
     observer_mailer:
       observer_added_notification:
         header: "You have been added as a subscriber to this request"
-      observer_removed_confirmation:
+      observer_removed_notification:
         header: "You have been been removed as an observer for this purchase request."
-        body: "You don't need to take any additional action."
+        body_html:
+         "No further action is required on <strong>%{public_id}</strong>
+         submitted by <strong>%{full_name}</strong>"
+        body: "No further action is required on %{public_id} submitted by %{full_name}"
       proposal_complete:
         header: "This request has been completed."

--- a/lib/mail_previews/observer_mailer_preview.rb
+++ b/lib/mail_previews/observer_mailer_preview.rb
@@ -3,8 +3,8 @@ class ObserverMailerPreview < ActionMailer::Preview
     ObserverMailer.observer_added_notification(observation, reason)
   end
 
-  def observer_removed_confirmation
-    ObserverMailer.observer_removed_confirmation(observation)
+  def observer_removed_notification
+    ObserverMailer.observer_removed_notification(observation)
   end
 
   def proposal_complete

--- a/spec/mailers/observer_mailer_spec.rb
+++ b/spec/mailers/observer_mailer_spec.rb
@@ -50,7 +50,7 @@ describe ObserverMailer do
       proposal = create(:proposal, :with_observer)
       observation = proposal.observations.first
 
-      mail = ObserverMailer.observer_removed_confirmation(observation)
+      mail = ObserverMailer.observer_removed_notification(observation)
 
       observer = observation.user
       expect(mail.to).to eq([observer.email_address])


### PR DESCRIPTION
* Rename to `observer_removed_notification` to stay consistent with
  naming of other emails ('confirmation' is for actions you yourself
  triggered)

https://trello.com/c/7venq0xj/224-22-round-3

![screen shot 2016-03-14 at 3 03 31 pm](https://cloud.githubusercontent.com/assets/601515/13761495/2f5c1060-e9f6-11e5-91cb-28695ca83f1c.png)

![screen shot 2016-03-14 at 3 03 38 pm](https://cloud.githubusercontent.com/assets/601515/13761498/32a7a4be-e9f6-11e5-9f36-7a84bc9d9801.png)

