### PR TITLE
Use lowercase status in attachment / comment emails

### DIFF
--- a/app/decorators/proposal_decorator.rb
+++ b/app/decorators/proposal_decorator.rb
@@ -2,20 +2,15 @@ class ProposalDecorator < Draper::Decorator
   delegate_all
 
   def detailed_status
-    if object.status == "pending" && object.individual_steps.any?
-      actionable_step = object.individual_steps.select { |individual_step| individual_step.status == "actionable" }.last
-      "pending #{actionable_step.decorate.noun}"
+    if object.status == "pending" && actionable_steps.any?
+      "pending #{actionable_steps.last.decorate.noun}"
     else
       object.status
     end
   end
 
-  def display_status
-    if object.pending?
-      "Pending approval"
-    else
-      object.status.capitalize
-    end
+  def capitalized_detailed_status
+    detailed_status.capitalize
   end
 
   def total_price
@@ -57,7 +52,7 @@ class ProposalDecorator < Draper::Decorator
   end
 
   def as_csv
-    [public_id, created_at, requester.display_name, display_status, client_data.csv_fields].flatten
+    [public_id, created_at, requester.display_name, detailed_status, client_data.csv_fields].flatten
   end
 
   def fields_for_email_display
@@ -72,5 +67,11 @@ class ProposalDecorator < Draper::Decorator
     if client_data
       client_data.decorate.public_send(:top_email_field)
     end
+  end
+
+  private
+
+  def actionable_steps
+    @actionable_steps ||= object.individual_steps.actionable
   end
 end

--- a/app/views/attachment_mailer/new_attachment_notification.html.haml
+++ b/app/views/attachment_mailer/new_attachment_notification.html.haml
@@ -9,7 +9,7 @@
 - cta_subheader = t("mailer.updated_subheader_html",
   public_id: @proposal.public_id,
   requester_name: @proposal.requester.full_name,
-  proposal_status: @proposal.display_status)
+  proposal_status: @proposal.detailed_status)
 
 %table.container
   = render partial: "mail_shared/email_header/hero_text",

--- a/app/views/attachment_mailer/new_attachment_notification.text.erb
+++ b/app/views/attachment_mailer/new_attachment_notification.text.erb
@@ -4,7 +4,7 @@
 <%= t("mailer.updated_subheader",
   public_id: @proposal.public_id,
   requester_name: @proposal.requester.full_name,
-  proposal_status: @proposal.display_status) %>
+  proposal_status: @proposal.detailed_status) %>
 
 <%= t("mailer.view_request_cta") %>
 <%= proposal_url(@proposal) %>

--- a/app/views/comment_mailer/comment_added_notification.html.haml
+++ b/app/views/comment_mailer/comment_added_notification.html.haml
@@ -9,7 +9,7 @@
 - cta_subheader = t("mailer.updated_subheader_html",
   public_id: @proposal.public_id,
   requester_name: @proposal.requester.full_name,
-  proposal_status: @proposal.display_status)
+  proposal_status: @proposal.detailed_status)
 
 %table.container
   = render partial: "mail_shared/email_header/hero_text",

--- a/app/views/comment_mailer/comment_added_notification.text.erb
+++ b/app/views/comment_mailer/comment_added_notification.text.erb
@@ -4,7 +4,7 @@
 <%= t("mailer.updated_subheader",
   public_id: @proposal.public_id,
   requester_name: @proposal.requester.full_name,
-  proposal_status: @proposal.display_status) %>
+  proposal_status: @proposal.detailed_status) %>
 
 <%= @comment.comment_text %>
 

--- a/app/views/observer_mailer/proposal_complete.html.haml
+++ b/app/views/observer_mailer/proposal_complete.html.haml
@@ -2,7 +2,7 @@
 - top_head = t("mailer.observer_mailer.proposal_complete.header")
 - proposal_link_text = t("mailer.view_request_cta")
 - cta_subheader = t("mailer.proposal_status_html",
-  proposal_status: @proposal.detailed_status)
+  proposal_status: @proposal.capitalized_detailed_status)
 
 %table.container
   = render partial: "mail_shared/email_header/hero_text",

--- a/app/views/observer_mailer/proposal_complete.text.erb
+++ b/app/views/observer_mailer/proposal_complete.text.erb
@@ -1,6 +1,7 @@
 <%= t("mailer.observer_mailer.proposal_complete.header")%>
 
-<%= t("mailer.proposal_status", proposal_status: @proposal.detailed_status) %>
+<%= t("mailer.proposal_status",
+      proposal_status: @proposal.capitalized_detailed_status) %>
 
 <%= t("mailer.view_request_cta")%>
 <%= proposal_url(@proposal) %>

--- a/app/views/proposal_mailer/emergency_proposal_created_confirmation.html.haml
+++ b/app/views/proposal_mailer/emergency_proposal_created_confirmation.html.haml
@@ -4,8 +4,7 @@
 - cta_subheader = t("mailer.proposal_mailer.emergency_proposal_created_confirmation.subheader")
 - proposal_link_text = t("mailer.view_request_cta")
 - cta_subheader_foot = t("mailer.proposal_status_html",
-  proposal_status: @proposal.detailed_status)
-
+  proposal_status: @proposal.capitalized_detailed_status)
 
 %table.container
   = render partial: "mail_shared/call_to_action/subheader",

