### PR TITLE
Pass canceler to cancelation mailer methods

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -86,7 +86,7 @@ class ProposalsController < ApplicationController
     comments = "Request canceled with comments: " + params[:reason_input]
     proposal.cancel!
     proposal.comments.create!(comment_text: comments, user: current_user)
-    DispatchFinder.run(proposal).deliver_cancelation_emails(params[:reason_input])
+    DispatchFinder.run(proposal).deliver_cancelation_emails(current_user, params[:reason_input])
   end
 
   def proposal

--- a/app/mailers/cancelation_mailer.rb
+++ b/app/mailers/cancelation_mailer.rb
@@ -1,24 +1,26 @@
 class CancelationMailer < ApplicationMailer
-  def cancelation_notification(to_email, proposal, reason = nil)
+  def cancelation_notification(recipient_email: , canceler:, proposal:, reason: nil)
     @reason = reason
+    @user = canceler
     @proposal = proposal.decorate
     assign_threading_headers(@proposal)
 
     mail(
-      to: to_email,
+      to: recipient_email,
       subject: subject(@proposal),
       from: user_email_with_name(@proposal.requester),
       reply_to: reply_email(@proposal)
     )
   end
 
-  def cancelation_confirmation(proposal, reason)
+  def cancelation_confirmation(canceler:, proposal:, reason: nil)
+    @user = canceler
     @reason = reason
     @proposal = proposal.decorate
     assign_threading_headers(@proposal)
 
     mail(
-      to: proposal.requester.email_address,
+      to: @user.email_address,
       subject: subject(@proposal),
       from: default_sender_email,
       reply_to: reply_email(@proposal)

--- a/app/models/dispatcher.rb
+++ b/app/models/dispatcher.rb
@@ -29,14 +29,23 @@ class Dispatcher
     end
   end
 
-  def deliver_cancelation_emails(reason = nil)
-    cancelation_notification_recipients = active_step_users + active_observers
+  def deliver_cancelation_emails(canceler, reason = nil)
+    cancelation_notification_recipients = [proposal.requester] + active_step_users + active_observers - [canceler]
 
     cancelation_notification_recipients.each do |recipient|
-      CancelationMailer.cancelation_notification(recipient.email_address, proposal, reason).deliver_later
+      CancelationMailer.cancelation_notification(
+        recipient_email: recipient.email_address,
+        canceler: canceler,
+        proposal: proposal,
+        reason: reason
+      ).deliver_later
     end
 
-    CancelationMailer.cancelation_confirmation(proposal, reason).deliver_later
+    CancelationMailer.cancelation_confirmation(
+      canceler: canceler,
+      proposal: proposal,
+      reason: reason
+    ).deliver_later
   end
 
   def step_complete(step)

--- a/app/views/cancelation_mailer/cancelation_confirmation.html.haml
+++ b/app/views/cancelation_mailer/cancelation_confirmation.html.haml
@@ -2,7 +2,7 @@
 - top_head = t("mailer.cancelation_mailer.cancelation_confirmation.header")
 - panel_icon = "emails/button-x-circled.png"
 - panel_action = t("mailer.cancelation_mailer.cancelation_confirmation.subsection",
-  name: @proposal.requester.full_name)
+  name: @user.full_name)
 - panel_action_date = time_and_date(@proposal.updated_at)
 - panel_text = t("mailer.cancelation_mailer.cancelation_confirmation.reason", reason: @reason)
 - cta_subheader = t("mailer.cancelation_mailer.cancelation_confirmation.subheader",

--- a/app/views/cancelation_mailer/cancelation_confirmation.text.erb
+++ b/app/views/cancelation_mailer/cancelation_confirmation.text.erb
@@ -1,5 +1,8 @@
 <%= t("mailer.cancelation_mailer.cancelation_confirmation.header") %>
 
+<%= t("mailer.cancelation_mailer.cancelation_confirmation.subsection",
+      name: @user.full_name) %>
+
 <%= t("mailer.cancelation_mailer.cancelation_confirmation.reason", reason: @reason) %>
 
 <%= t("mailer.view_request_cta") %>

--- a/app/views/cancelation_mailer/cancelation_notification.html.haml
+++ b/app/views/cancelation_mailer/cancelation_notification.html.haml
@@ -1,10 +1,10 @@
 - content_for :header_icon, "emails/icon-pencil-circle.png"
 - top_head = t("mailer.cancelation_mailer.cancelation_notification.header_html",
-                name: @proposal.requester.full_name)
+  name: @user.full_name)
 - panel_icon = "emails/button-x-circled.png"
 - panel_action_date = time_and_date(@proposal.created_at)
 - panel_action = t("mailer.cancelation_mailer.cancelation_notification.subsection",
-  name: @proposal.requester.full_name)
+  name: @user.full_name)
 - panel_text = t("mailer.cancelation_mailer.cancelation_notification.reason", reason: @reason)
 - cta_subheader = t("mailer.cancelation_mailer.cancelation_notification.subheader",
   public_id: @proposal.public_id,

--- a/app/views/cancelation_mailer/cancelation_notification.text.erb
+++ b/app/views/cancelation_mailer/cancelation_notification.text.erb
@@ -1,5 +1,5 @@
 <%= t("mailer.cancelation_mailer.cancelation_notification.header",
-      name: @proposal.requester.full_name) %>
+      name: @user.full_name) %>
 
 <%= t("mailer.cancelation_mailer.cancelation_notification.subheader",
       public_id: @proposal.public_id, full_name: @proposal.requester.full_name) %>

