### PR TITLE
Reference approval chain icons via http

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -31,9 +31,9 @@ module MailerHelper
 
   def step_status_icon(proposal_step)
     if proposal_step.status == "completed"
-      "icon-completed.png"
+      "emails/numbers/icon-completed.png"
     else
-      "icon-number-" + (proposal_step.position - 1).to_s + "-pending.png"
+      "emails/numbers/icon-number-" + (proposal_step.position - 1).to_s + "-pending.png"
     end
   end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -30,19 +30,6 @@ class ApplicationMailer < ActionMailer::Base
       )
   end
 
-  def add_approval_chain_attachments
-    add_inline_number_attachment("icon-completed.png")
-    add_inline_number_attachment("icon-number-1-pending.png")
-    add_inline_number_attachment("icon-number-2-pending.png")
-    add_inline_number_attachment("icon-number-3-pending.png")
-  end
-
-  def add_inline_number_attachment(file_name)
-    attachments.inline[file_name] = File.read(
-      "app/assets/images/emails/numbers/#{file_name}"
-    )
-  end
-
   def email_to_user(user)
     email_with_name(user.email_address, user.full_name)
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -19,9 +19,14 @@ class ApplicationMailer < ActionMailer::Base
     add_inline_attachment("logo-c2-blue.png")
   end
 
-  def add_proposal_attributes_icons
-    add_inline_attachment("icon-clipped_page.png")
-    add_inline_attachment("icon-speech_bubble-blue.png")
+  def add_proposal_attributes_icons(proposal)
+    if proposal.attachments.any?
+      add_inline_attachment("icon-clipped_page.png")
+    end
+
+    if proposal.comments.any?
+      add_inline_attachment("icon-speech_bubble-blue.png")
+    end
   end
 
   def add_inline_attachment(file_name)

--- a/app/mailers/observer_mailer.rb
+++ b/app/mailers/observer_mailer.rb
@@ -1,6 +1,5 @@
 class ObserverMailer < ApplicationMailer
   def observer_added_notification(observation, reason)
-    add_approval_chain_attachments
     add_proposal_attributes_icons
     add_inline_attachment("icon-page-circle.png")
     @observation = observation

--- a/app/mailers/observer_mailer.rb
+++ b/app/mailers/observer_mailer.rb
@@ -1,11 +1,11 @@
 class ObserverMailer < ApplicationMailer
   def observer_added_notification(observation, reason)
-    add_proposal_attributes_icons
+    @proposal = observation.proposal.decorate
+    add_proposal_attributes_icons(@proposal)
     add_inline_attachment("icon-page-circle.png")
     @observation = observation
     @reason = reason
     observer = observation.user
-    @proposal = observation.proposal.decorate
 
     assign_threading_headers(@proposal)
 
@@ -31,10 +31,10 @@ class ObserverMailer < ApplicationMailer
   end
 
   def proposal_complete(user, proposal)
-    add_proposal_attributes_icons
+    @proposal = proposal.decorate
+    add_proposal_attributes_icons(@proposal)
     add_inline_attachment("icon-check-green-circle.png")
     user = user
-    @proposal = proposal.decorate
 
     assign_threading_headers(@proposal)
 

--- a/app/mailers/proposal_mailer.rb
+++ b/app/mailers/proposal_mailer.rb
@@ -1,8 +1,8 @@
 class ProposalMailer < ApplicationMailer
   def emergency_proposal_created_confirmation(proposal)
-    add_proposal_attributes_icons
-    add_inline_attachment("icon-truck-circle.png")
     @proposal = proposal.decorate