--- a/app/views/proposal_mailer/proposal_complete.html.haml
+++ b/app/views/proposal_mailer/proposal_complete.html.haml
@@ -3,7 +3,7 @@
 - cta_subheader = t("mailer.proposal_mailer.proposal_complete.subheader")
 - proposal_link_text = t("mailer.view_request_cta")
 - cta_subheader_foot = t("mailer.proposal_status_html",
-  proposal_status: @proposal.detailed_status)
+  proposal_status: @proposal.capitalized_detailed_status)
 
 %table.container
   = render partial: "mail_shared/email_header/hero_text",

--- a/app/views/proposal_mailer/proposal_complete.text.erb
+++ b/app/views/proposal_mailer/proposal_complete.text.erb
@@ -2,7 +2,8 @@
 
 <%= t("mailer.proposal_mailer.proposal_complete.subheader") %>
 
-<%= t("mailer.proposal_status", proposal_status: @proposal.detailed_status.capitalize) %>
+<%= t("mailer.proposal_status",
+      proposal_status: @proposal.capitalized_detailed_status) %>
 
 <%= t("mailer.view_request_cta") %>
 <%= proposal_url(@proposal) %>

--- a/app/views/proposal_mailer/proposal_updated_needs_re_review.html.haml
+++ b/app/views/proposal_mailer/proposal_updated_needs_re_review.html.haml
@@ -8,7 +8,7 @@
 - panel_action = t("mailer.modifier_action", full_name: @modifier.full_name)
 - panel_action_date = time_and_date(@proposal.updated_at)
 - cta_subheader_foot = t("mailer.proposal_status_html",
-  proposal_status: @proposal.detailed_status)
+  proposal_status: @proposal.capitalized_detailed_status)
 
 %table.container
   = render partial: "mail_shared/email_header/hero_text",

--- a/app/views/proposal_mailer/proposal_updated_while_step_pending.html.haml
+++ b/app/views/proposal_mailer/proposal_updated_while_step_pending.html.haml
@@ -7,7 +7,7 @@
 - panel_action_date = time_and_date(@proposal.updated_at)
 - panel_action = t("mailer.modifier_action", full_name: @modifier.full_name)
 - cta_subheader_foot = t("mailer.proposal_status_html",
-  proposal_status: @proposal.detailed_status)
+  proposal_status: @proposal.capitalized_detailed_status)
 
 %table.container
   = render partial: "mail_shared/email_header/hero_text",

--- a/app/views/step_mailer/proposal_notification.html.haml
+++ b/app/views/step_mailer/proposal_notification.html.haml
@@ -2,7 +2,7 @@
 - top_head = t("mailer.step_mailer.proposal_notification.header_html",
   requester_name: @proposal.requester.full_name, step_type_noun: @step.adjective)
 - cta_subheader = t("mailer.proposal_status_html",
-  proposal_status: @proposal.detailed_status.capitalize)
+  proposal_status: @proposal.capitalized_detailed_status)
 
 %table.container
   = render partial: "mail_shared/email_header/hero_text",

--- a/app/views/step_mailer/proposal_notification.text.erb
+++ b/app/views/step_mailer/proposal_notification.text.erb
@@ -2,7 +2,8 @@
     requester_name: @proposal.requester.full_name,
     step_type_noun: @step.noun) %>
 
-<%= t("mailer.proposal_status", proposal_status: @proposal.detailed_status) %>
+  <%= t("mailer.proposal_status",
+        proposal_status: @proposal.capitalized_detailed_status) %>
 
 <%= @step.action_name %>
 <%= generate_approve_url(@step) %>

--- a/app/views/step_mailer/step_reply_received.html.haml
+++ b/app/views/step_mailer/step_reply_received.html.haml
@@ -1,7 +1,8 @@
 - content_for :header_icon, "emails/icon-page-circle.png"
 - top_head = t("mailer.step_mailer.step_reply_received.body_html",
   full_name: @last_completed_step_user.full_name)
-- cta_subheader = t("mailer.proposal_status_html", proposal_status: @proposal.display_status)
+- cta_subheader = t("mailer.proposal_status_html",
+  proposal_status: @proposal.capitalized_detailed_status)
 
 %table.container
   = render partial: "mail_shared/email_header/hero_text",

--- a/lib/mail_previews/proposal_mailer_preview.rb
+++ b/lib/mail_previews/proposal_mailer_preview.rb
@@ -26,7 +26,7 @@ class ProposalMailerPreview < ActionMailer::Preview
   private
 
   def proposal
-    Proposal.where(client_data_type: "Gsa18f::Procurement").last
+    Proposal.where.not(individual_steps: []).last
   end
 
   def step

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -53,14 +53,14 @@ describe Step do
     end
   end
 
-  describe '#on_approved_entry' do
-    it "notified the proposal if the root gets approved" do
+  describe '#on_completed_entry' do
+    it "notified the proposal if the root gets completed" do
       expect(approval.proposal).to receive(:complete!).once
       approval.initialize!
       approval.complete!
     end
 
-    it "does not notify the proposal if a child gets approved" do
+    it "does not notify the proposal if a child gets completed" do
       proposal = create(:proposal)
       child1 = build(:approval, user: create(:user))
       child2 = build(:approval, user: create(:user))


### PR DESCRIPTION
* Remove `display_status` method from ProposalDecorator
* User `detailed_status` instead

https://trello.com/c/oFsbuwoq/266-attachment-email-status-should-be-complete-not-completed-in-header