### PR TITLE
Send email to requester when final step is completed

### DIFF
--- a/app/models/dispatcher.rb
+++ b/app/models/dispatcher.rb
@@ -54,7 +54,7 @@ class Dispatcher
       StepMailer.proposal_notification(next_step).deliver_later
     end
 
-    if requires_approval_notice? && proposal.reload.pending?
+    if requires_approval_notice? && proposal.pending?
       StepMailer.step_reply_received(step).deliver_later
     elsif proposal.completed?
       proposal.observers.each { |observer| ObserverMailer.proposal_complete(observer, proposal).deliver_later }
@@ -106,6 +106,6 @@ class Dispatcher
   end
 
   def next_step
-    proposal.currently_awaiting_steps.first
+    proposal.reload.currently_awaiting_steps.first
   end
 end

--- a/spec/features/gsa18f/procurements/approve_spec.rb
+++ b/spec/features/gsa18f/procurements/approve_spec.rb
@@ -1,15 +1,20 @@
 feature "Approve a Gsa18F procurement" do
+  include EnvVarSpecHelper
+
   context "when signed in as the approver" do
     context "last step is completed" do
       it "sends one email to the requester" do
-        procurement.individual_steps.first.complete!
-        deliveries.clear
+        with_env_var("NO_WELCOME_EMAIL", "true") do
+          procurement.individual_steps.first.complete!
+          deliveries.clear
 
-        login_as(purchaser)
-        visit proposal_path(proposal)
-        click_on("Mark as Purchased")
+          login_as(purchaser)
+          visit proposal_path(proposal)
+          click_on("Mark as Purchased")
 
-        expect(deliveries.length).to eq(1)
+          expect(deliveries.length).to eq(1)
+          expect(deliveries.first.to).to eq([proposal.requester.email_address])
+        end
       end
     end
 

--- a/spec/features/ncr/work_orders/approve_spec.rb
+++ b/spec/features/ncr/work_orders/approve_spec.rb
@@ -1,0 +1,23 @@
+feature "Approve a NCR work order" do
+  include EnvVarSpecHelper
+
+  context "when signed in as the approver" do
+    context "last step is completed" do
+      it "sends one email to the requester" do
+        with_env_var("NO_WELCOME_EMAIL", "true") do
+          work_order = create(:ncr_work_order, :with_approvers)
+          approver = work_order.individual_steps.last.user
+          work_order.individual_steps.first.complete!
+          deliveries.clear
+
+          login_as(approver)
+          visit proposal_path(work_order.proposal)
+          click_on("Approve")
+
+          expect(deliveries.length).to eq(1)
+          expect(deliveries.first.to).to eq([work_order.proposal.requester.email_address])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Was not sending in production because `proposal` was not reloaded
* Wrote feature specs for each use case to confirm behavior
* Always good to actually send emails :)

https://trello.com/c/CP1x6c5e