### PR TITLE
revert P112xxxx org code match for ba_6x_tier1_team logic

### DIFF
--- a/app/models/ncr/organization.rb
+++ b/app/models/ncr/organization.rb
@@ -29,7 +29,7 @@ module Ncr
     end
 
     def ba_6x_tier1_team?
-      code.match(/^P11[1247ACJTZ]....$/)
+      code.match(/^P11[147ACJTZ]....$/)
     end
   end
 end

--- a/spec/models/ncr/work_order_spec.rb
+++ b/spec/models/ncr/work_order_spec.rb
@@ -72,7 +72,7 @@ describe Ncr::WorkOrder do
 
   describe "#ba_6x_tier1_team?" do
     it "is true for whitelist of organizations" do
-      org_letters = %w( 1 2 4 7 A C J T Z )
+      org_letters = %w( 1 4 7 A C J T Z )
       org_letters.each do |org_letter|
         org_code = "P11#{org_letter}XXXX"
         ncr_org = build(:ncr_organization, code: org_code)

--- a/spec/services/ncr/approval_manager_spec.rb
+++ b/spec/services/ncr/approval_manager_spec.rb
@@ -177,7 +177,7 @@ describe Ncr::ApprovalManager do
 
     context "for a BA60 or BA61 request" do
       it "uses BA61 tier1 team approver when org code matches" do
-        org_letters = %w( 7 J 4 T 1 A C Z )
+        org_letters = %w( 1 4 7 A C J T Z )
         org_letters.each do |org_letter|
           org_code = "P11#{org_letter}XXXX"
           ncr_org = create(:ncr_organization, code: org_code)


### PR DESCRIPTION
related trello cards:

https://trello.com/c/5F3tGv0X/301-clarify-ncr-ba61-budgetteam-routing
reverts --> https://trello.com/c/4yAps2bL/241-budget-routing-request-any-request-with-a-code-with-p112xxxx-configuration
https://trello.com/c/FJLK6vYZ/118-budget-routing-request

see ticket https://18f.uservoice.com/admin/tickets/146 for original history