### PR TITLE
Include next step type when proposal is "pending"

### DIFF
--- a/app/decorators/proposal_decorator.rb
+++ b/app/decorators/proposal_decorator.rb
@@ -1,6 +1,15 @@
 class ProposalDecorator < Draper::Decorator
   delegate_all
 
+  def detailed_status
+    if object.status == "pending" && object.individual_steps.any?
+      actionable_step = object.individual_steps.select { |individual_step| individual_step.status == "actionable" }.last
+      "pending #{actionable_step.decorate.noun}"
+    else
+      object.status
+    end
+  end
+
   def total_price
     client_data.try(:total_price) || ""
   end

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -3,28 +3,6 @@ module MailerHelper
     "#{date.strftime('%m/%d/%Y')} at #{date.strftime('%I:%M %P')}"
   end
 
-  def status_icon_tag(status, last_approver = false)
-    base_url = root_url.gsub(/\?.*$/, "").chomp("/")
-    bg_linear_image = base_url + image_path("bg_#{status}_status.gif")
-
-    image_tag(
-      base_url + image_path("icon-#{status}.png"),
-      class: "status-icon #{status} linear",
-      style: ("background-image: url('#{bg_linear_image}');" unless last_approver)
-    )
-  end
-
-  def generate_bookend_class(index, count)
-    case index
-    when count - 1
-      "class=last"
-    when 0
-      "class=first"
-    else
-      ""
-    end
-  end
-
   def generate_approve_url(approval)
     proposal = approval.proposal
     opts = { version: proposal.version, cch: approval.api_token.access_token }
@@ -50,4 +28,17 @@ module MailerHelper
     end
   end
 
+  def step_status_icon(step)
+    if step.status == "actionable"
+      "emails/numbers/icon-number-" + (step.position - 1).to_s + ".png"
+    elsif step.status == "pending"
+      "emails/numbers/icon-number-" + (step.position - 1).to_s + "-pending.png"
+    elsif step.status == "completed"
+      "emails/numbers/icon-completed.png"
+    end
+  end
+
+  def step_user_title(step)
+    step.decorate.role_name
+  end
 end

--- a/app/helpers/proposals_helper.rb
+++ b/app/helpers/proposals_helper.rb
@@ -11,4 +11,16 @@ module ProposalsHelper
       end
     end
   end
+
+  def status_icon_tag(status, last_approver = false)
+    base_url = root_url.gsub(/\?.*$/, "").chomp("/")
+    bg_linear_image = base_url + image_path("bg_#{status}_status.gif")
+
+    image_tag(
+      base_url + image_path("icon-#{status}.png"),
+      class: "status-icon #{status} linear",
+      style: ("background-image: url('#{bg_linear_image}');" unless last_approver)
+    )
+  end
+
 end

--- a/app/views/mail_shared/approval/_chain.html.haml
+++ b/app/views/mail_shared/approval/_chain.html.haml
@@ -1,29 +1,17 @@
 %tr{align: "center", valign: "top"}
   %td.wrapper.no-top-padding.last{align: "center", valign: "top"}
     %center
-      - @proposal.individual_steps.each_with_index do |step, index|
-        - if step.status == 'actionable'
-          - icon_name = 'emails/numbers/icon-number-' + (index + 1).to_s + '.png'
-        - elsif step.status == 'pending'
-          - icon_name = 'emails/numbers/icon-number-' + (index + 1).to_s + '-pending.png'
-        - elsif step.status == 'completed'
-          - icon_name = 'emails/numbers/icon-completed.png'
+      - @proposal.individual_steps.each do |step|
         %table.eight.columns
           %tr
             %td.two.sub-columns.last
-              = image_tag icon_name
+              = image_tag step_status_icon(step)
             %td.ten.sub-columns.no-bottom-padding
               %b
-                - case index
-                - when 0
-                  = t("mailer.proposal_mailer.generic_approval_name.step_1")
-                - when 1
-                  = t("mailer.proposal_mailer.generic_approval_name.step_2")
-                - when 2
-                  = t("mailer.proposal_mailer.generic_approval_name.step_3")
+                = step_user_title(step)
               %br/
               %span.lighter-text
                 = step.user.full_name
