### PR TITLE
Admin tests

### DIFF
--- a/app/admin/proposal.rb
+++ b/app/admin/proposal.rb
@@ -41,10 +41,6 @@ ActiveAdmin.register Proposal do
     link_to "Re-index", reindex_admin_proposal_path(proposal), "data-method" => :post, title: "Re-index this proposal"
   end
 
-  action_item :restart, only: [:show] do
-    link_to "Restart", restart_admin_proposal_path(proposal), "data-method" => :post, title: "Re-start the steps for this proposal"
-  end
-
   action_item :fully_complete, only: [:show] do
     link_to "Complete", fully_complete_admin_proposal_path(proposal), "data-method" => :post, title: "Fully complete this proposal"
   end
@@ -52,12 +48,6 @@ ActiveAdmin.register Proposal do
   member_action :reindex, method: :post do
     resource.delay.reindex
     flash[:alert] = "Re-index scheduled!"
-    redirect_to admin_proposal_path(resource)
-  end
-
-  member_action :restart, method: :post do
-    resource.restart
-    flash[:alert] = "Restarted!"
     redirect_to admin_proposal_path(resource)
   end
 

--- a/app/admin/step.rb
+++ b/app/admin/step.rb
@@ -18,6 +18,29 @@ ActiveAdmin.register Step do
     actions
   end
 
+  # make sure side effects are triggered
+  controller do
+    def update
+      super
+      if params.require(:step)[:status]
+        update_step_via_status
+      end
+    end
+
+    def update_step_via_status
+      step_params = params.require(:step)
+      step = resource
+      if step_params[:status] == "completed"
+        if step_params[:completer_id].empty?
+          step.update_attributes!(completer: current_user)
+        end
+        if !step.completed_at
+          step.update_attributes!(completed_at: Time.current)
+        end
+      end
+    end
+  end
+
   # /:id/edit page
   form do |f|
     f.inputs "Step" do

--- a/app/admin/step.rb
+++ b/app/admin/step.rb
@@ -34,7 +34,7 @@ ActiveAdmin.register Step do
         if step_params[:completer_id].empty?
           step.update_attributes!(completer: current_user)
         end
-        if !step.completed_at
+        unless step.completed_at
           step.update_attributes!(completed_at: Time.current)
         end
       end

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -81,6 +81,22 @@ describe "admin" do
     expect(proposal).to be_completed
   end
 
+  it "triggers no actions on Step edit" do
+    user = login_as_admin_user
+    proposal = create(:proposal, :with_serial_approvers)
+    first_step = proposal.individual_steps.first
+
+    deliveries.clear
+    visit edit_admin_step_path(first_step)
+    expect(page).to have_content("actionable")
+
+    select "completed", from: "step[status]"
+    click_button "Update Approval"
+
+    expect(page).to have_content("Approval was successfully updated")
+    expect(deliveries.count).to eq(0)
+  end
+
   def login_as_admin_user
     user = create(:user, :admin)
     login_as(user)

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -1,8 +1,6 @@
 describe "admin" do
   it "does not allow Delete of Users" do
-    user = create(:user)
-    user.add_role("admin")
-    login_as(user)
+    user = login_as_admin_user
 
     visit admin_users_path
 
@@ -10,12 +8,10 @@ describe "admin" do
   end
 
   it "does not allow editing of user delegates" do
-    user = create(:user)
-    user.add_role("admin")
+    user = login_as_admin_user
     other_user = create(:user)
     user_delegate = create(:user_delegate, assigner: user, assignee: other_user)
 
-    login_as(user)
     visit edit_admin_user_path(user)
     visit admin_user_delegate_path(user_delegate)
 
@@ -23,10 +19,8 @@ describe "admin" do
   end
 
   it "does not allow delete of proposals" do
-    user = create(:user)
-    user.add_role("admin")
+    user = login_as_admin_user
     _proposal = create(:proposal)
-    login_as(user)
 
     visit admin_proposals_path
 
@@ -34,10 +28,8 @@ describe "admin" do
   end
 
   it "does not allow edit of proposals" do
-    user = create(:user)
-    user.add_role("admin")
+    user = login_as_admin_user
     _proposal = create(:proposal)
-    login_as(user)
 
     visit admin_proposals_path
 
@@ -45,10 +37,8 @@ describe "admin" do
   end
 
   it "shows user.display_name when viewing User records" do
-    user = create(:user)
-    user.add_role("admin")
+    user = login_as_admin_user
     proposal = create(:proposal, requester: user)
-    login_as(user)
 
     visit admin_proposals_path
 
@@ -56,8 +46,7 @@ describe "admin" do
   end
 
   it "contains reindex button link" do
-    user = create(:user, :admin)
-    login_as(user)
+    user = login_as_admin_user
 
     visit admin_dashboard_path
 
@@ -65,9 +54,7 @@ describe "admin" do
   end
 
   it "creates new User" do
-    user = create(:user)
-    user.add_role("admin")
-    login_as(user)
+    user = login_as_admin_user
 
     visit new_admin_user_path
 
@@ -79,5 +66,24 @@ describe "admin" do
     click_button "Create User"
 
     expect(page).to have_content("test user <testuser@example.com>")
+  end
+
+  it "triggers actions on Complete button click" do
+    user = login_as_admin_user
+    proposal = create(:proposal, :with_serial_approvers)
+
+    deliveries.clear
+    visit admin_proposal_path(proposal)
+    click_link "Complete"
+
+    expect(deliveries.count).to eq(3)
+    proposal.reload
+    expect(proposal).to be_completed
+  end
+
+  def login_as_admin_user
+    user = create(:user, :admin)
+    login_as(user)
+    user
   end
 end

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -81,7 +81,7 @@ describe "admin" do
     expect(proposal).to be_completed
   end
 
-  it "triggers no actions on Step edit" do
+  it "triggers actions on Step edit" do
     user = login_as_admin_user
     proposal = create(:proposal, :with_serial_approvers)
     first_step = proposal.individual_steps.first
@@ -95,6 +95,9 @@ describe "admin" do
 
     expect(page).to have_content("Approval was successfully updated")
     expect(deliveries.count).to eq(0)
+    first_step.reload
+    expect(first_step.completed_at).to_not be_nil
+    expect(first_step.completer).to eq(user)
   end
 
   def login_as_admin_user


### PR DESCRIPTION
trello: https://trello.com/c/y5c9XvmW/299-add-tests-to-include-request-updates-from-active-admin

* removes the `/admin/proposals/:id/restart` action because confusing
* adds tests verifying behavior of modifying proposals and steps via `/admin` UI