### PR TITLE
Ensure client admins see all summaries if they have other admin roles

### DIFF
--- a/app/controllers/summary_controller.rb
+++ b/app/controllers/summary_controller.rb
@@ -27,7 +27,7 @@ class SummaryController < ApplicationController
   end
 
   def titleized_client_namespaces
-    namespaces = if current_user.client_admin?
+    namespaces = if !(current_user.gateway_admin? || current_user.admin?)
                    [current_user.client_slug]
                  else
                    Proposal.client_slugs

--- a/spec/controllers/summary_controller_spec.rb
+++ b/spec/controllers/summary_controller_spec.rb
@@ -67,6 +67,16 @@ describe SummaryController do
           expect(assigns(:summaries).length).to eq(1)
           expect(assigns(:summaries)[0].client_namespace).to eq(client_admin_user.client_slug.titleize)
         end
+
+        context "and the user is also a regular or gateway admin" do
+          it "produces a summary for each client" do
+            client_admin_user = create(:user, :client_admin, client_slug: "ncr")
+            client_admin_user.add_role(:gateway_admin)
+            login_as(client_admin_user)
+            get :index
+            expect(assigns(:summaries).map(&:client_namespace).sort).to eq(Proposal.client_slugs.sort.map(&:titleize))
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes bug where a regular or gateway admin was only seeing one summary because they were also a client admin.