### PR TITLE
Trigger emergency proposal confirmation when emergency

### DIFF
--- a/app/models/dispatcher.rb
+++ b/app/models/dispatcher.rb
@@ -16,7 +16,7 @@ class Dispatcher
       StepMailer.proposal_notification(step).deliver_later
     end
 
-    ProposalMailer.proposal_created_confirmation(proposal).deliver_later
+    deliver_proposal_created_confirmation
   end
 
   def deliver_attachment_emails(attachment)
@@ -107,5 +107,9 @@ class Dispatcher
 
   def next_step
     proposal.reload.currently_awaiting_steps.first
+  end
+
+  def deliver_proposal_created_confirmation
+    ProposalMailer.proposal_created_confirmation(proposal).deliver_later
   end
 end

--- a/app/models/ncr_dispatcher.rb
+++ b/app/models/ncr_dispatcher.rb
@@ -75,4 +75,12 @@ class NcrDispatcher < Dispatcher
   def step_user_already_notifier_about_proposal?(step)
     step.api_token.present?
   end
+
+  def deliver_proposal_created_confirmation
+    if proposal.client_data.emergency?
+      ProposalMailer.emergency_proposal_created_confirmation(proposal).deliver_later
+    else
+      ProposalMailer.proposal_created_confirmation(proposal).deliver_later
+    end
+  end
 end

--- a/spec/models/ncr_dispatcher_spec.rb
+++ b/spec/models/ncr_dispatcher_spec.rb
@@ -1,4 +1,36 @@
 describe NcrDispatcher do
+  describe "#deliver_new_proposal_emails" do
+    context "work order is emergency" do
+      it "sends the emergency proposal created confirmation do the requester" do
+        work_order = create(:ncr_work_order, :is_emergency)
+        proposal = work_order.proposal
+
+        allow(ProposalMailer).to receive(:emergency_proposal_created_confirmation).
+          with(proposal).
+          and_return(double(deliver_later: true))
+
+        NcrDispatcher.new(proposal).deliver_new_proposal_emails
+
+        expect(ProposalMailer).to have_received(:emergency_proposal_created_confirmation).with(proposal)
+      end
+
+      context "work order is not emergency" do
+        it "sends the regular proposal created confirmation do the requester" do
+          work_order = create(:ncr_work_order)
+          proposal = work_order.proposal
+
+          allow(ProposalMailer).to receive(:proposal_created_confirmation).
+            with(proposal).
+            and_return(double(deliver_later: true))
+
+          NcrDispatcher.new(proposal).deliver_new_proposal_emails
+
+          expect(ProposalMailer).to have_received(:proposal_created_confirmation).with(proposal)
+        end
+      end
+    end
+  end
+
   describe "#on_proposal_update" do
     context "proposal needs to be re-reviewed" do
       it "notifies pending step users" do


### PR DESCRIPTION
* We already had layout but were never triggering the email!

https://trello.com/c/YkctRfUy/289-emergency-request-email-update-layout-to-match-designs