### PR TITLE
switch from cf-blue-green to autopilot for zero downtime deploys

### DIFF
--- a/doc/production.md
+++ b/doc/production.md
@@ -34,7 +34,7 @@ organization: cap
 1. If your deploy has a destructive migration,
     * [Take a snapshot](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_CreateSnapshot.html) of [the database](https://console.aws.amazon.com/rds/home?region=us-east-1#dbinstances:).
     * Note that you may see exceptions if doing a zero-downtime deployment, as the old copies of the application are expecting the old data format.
-1. Install [cf-blue-green](https://github.com/18F/cf-blue-green) v0.2.1+.
+1. Install [autopilot](https://github.com/concourse/autopilot).
 1. Run `cf target -o cap -s general`.
 1. Deploy the application
     * If you want to do an official "release" to production, run [`./script/release`](../script/release), which will:

--- a/script/deploy
+++ b/script/deploy
@@ -9,9 +9,12 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 
-# http://stackoverflow.com/a/677212/358804
-if ! hash cf-blue-green 2>/dev/null; then
-  npm install -g cf-blue-green
+if ! hash autopilot 2>/dev/null; then
+  echo "You need to install autopilot CF plugin: https://github.com/concourse/autopilot"
+  exit 1
 fi
 
-cf-blue-green $1
+APPNAME=$1
+
+cf create-app-manifest $APPNAME
+cf zero-downtime-push $APPNAME -f ${APPNAME}_manifest.yml


### PR DESCRIPTION
tested successfully on c2-dev and c2-staging