### PR TITLE
explicitly load rask tasks within clockwork config

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -5,6 +5,8 @@ require "clockwork"
 require_relative "boot"
 require_relative "environment"
 
+C2::Application.load_tasks
+
 puts "Clockwork loaded."
 
 module Clockwork


### PR DESCRIPTION
fix bug at cloud.gov where clockwork tasks fail to execute rake tasks

![screen shot 2016-03-21 at 3 16 07 pm](https://cloud.githubusercontent.com/assets/1205061/13932900/6d0de6f4-ef78-11e5-968e-cbf58a39f3c4.png)