-              - if index != @proposal.individual_steps.count - 1
+              - if step != @proposal.individual_steps.last
                 %hr/
             %td.expander

--- a/app/views/observer_mailer/proposal_complete.html.haml
+++ b/app/views/observer_mailer/proposal_complete.html.haml
@@ -1,7 +1,8 @@
 - content_for :header_icon, "emails/icon-check-green-circle.png"
 - top_head = t("mailer.observer_mailer.proposal_complete.header")
 - proposal_link_text = t("mailer.view_request_cta")
-- cta_subheader = t("mailer.proposal_status_html", proposal_status: @proposal.status)
+- cta_subheader = t("mailer.proposal_status_html",
+  proposal_status: @proposal.detailed_status)
 
 %table.container
   = render partial: "mail_shared/email_header/hero_text",

--- a/app/views/observer_mailer/proposal_complete.text.erb
+++ b/app/views/observer_mailer/proposal_complete.text.erb
@@ -1,6 +1,6 @@
 <%= t("mailer.observer_mailer.proposal_complete.header")%>
 
-<%= t("mailer.proposal_status", proposal_status: @proposal.status) %>
+<%= t("mailer.proposal_status", proposal_status: @proposal.detailed_status) %>
 
 <%= t("mailer.view_request_cta")%>
 <%= proposal_url(@proposal) %>

--- a/app/views/proposal_mailer/emergency_proposal_created_confirmation.html.haml
+++ b/app/views/proposal_mailer/emergency_proposal_created_confirmation.html.haml
@@ -3,7 +3,8 @@
   proposal_name: @proposal.name)
 - cta_subheader = t("mailer.proposal_mailer.emergency_proposal_created_confirmation.subheader")
 - proposal_link_text = t("mailer.view_request_cta")
-- cta_subheader_foot = t("mailer.proposal_status_html", proposal_status: @proposal.status)
+- cta_subheader_foot = t("mailer.proposal_status_html",
+  proposal_status: @proposal.detailed_status)
 
 %table.container
   = render partial: "mail_shared/email_header/hero_text",

--- a/app/views/proposal_mailer/proposal_complete.html.haml
+++ b/app/views/proposal_mailer/proposal_complete.html.haml
@@ -2,7 +2,8 @@
 - top_head = t("mailer.proposal_mailer.proposal_complete.header")
 - cta_subheader = t("mailer.proposal_mailer.proposal_complete.subheader")
 - proposal_link_text = t("mailer.view_request_cta")
-- cta_subheader_foot = t("mailer.proposal_status_html", proposal_status: @proposal.status)
+- cta_subheader_foot = t("mailer.proposal_status_html",
+  proposal_status: @proposal.detailed_status)
 
 %table.container
   = render partial: "mail_shared/email_header/hero_text",

--- a/app/views/proposal_mailer/proposal_complete.text.erb
+++ b/app/views/proposal_mailer/proposal_complete.text.erb
@@ -2,7 +2,7 @@
 
 <%= t("mailer.proposal_mailer.proposal_complete.subheader") %>
 
-<%= t("mailer.proposal_status", proposal_status: @proposal.status) %>
+<%= t("mailer.proposal_status", proposal_status: @proposal.detailed_status) %>
 
 <%= t("mailer.view_request_cta") %>
 <%= proposal_url(@proposal) %>

--- a/app/views/proposal_mailer/proposal_updated_needs_re_review.html.haml
+++ b/app/views/proposal_mailer/proposal_updated_needs_re_review.html.haml
@@ -7,7 +7,8 @@
 - panel_icon = "emails/button-circle.png"
 - panel_action = t("mailer.modifier_action", full_name: @modifier.full_name)
 - panel_action_date = time_and_date(@proposal.updated_at)
-- cta_subheader_foot = t("mailer.proposal_status_html", proposal_status: @proposal.status)
+- cta_subheader_foot = t("mailer.proposal_status_html",
+  proposal_status: @proposal.detailed_status)
 
 %table.container
   = render partial: "mail_shared/email_header/hero_text",

