### PR TITLE
Revert subject lines back to old version

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -18,7 +18,12 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def subject(proposal)
-    "Request #{proposal.public_id}: #{proposal.name}"
+    if proposal.client_data_type == "Ncr::WorkOrder"
+      client_data = proposal.client_data
+      %(Request #{proposal.public_id}, #{client_data.organization_code_and_name}, #{client_data.building_id} from #{proposal.requester.email_address})
+    else
+      "Request #{proposal.public_id}"
+    end
   end
 
   def email_with_name(email, name)

--- a/app/mailers/cancelation_mailer.rb
+++ b/app/mailers/cancelation_mailer.rb
@@ -38,10 +38,4 @@ class CancelationMailer < ApplicationMailer
       reply_to: reply_email(@proposal)
     )
   end
-
-  private
-
-  def subject(proposal)
-    "Request #{proposal.public_id} canceled: #{proposal.name}"
-  end
 end

--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -7,16 +7,10 @@ class CommentMailer < ApplicationMailer
     unless @comment.update_comment
       mail(
         to: to_email,
-        subject: subject(@comment, @proposal),
+        subject: subject(@proposal),
         from: user_email_with_name(comment.user),
         reply_to: reply_email(@proposal)
       )
     end
-  end
-
-  private
-
-  def subject(comment, proposal)
-    "#{comment.user.full_name} added a comment to the request: #{proposal.name}"
   end
 end

--- a/lib/mail_previews/cancelation_mailer_preview.rb
+++ b/lib/mail_previews/cancelation_mailer_preview.rb
@@ -1,10 +1,19 @@
 class CancelationMailerPreview < ActionMailer::Preview
   def cancelation_notification
-    CancelationMailer.cancelation_notification(email, proposal, reason)
+    CancelationMailer.cancelation_notification(
+      recipient_email: email,
+      cancler: user,
+      proposal: proposal,
+      reason: reason
+    )
   end
 
   def cancelation_confirmation
-    CancelationMailer.cancelation_confirmation(proposal, reason)
+    CancelationMailer.cancelation_confirmation(
+      proposal: proposal,
+      canceler: user,
+      reason: reason
+    )
   end
 
   def fiscal_cancelation_notification
@@ -17,8 +26,12 @@ class CancelationMailerPreview < ActionMailer::Preview
     "test@example.com"
   end
 
+  def user
+    User.last
+  end
+
   def reason
-    "Example reason for cancelling proposal"
+    "Example reason for canceling proposal"
   end
 
   def proposal

--- a/spec/mailers/proposal_mailer_spec.rb
+++ b/spec/mailers/proposal_mailer_spec.rb
@@ -6,10 +6,6 @@ describe ProposalMailer do
 
     it_behaves_like "a proposal email"
 
-    it "has the correct subject" do
-      expect(mail.subject).to eq("Request #{proposal.public_id}: #{proposal.name}")
-    end
-
     it "renders the receiver email" do
       expect(mail.to).to eq([proposal.requester.email_address])
     end


### PR DESCRIPTION
* Keeping as-is until further research is conducted

https://trello.com/c/4AV6FKVn/227-subject-lines-in-emails

for NCR it looks like this:

![screen shot 2016-03-16 at 12 48 25 pm](https://cloud.githubusercontent.com/assets/601515/13826524/496228fc-eb75-11e5-8c38-ae07114362b5.png)

for 18F it looks like this:

![screen shot 2016-03-16 at 12 48 50 pm](https://cloud.githubusercontent.com/assets/601515/13826542/57ffad30-eb75-11e5-9676-5f20d3e0db4d.png)