+    add_proposal_attributes_icons(@proposal)
+    add_inline_attachment("icon-truck-circle.png")
     assign_threading_headers(@proposal)
 
     mail(
@@ -14,9 +14,9 @@ class ProposalMailer < ApplicationMailer
   end
 
   def proposal_complete(proposal)
-    add_inline_attachment("icon-check-green-circle.png")
-    add_proposal_attributes_icons
     @proposal = proposal.decorate
+    add_inline_attachment("icon-check-green-circle.png")
+    add_proposal_attributes_icons(@proposal)
     assign_threading_headers(@proposal)
 
     mail(
@@ -57,10 +57,10 @@ class ProposalMailer < ApplicationMailer
   end
 
   def proposal_updated_needs_re_review(user, proposal, comment)
-    add_proposal_attributes_icons
+    @proposal = proposal.decorate
+    add_proposal_attributes_icons(@proposal)
     add_inline_attachment("icon-pencil-circle.png")
     add_inline_attachment("button-circle.png")
-    @proposal = proposal.decorate
     @modifier = comment.user
     @comment = comment
     assign_threading_headers(@proposal)
@@ -74,12 +74,12 @@ class ProposalMailer < ApplicationMailer
   end
 
   def proposal_updated_while_step_pending(step, comment)
-    add_proposal_attributes_icons
+    @proposal = step.proposal.decorate
+    add_proposal_attributes_icons(@proposal)
     add_inline_attachment("icon-pencil-circle.png")
     add_inline_attachment("button-circle.png")
     @step = step.decorate
     @modifier = comment.user
-    @proposal = step.proposal.decorate
     @comment = comment
     assign_threading_headers(@proposal)
 

--- a/app/mailers/proposal_mailer.rb
+++ b/app/mailers/proposal_mailer.rb
@@ -28,7 +28,6 @@ class ProposalMailer < ApplicationMailer
   end
 
   def proposal_created_confirmation(proposal)
-    add_approval_chain_attachments
     add_inline_attachment("icon-page-circle.png")
     @proposal = proposal.decorate
     assign_threading_headers(@proposal)
@@ -58,7 +57,6 @@ class ProposalMailer < ApplicationMailer
   end
 
   def proposal_updated_needs_re_review(user, proposal, comment)
-    add_approval_chain_attachments
     add_proposal_attributes_icons
     add_inline_attachment("icon-pencil-circle.png")
     add_inline_attachment("button-circle.png")
@@ -76,7 +74,6 @@ class ProposalMailer < ApplicationMailer
   end
 
   def proposal_updated_while_step_pending(step, comment)
-    add_approval_chain_attachments
     add_proposal_attributes_icons
     add_inline_attachment("icon-pencil-circle.png")
     add_inline_attachment("button-circle.png")

--- a/app/mailers/step_mailer.rb
+++ b/app/mailers/step_mailer.rb
@@ -1,6 +1,5 @@
 class StepMailer < ApplicationMailer
   def step_reply_received(step)
-    add_approval_chain_attachments
     add_inline_attachment("icon-page-circle.png")
     @proposal = step.proposal.decorate
     assign_threading_headers(@proposal)
@@ -30,7 +29,6 @@ class StepMailer < ApplicationMailer
   end
 
   def proposal_notification(step)
-    add_approval_chain_attachments
     add_proposal_attributes_icons
     add_inline_attachment("icon-page-circle.png")
     @proposal = step.proposal.decorate

--- a/app/mailers/step_mailer.rb
+++ b/app/mailers/step_mailer.rb
@@ -29,9 +29,9 @@ class StepMailer < ApplicationMailer
   end
 
   def proposal_notification(step)
-    add_proposal_attributes_icons
-    add_inline_attachment("icon-page-circle.png")
     @proposal = step.proposal.decorate
+    add_proposal_attributes_icons(@proposal)
+    add_inline_attachment("icon-page-circle.png")
     assign_threading_headers(@proposal)
     @step = step.decorate
 

--- a/app/views/mail_shared/approval/_chain.html.haml
+++ b/app/views/mail_shared/approval/_chain.html.haml
@@ -5,7 +5,7 @@
         %table.eight.columns
           %tr
             %td.two.sub-columns.last
-              = image_tag attachments[step_status_icon(step)].try(:url)
+              = image_tag step_status_icon(step)
             %td.ten.sub-columns.no-bottom-padding
               %b
                 = t("mailer.step_number", number: step.position - 1)

--- a/spec/helpers/mailer_helper_spec.rb
+++ b/spec/helpers/mailer_helper_spec.rb
@@ -77,7 +77,7 @@ describe MailerHelper do
 
         icon = step_status_icon(step)
 
-        expect(icon).to eq "icon-number-1-pending.png"
+        expect(icon).to eq "emails/numbers/icon-number-1-pending.png"
       end
     end
 
@@ -87,7 +87,7 @@ describe MailerHelper do
 
         icon = step_status_icon(step)
 
-        expect(icon).to eq "icon-number-2-pending.png"
+        expect(icon).to eq "emails/numbers/icon-number-2-pending.png"
       end
     end
 
@@ -97,7 +97,7 @@ describe MailerHelper do
 
         icon = step_status_icon(step)
 
-        expect(icon).to eq "icon-completed.png"
+        expect(icon).to eq "emails/numbers/icon-completed.png"
       end
     end
   end


### PR DESCRIPTION
* When attach all images as inline, unused images show as attachments
* In future we can inline but need to be more sophisticated about
  logic, shouldn't just inline all images