--- a/app/views/proposal_mailer/proposal_updated_no_action_required.html.haml
+++ b/app/views/proposal_mailer/proposal_updated_no_action_required.html.haml
@@ -3,7 +3,7 @@
 - cta_subheader = t("mailer.updated_subheader_html",
   public_id: @proposal.public_id,
   requester_name: @proposal.requester.full_name,
-  proposal_status: @proposal.status)
+  proposal_status: @proposal.detailed_status)
 - proposal_link_text = t("mailer.view_request_cta")
 - panel_action = t("mailer.modifier_action", full_name: @modifier.full_name)
 - panel_icon = "emails/button-circle.png"

--- a/app/views/proposal_mailer/proposal_updated_no_action_required.text.erb
+++ b/app/views/proposal_mailer/proposal_updated_no_action_required.text.erb
@@ -3,7 +3,7 @@
 <%= t("mailer.updated_subheader",
   public_id: @proposal.public_id,
   requester_name: @proposal.requester.full_name,
-  proposal_status: @proposal.status) %>
+  proposal_status: @proposal.detailed_status) %>
 
 <%= @comment.comment_text %>
 

--- a/app/views/proposal_mailer/proposal_updated_while_step_pending.html.haml
+++ b/app/views/proposal_mailer/proposal_updated_while_step_pending.html.haml
@@ -6,7 +6,8 @@
 - panel_icon = "emails/button-circle.png"
 - panel_action_date = time_and_date(@proposal.updated_at)
 - panel_action = t("mailer.modifier_action", full_name: @modifier.full_name)
-- cta_subheader_foot = t("mailer.proposal_status_html", proposal_status: @proposal.status)
+- cta_subheader_foot = t("mailer.proposal_status_html",
+  proposal_status: @proposal.detailed_status)
 
 %table.container
   = render partial: "mail_shared/email_header/hero_text",
@@ -37,7 +38,7 @@
     locals: { subheader: cta_subheader_foot }
 
   = render partial: "mail_shared/approval/chain",
-    locals: { proposal: @proposal, status: @step.status, public_id: @proposal.public_id }
+    locals: { proposal: @proposal }
 
   = render partial: "mail_shared/call_to_action/subheader",
     locals: { subheader: "" }

--- a/app/views/step_mailer/proposal_notification.html.haml
+++ b/app/views/step_mailer/proposal_notification.html.haml
@@ -1,7 +1,8 @@
 - content_for :header_icon, "emails/icon-page-circle.png"
 - top_head = t("mailer.step_mailer.proposal_notification.header_html",
   requester_name: @proposal.requester.full_name, step_type_noun: @step.adjective)
-- cta_subheader = t("mailer.proposal_status_html", proposal_status: @proposal.status)
+- cta_subheader = t("mailer.proposal_status_html",
+  proposal_status: @proposal.detailed_status)
 
 %table.container
   = render partial: "mail_shared/email_header/hero_text",

--- a/app/views/step_mailer/proposal_notification.text.erb
+++ b/app/views/step_mailer/proposal_notification.text.erb
@@ -2,7 +2,7 @@
     requester_name: @proposal.requester.full_name,
     step_type_noun: @step.noun) %>
 
-<%= t("mailer.proposal_status", proposal_status: @proposal.status) %>
+<%= t("mailer.proposal_status", proposal_status: @proposal.detailed_status) %>
 
 <%= @step.action_name %>
 <%= generate_approve_url(@step) %>

--- a/app/views/step_mailer/step_reply_received.html.haml
+++ b/app/views/step_mailer/step_reply_received.html.haml
@@ -1,5 +1,5 @@
 - content_for :header_icon, "emails/icon-page-circle.png"
