### PR TITLE
Fix `urgency` display for 18F procurements

### DIFF
--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -17,6 +17,22 @@ module Gsa18f
       ]
     end
 
+    def display
+      [
+        [translated_key("product_name_and_description"), object.product_name_and_description],
+        [translated_key("purchase_type"), object.purchase_type],
+        [translated_key("justification"), object.justification],
+        [translated_key("date_requested"), object.date_requested],
+        [translated_key("quantity"), object.quantity],
+        [translated_key("cost_per_unit"), object.cost_per_unit],
+        [translated_key("total_price"), object.total_price],
+        [translated_key("office"), object.office],
+        [translated_key("urgency"), object.urgency_string],
+        [translated_key("link_to_product"), object.link_to_product],
+        [translated_key("additional_info"), object.additional_info]
+      ] + recurring_fields
+    end
+
     def top_email_field
     end
 
@@ -24,6 +40,17 @@ module Gsa18f
 
     def translated_key(key)
       I18n.t("decorators.gsa18f/procurement.#{key}")
+    end
+
+    def recurring_fields
+      if recurring
+        [
+          [translated_key("recurring_interval"), object.recurring_interval],
+          [translated_key("recurring_length"), object.recurring_length]
+        ]
+      else
+        []
+      end
     end
   end
 end

--- a/app/decorators/ncr/work_order_decorator.rb
+++ b/app/decorators/ncr/work_order_decorator.rb
@@ -21,6 +21,16 @@ module Ncr
       end
     end
 
+    def display
+      if object.ba80?
+        base_fields + [rwa_field, work_order_ticket_number]
+      elsif object.ba61?
+        base_fields + [emergency_field]
+      else
+        base_fields
+      end
+    end
+
     def top_email_field
       object.description
     end
@@ -62,7 +72,25 @@ module Ncr
         [translated_key("vendor"), object.vendor],
         [translated_key("soc_code"), object.soc_code],
         [translated_key("building_number"), object.building_number],
-        [translated_key("org_code"), object.organization_code_and_name]
+        [translated_key("org_code"), object.organization_code_and_name],
+        [direct_pay_field]
+      ]
+    end
+
+    def base_fields
+      [
+        [translated_key("project_title"), object.project_title],
+        [translated_key("description"), object.description],
+        [translated_key("approving_official"), object.approving_official],
+        [amount_and_not_to_exceed, object.amount],
+        [translated_key("building_number"), object.building_number],
+        [translated_key("cl_number"), object.cl_number],
+        [translated_key("expense_type"), object.expense_type],
+        [translated_key("function_code"), object.function_code],
+        [translated_key("vendor"), object.vendor],
+        [translated_key("soc_code"), object.soc_code],
+        [translated_key("org_code"), object.organization_code_and_name],
+        direct_pay_field
       ]
     end
 
@@ -72,6 +100,10 @@ module Ncr
 
     def work_order_ticket_number
       [translated_key("code"), object.code]
+    end
+
+    def emergency_field
+      [translated_key("emergency"), object.emergency]
     end
 
     def direct_pay_field

--- a/app/decorators/proposal_decorator.rb
+++ b/app/decorators/proposal_decorator.rb
@@ -83,9 +83,17 @@ class ProposalDecorator < Draper::Decorator
     [public_id, created_at, requester.display_name, detailed_status, final_completed_date, total_completion_days, client_data.csv_fields].flatten
   end
 
+  def fields_for_display
+    if client_data
+      client_data.decorate.display
+    else
+      []
+    end
+  end
+
   def fields_for_email_display
     if client_data
-      client_data.decorate.public_send(:email_display)
+      client_data.decorate.email_display
     else
       []
     end
@@ -93,7 +101,7 @@ class ProposalDecorator < Draper::Decorator
 
   def top_email_field
     if client_data
-      client_data.decorate.public_send(:top_email_field)
+      client_data.decorate.top_email_field
     end
   end
 

--- a/app/models/gsa18f/procurement_fields.rb
+++ b/app/models/gsa18f/procurement_fields.rb
@@ -14,10 +14,6 @@ module Gsa18f
       fields
     end
 
-    def display
-      attributes_for_view.push(["Total Price", procurement.total_price])
-    end
-
     private
 
     attr_reader :procurement
@@ -35,12 +31,6 @@ module Gsa18f
         :quantity,
         :urgency,
       ]
