### PR TITLE
Set protocol to `https` in production

### DIFF
--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,17 +1,10 @@
-# needs to be set up after DEFAULT_URL_HOST is defined in env_check
-
 if Rails.env.production?
-  default_scheme = "https"
-  default_port = nil
-else
-  default_scheme = "http"
-  default_port = 3000
+  protocol = "https"
 end
 
 C2::Application.config.action_mailer.default_url_options ||= {
-  scheme: ENV["DEFAULT_URL_SCHEME"] || default_scheme,
   host: ENV["DEFAULT_URL_HOST"],
-  port: ENV["DEFAULT_URL_PORT"] || default_port
+  protocol: protocol || "http"
 }
 
 # indicate that this is not a real request in the email subjects,
@@ -23,5 +16,6 @@ unless ENV["DISABLE_SANDBOX_WARNING"] == "true"
       mail.subject = "[TEST] " + mail.subject
     end
   end
+
   ActionMailer::Base.register_interceptor(PrefixEmailSubject)
 end


### PR DESCRIPTION
* Previous setup was adding `scheme` to URL as a query param

eg: https://cap.18f.gov/proposals/2267?scheme=https

now it just goes to an http or https url 