### PR TITLE
Attachment mailer updates

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -27,6 +27,7 @@ class AttachmentsController < ApplicationController
   end
 
   protected
+
   def proposal
     @cached_proposal ||= Proposal.find(params[:proposal_id])
   end

--- a/app/decorators/attachment_decorator.rb
+++ b/app/decorators/attachment_decorator.rb
@@ -2,11 +2,17 @@ class AttachmentDecorator < Draper::Decorator
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::AssetTagHelper
   include ActionView::Helpers::UrlHelper
+  default_url_options[:host] = ::Rails.application.routes.default_url_options[:host]
+
   delegate_all
 
   def file_preview
     if file.content_type =~ /\Aimage/
-      image_tag(file.url, alt: "", class: "image-with-border")
+      image_tag(
+        object.url,
+        alt: "",
+        class: "image-with-border"
+      )
     else
       "<br><table class='button'><tr><td>#{link_text}</td></tr></table>"
     end

--- a/app/mailers/concerns/proposal_conversation_threading.rb
+++ b/app/mailers/concerns/proposal_conversation_threading.rb
@@ -2,7 +2,7 @@ module ProposalConversationThreading
   extend ActiveSupport::Concern
 
   def assign_threading_headers(proposal)
-    msg_id = "<proposal-#{proposal.id}@#{DEFAULT_URL_HOST}>"
+    msg_id = "<proposal-#{proposal.id}@#{ENV['DEFAULT_URL_HOST']}>"
     self.thread_id = msg_id
   end
 

--- a/app/models/dispatcher.rb
+++ b/app/models/dispatcher.rb
@@ -20,7 +20,8 @@ class Dispatcher
   end
 
   def deliver_attachment_emails(attachment)
-    proposal.subscribers_except_delegates.each do |user|
+    recipients = proposal.subscribers_except_delegates - [attachment.user]
+    recipients.each do |user|
       step = proposal.steps.find_by(user: user)
 
       if user_is_not_step_user?(step) || step_user_knows_about_proposal?(step)

--- a/app/services/ncr/reporter.rb
+++ b/app/services/ncr/reporter.rb
@@ -5,7 +5,7 @@ module Ncr
         controller: "proposals",
         action: "show",
         id: proposal.id,
-        host: DEFAULT_URL_HOST
+        host: ENV["DEFAULT_URL_HOST"]
       )
     end
 

--- a/app/views/attachment_mailer/new_attachment_notification.html.haml
+++ b/app/views/attachment_mailer/new_attachment_notification.html.haml
@@ -27,7 +27,9 @@
     locals: { icon: panel_icon, action: panel_action, datetime: panel_action_date}
 
   = render partial: "mail_shared/panel/row_content_image",
-    locals: { image: panel_image, image_link: proposal_url(@proposal), last: true}
+    locals: { image: panel_image,
+    image_link: proposal_url(@proposal, anchor: "files"),
+    last: true }
 
   = render partial: "mail_shared/panel/vertical_buffer"
   / End Panel Wrapper

--- a/config/initializers/env_check.rb
+++ b/config/initializers/env_check.rb
@@ -12,15 +12,3 @@ required_keys = get_keys(".env.example")
 required_keys.each do |key|
   ENV.fetch(key)
 end
-
-if ENV["HOST_URL"]
-  Rails.logger.warn("HOST_URL is deprecated – use DEFAULT_URL_HOST instead.")
-end
-
-default_url_host = ENV["DEFAULT_URL_HOST"]
-
-if default_url_host.nil? && Rails.env.production?
-  raise "Please set DEFAULT_URL_HOST"
-end
-
-DEFAULT_URL_HOST = default_url_host || ENV["HOST_URL"] || "localhost"

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -10,7 +10,7 @@ end
 
 C2::Application.config.action_mailer.default_url_options ||= {
   scheme: ENV["DEFAULT_URL_SCHEME"] || default_scheme,
-  host: DEFAULT_URL_HOST,
+  host: ENV["DEFAULT_URL_HOST"],
   port: ENV["DEFAULT_URL_PORT"] || default_port
 }
 

--- a/spec/models/dispatcher_spec.rb
+++ b/spec/models/dispatcher_spec.rb
@@ -23,6 +23,17 @@ describe Dispatcher do
       expect(email_recipients).to match_array(proposal.subscribers.map(&:email_address))
     end
 
+    it "does not email person who added attachment" do
+      proposal = create(:proposal, :with_approver, :with_observer)
+      attachment = create(:attachment, proposal: proposal, user: proposal.requester)
+
+      Dispatcher.new(proposal).deliver_attachment_emails(attachment)
+
+      expect(email_recipients).to match_array(
+        proposal.subscribers.map(&:email_address) - [proposal.requester.email_address]
+      )
+    end
+
     it "does not email pending approvers" do
       proposal = create(:proposal, :with_serial_approvers, :with_observer)
       attachment = create(:attachment, proposal: proposal)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,4 +23,5 @@ RSpec.configure do |config|
   Capybara.default_host = 'http://localhost:3000'
   OmniAuth.config.test_mode = true
   ENV["DISABLE_SANDBOX_WARNING"] = "true"
+  ENV["DEFAULT_URL_HOST"] = "example.com"
 end

--- a/spec/support/shared_examples/proposal_email.rb
+++ b/spec/support/shared_examples/proposal_email.rb
@@ -24,7 +24,7 @@ shared_examples "a proposal email" do
     mail.deliver_later
 
     %w(In-Reply-To References).each do |header|
-      expect(mail[header].value).to eq("<proposal-#{proposal.id}@#{DEFAULT_URL_HOST}>")
+      expect(mail[header].value).to eq("<proposal-#{proposal.id}@#{ENV['DEFAULT_URL_HOST']}>")
     end
   end
 


### PR DESCRIPTION
* Link to `files` anchor when user clicks attachment in email
* Do not send attachment email to person who added attachment

https://trello.com/c/oCt6aVdo
https://trello.com/c/v24zGByh