-    end
-
-    def attributes_for_view
-      relevant(procurement.recurring).map do |attribute|
-        [Gsa18f::Procurement.human_attribute_name(attribute), procurement.send(attribute)]
-      end
     end
   end
 end

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -124,7 +124,11 @@ module Ncr
     end
 
     def ba80?
-      self.expense_type == "BA80"
+      expense_type == "BA80"
+    end
+
+    def ba61?
+      expense_type == "BA61"
     end
 
     def not_ba60?

--- a/app/models/ncr/work_order_fields.rb
+++ b/app/models/ncr/work_order_fields.rb
@@ -16,13 +16,6 @@ module Ncr
       fields
     end
 
-    def display
-      attributes_for_view.push(
-        ["Org code", work_order.organization_code_and_name],
-        ["Approving official", work_order.approving_official.try(:email_address)]
-      )
-    end
-
     private
 
     attr_reader :work_order
@@ -43,16 +36,6 @@ module Ncr
         :soc_code,
         :vendor,
       ]
-    end
-
-    def attributes_for_view
-      attributes = relevant(work_order.expense_type) - [:ncr_organization_id, :approving_official_id]
-      attributes.map do |attribute|
-        [
-          Ncr::WorkOrder.human_attribute_name(attribute),
-          work_order.send(attribute)
-        ]
-      end
     end
   end
 end

--- a/config/locales/decorators/en.yml
+++ b/config/locales/decorators/en.yml
@@ -33,7 +33,13 @@ en:
       quantity: "Quantity"
       total_price: "Total Price"
       urgency: "Urgency"
+      product_name_and_description: "Product name and descripton"
+      recurring_interval: "Recurring interval"
+      recurring_length: "Recurring length"
     ncr/work_order:
+      project_title: "Project title"
+      description: "Description"
+      approving_official: "Approving official"
       amount: "Amount"
       building_number: "Building Number"
       cl_number: "CL#"

--- a/spec/models/gsa18f/procurement_fields_spec.rb
+++ b/spec/models/gsa18f/procurement_fields_spec.rb
@@ -14,26 +14,4 @@ describe Gsa18f::ProcurementFields do
       expect(fields).not_to include(:recurring_length)
     end
   end
-
-  describe "#display" do
-    it "returns relevant fields for the procurement passed in, plus total price" do
-      procurement = build(:gsa18f_procurement)
-
-      fields = Gsa18f::ProcurementFields.new(procurement).display
-
-      expect(fields).to eq([
-        ["Additional info", procurement.additional_info],
-        ["Cost per unit", procurement.cost_per_unit],
-        ["Date requested", procurement.date_requested],
-        ["Justification", procurement.justification],
-        ["Link to product", procurement.link_to_product],
-        ["Office", procurement.office],
-        ["Product name and description", procurement.product_name_and_description],
-        ["Purchase type", procurement.purchase_type],
-        ["Quantity", procurement.quantity],
-        ["Urgency", procurement.urgency],
-        ["Total Price", procurement.total_price]
-      ])
-    end
-  end
 end

--- a/spec/models/ncr/work_order_fields_spec.rb
+++ b/spec/models/ncr/work_order_fields_spec.rb
@@ -43,29 +43,4 @@ describe Ncr::WorkOrderFields do
       ])
     end
   end
-
-  describe "#display" do
-    it "returns relevant fields for the work order passed in" do
-      work_order = build(:ncr_work_order, expense_type: "BA61")
-
-      fields = Ncr::WorkOrderFields.new(work_order).display
-
-      expect(fields).to eq([
-         ["Amount", work_order.amount],
-         ["Building number", work_order.building_number],
-         ["CL number", work_order.cl_number],
-         ["Description", work_order.description],
-         ["Direct pay", work_order.direct_pay],
-         ["Expense type", work_order.expense_type],
-         ["Function code", work_order.function_code],
-         ["Not to exceed", work_order.not_to_exceed],
-         ["Project title", work_order.project_title],
-         ["Object field / SOC code", work_order.soc_code],
-         ["Vendor", work_order.vendor],
-         ["Emergency", work_order.emergency],
-         ["Org code", work_order.organization_code_and_name],
-         ["Approving official", work_order.approving_official.email_address],
-      ])
-    end
-  end
 end


### PR DESCRIPTION
* Was showing as integer rather than string
* Move logic from model -> decorator

![screen shot 2016-03-24 at 3 25 59 pm](https://cloud.githubusercontent.com/assets/601515/14033086/bc9209d6-f1d4-11e5-809b-249ec1c528cf.png)


https://trello.com/c/YEbcYtjo/255-18f-urgency-showing-as-integer-not-string