### PR TITLE
Do not show "reason" text when no reason for adding observer

### DIFF
--- a/app/views/observer_mailer/observer_added_notification.html.haml
+++ b/app/views/observer_mailer/observer_added_notification.html.haml
@@ -1,6 +1,6 @@
 - content_for :header_icon, "emails/icon-page-circle.png"
 - top_head = t("mailer.observer_mailer.observer_added_notification.header" )
-- cta_subheader = t("mailer.observer_mailer.observer_added_notification.subheader", 
+- cta_subheader = t("mailer.observer_mailer.observer_added_notification.subheader",
                     reason: @reason)
 - attachment_icon = "emails/icon-clipped_page.png"
 
@@ -8,8 +8,9 @@
   = render partial: "mail_shared/email_header/hero_text",
     locals: { text: top_head, style: "no-margin-wrapper" }
 
-  = render partial: "mail_shared/call_to_action/subheader",
-    locals: { bold: "not-bold", subheader: cta_subheader, vertical: "" }
+  - if @reason.present?
+    = render partial: "mail_shared/call_to_action/subheader",
+      locals: { bold: "not-bold", subheader: cta_subheader, vertical: "" }
 
   = render partial: "mail_shared/approval/chain",
     locals: { proposal: @proposal }

--- a/app/views/observer_mailer/observer_added_notification.text.erb
+++ b/app/views/observer_mailer/observer_added_notification.text.erb
@@ -1,6 +1,9 @@
 <%= t("mailer.observer_mailer.observer_added_notification.header" ) %>
-<%= t("mailer.observer_mailer.observer_added_notification.subheader", 
-                    reason: @reason)%>
+
+<% if @reason.present? %>
+  <%= t("mailer.observer_mailer.observer_added_notification.subheader",
+        reason: @reason) %>
+<% end %>
 
 <%= t("mailer.view_request_cta") %>
 <%= proposal_url(@proposal) %>

--- a/spec/mailers/observer_mailer_spec.rb
+++ b/spec/mailers/observer_mailer_spec.rb
@@ -31,6 +31,20 @@ describe ObserverMailer do
       mail = ObserverMailer.observer_added_notification(observation, reason)
       expect(mail.body.encoded).to include(reason)
     end
+
+    it "does not include reason text if there is not one" do
+      proposal = create(:proposal)
+      observer = create(:user)
+      adder = create(:user)
+      proposal.add_observer(observer, adder, nil)
+      observation = proposal.observations.first
+
+      mail = ObserverMailer.observer_added_notification(observation, nil)
+      expect(mail.body.encoded).not_to include(
+        I18n.t("mailer.observer_mailer.observer_added_notification.subheader",
+               reason: nil)
+      )
+    end
   end
 
   describe "#observer_removed_notification" do


### PR DESCRIPTION
* Previously showed "Reason: " when no reason

https://trello.com/c/jYGT0z5J