### PR TITLE
Update logic around `proposal_complete` emails

### DIFF
--- a/app/models/dispatcher.rb
+++ b/app/models/dispatcher.rb
@@ -54,10 +54,10 @@ class Dispatcher
       StepMailer.proposal_notification(next_step).deliver_later
     end
 
-    if requires_approval_notice? && proposal.pending?
+    if requires_approval_notice? && proposal.reload.pending?
       StepMailer.step_reply_received(step).deliver_later
     elsif proposal.completed?
-      active_observers.each { |observer| ObserverMailer.proposal_complete(observer, proposal) }
+      proposal.observers.each { |observer| ObserverMailer.proposal_complete(observer, proposal).deliver_later }
       ProposalMailer.proposal_complete(step.proposal).deliver_later
     end
   end
@@ -106,8 +106,6 @@ class Dispatcher
   end
 
   def next_step
-    if proposal.pending?
-      proposal.currently_awaiting_steps.first
-    end
+    proposal.currently_awaiting_steps.first
   end
 end

--- a/app/models/steps/individual.rb
+++ b/app/models/steps/individual.rb
@@ -1,5 +1,3 @@
-# Represents a single user's ability to approve, the "leaves" of an approval
-# chain
 module Steps
   class Individual < Step
     belongs_to :user

--- a/lib/mail_previews/cancelation_mailer_preview.rb
+++ b/lib/mail_previews/cancelation_mailer_preview.rb
@@ -2,7 +2,7 @@ class CancelationMailerPreview < ActionMailer::Preview
   def cancelation_notification
     CancelationMailer.cancelation_notification(
       recipient_email: email,
-      cancler: user,
+      canceler: user,
       proposal: proposal,
       reason: reason
     )

--- a/spec/features/gsa18f/procurements/approve_spec.rb
+++ b/spec/features/gsa18f/procurements/approve_spec.rb
@@ -1,5 +1,18 @@
 feature "Approve a Gsa18F procurement" do
   context "when signed in as the approver" do
+    context "last step is completed" do
+      it "sends one email to the requester" do
+        procurement.individual_steps.first.complete!
+        deliveries.clear
+
+        login_as(purchaser)
+        visit proposal_path(proposal)
+        click_on("Mark as Purchased")
+
+        expect(deliveries.length).to eq(1)
+      end
+    end
+
     it "the step execution button is correctly marked" do
       login_as(approver)
 

--- a/spec/features/proposals/approve_spec.rb
+++ b/spec/features/proposals/approve_spec.rb
@@ -38,17 +38,17 @@ describe "Approving a proposal" do
     expect(page).to have_content("You have approved #{proposal.public_id}")
   end
 
-  it "doesn't send multiple emails to approvers who are also observers" do
+  it "sends email to observers and requester when proposal is complete" do
     with_env_var("NO_WELCOME_EMAIL", "true") do
       proposal = create(:proposal, :with_approver)
       proposal.add_observer(proposal.approvers.first)
 
       login_as(proposal.approvers.first)
-      visit "/proposals/#{proposal.id}"
+      visit proposal_path(proposal)
       click_on("Approve")
 
       expect(proposal.observers.length).to eq(1)
-      expect(deliveries.length).to eq(1)
+      expect(deliveries.length).to eq(2)
     end
   end
 end


### PR DESCRIPTION
* Was not sending to NCR requester / observers because the former
  "pending" status was cached (fixed by reloading proposal)
* Was not sending to 18F for same reason.
* Was sending `step_complete` email to 18F for same reason too
* One tweak: sending email to all observers rather than
  `active_observers`

https://trello.com/c/PMcncLYA
https://trello.com/c/ri0POaQW