--- a/spec/mailers/cancelation_mailer_spec.rb
+++ b/spec/mailers/cancelation_mailer_spec.rb
@@ -1,11 +1,26 @@
 describe CancelationMailer do
   describe "#cancelation_notification" do
+    let(:proposal) { create(:proposal) }
+    let(:user) { create(:user) }
+    let(:mail) { CancelationMailer.cancelation_notification(
+      recipient_email: user.email_address,
+      canceler: user,
+      proposal: proposal
+    ) }
+
+    it_behaves_like "a proposal email"
+
     it "includes the cancelation reason" do
       user = create(:user)
       proposal = create(:proposal, requester: user)
       reason = "cancelation reason"
 
-      mail = CancelationMailer.cancelation_notification(user.email_address, proposal, reason)
+      mail = CancelationMailer.cancelation_notification(
+        recipient_email: user.email_address,
+        canceler: user,
+        proposal: proposal,
+        reason: reason
+      )
 
       expect(mail.body.encoded).to include(
         I18n.t("mailer.cancelation_mailer.cancelation_notification.reason", reason: reason)
@@ -14,12 +29,25 @@ describe CancelationMailer do
   end
 
   describe "#cancelation_confirmation" do
+    let(:proposal) { create(:proposal) }
+    let(:user) { create(:user) }
+    let(:mail) { CancelationMailer.cancelation_confirmation(
+      canceler: user,
+      proposal: proposal
+    ) }
+
+    it_behaves_like "a proposal email"
+
     it "includes the cancelation reason" do
       user = create(:user)
       proposal = create(:proposal, requester: user)
       reason = "cancelation reason"
 
-      mail = CancelationMailer.cancelation_confirmation(proposal, reason)
+      mail = CancelationMailer.cancelation_confirmation(
+        canceler: user,
+        proposal: proposal,
+        reason: reason
+      )
 
       expect(mail.body.encoded).to include(
         I18n.t("mailer.cancelation_mailer.cancelation_confirmation.reason", reason: reason)


### PR DESCRIPTION
* Previously, only the requester could cancel a proposal
* Now approvers can also cancel a proposal
* So we must pass canceler to mailers to know who gets what email

https://trello.com/c/tsQSwMvz