-- top_head = t("mailer.step_mailer.step_reply_received.body",
+- top_head = t("mailer.step_mailer.step_reply_received.body_html",
   full_name: @last_completed_step_user.full_name)
 
 %table.container
@@ -7,7 +7,7 @@
     locals: { text: top_head }
 
   = render partial: "mail_shared/approval/chain",
-    locals: { proposal: @proposal, status: @step.status, public_id: @proposal.public_id }
+    locals: { proposal: @proposal }
 
   = render partial: "mail_shared/call_to_action/subheader",
     locals: { subheader: "" }

--- a/app/views/step_mailer/step_reply_received.text.erb
+++ b/app/views/step_mailer/step_reply_received.text.erb
@@ -1,7 +1,5 @@
 <%= t("mailer.step_mailer.step_reply_received.body",
-      full_name: @step.user.full_name,
-      status: @step.status,
-      public_id: @proposal.public_id) %>
+      full_name: @last_completed_step_user.full_name) %>
 
 <%= t("mailer.view_request_cta") %>
 <%= proposal_url(@proposal) %>

--- a/config/locales/mailers/en.yml
+++ b/config/locales/mailers/en.yml
@@ -49,6 +49,8 @@ en:
           C2 has sent it to the next person."
       step_reply_received:
         body:
+          "%{full_name} approved your request. C2 has sent it to the next person."
+        body_html:
           "<span class='name-color'>%{full_name}</span> approved your request.
           C2 has sent it to the next person."
         details: "Please see below for more details."
@@ -66,10 +68,6 @@ en:
           you to %{step_type_noun}"
         header: "A new request submitted by %{requester_name} needs your %{step_type_noun}"
     proposal_mailer:
-      generic_approval_name:
-        step_1: "Approver"
-        step_2: "Budget Tier 1"
-        step_3: "Budget Tier 2"
       emergency_proposal_created_confirmation:
         header: "Your emergency request has been completed."
         subheader: "If the actual purchase price changes, please update the request in C2."

--- a/spec/decorators/proposal_decorator_spec.rb
+++ b/spec/decorators/proposal_decorator_spec.rb
@@ -1,4 +1,27 @@
 describe ProposalDecorator do
+  describe "#detailed_status" do
+    context "pending" do
+      it "returns 'pending [next step type]'" do
+        proposal = create(:proposal, status: "pending")
+        create(:approval_step, status: "actionable", proposal: proposal)
+
+        decorator = ProposalDecorator.new(proposal)
+
+        expect(decorator.detailed_status).to eq "pending approval"
+
+      end
+    end
+
+    context "canceled or completed" do
+      it "returns regular status" do
+        proposal = build(:proposal, status: "canceled")
+
+        decorator = ProposalDecorator.new(proposal)
+
+        expect(decorator.detailed_status).to eq "canceled"
+      end
+    end
+  end
   describe "#total_price" do
     context "client data present" do
       it "returns total price from client data" do

--- a/spec/helpers/mailer_helper_spec.rb
+++ b/spec/helpers/mailer_helper_spec.rb
@@ -25,4 +25,36 @@ describe MailerHelper do
       }.to raise_error(NoMethodError) # TODO create a more specific error
     end
   end
+
+  describe "step_status_icon" do
+    context "step is actionable" do
+      it "returns actionable icon for position" do
+        step = create(:approval_step, status: "actionable", position: 2)
+
+        icon = step_status_icon(step)
+
+        expect(icon).to eq "emails/numbers/icon-number-1.png"
+      end
+    end
+
+    context "step is pending" do
+      it "returns pending icon for step number" do
+        step = create(:approval_step, status: "pending", position: 3)
+
+        icon = step_status_icon(step)
+
+        expect(icon).to eq "emails/numbers/icon-number-2-pending.png"
+      end
+    end
+
+    context "step is completed" do
+      it "returns completed icon" do
+        step = create(:approval_step, status: "completed", position: 4)
+
+        icon = step_status_icon(step)
+
+        expect(icon).to eq "emails/numbers/icon-completed.png"
+      end
+    end
+  end
 end


### PR DESCRIPTION
* If next step is approval, status is "pending approval"
* If next step is purchase, status is "pending purchase"

Looks like this in emails:

![screen shot 2016-03-15 at 2 58 16 pm](https://cloud.githubusercontent.com/assets/601515/13795501/72e647c4-eabe-11e5-8907-6466d173d896.png)

https://trello.com/c/wSUB35wL/237-update-status-in-emails