### PR TITLE
re-approval checks teammates as well as completers

### DIFF
--- a/app/services/ncr/work_order_reapproval_checker.rb
+++ b/app/services/ncr/work_order_reapproval_checker.rb
@@ -16,7 +16,15 @@ module Ncr
     private
 
     def budget_approver?
-      work_order.budget_approvers.include?(current_user)
+      work_order.budget_approvers.include?(current_user) || tier2_budget_approver_delegates?
+    end
+
+    def tier2_budget_approver_delegates?
+      tier2_budget_approvers.any? { |tier2_user| tier2_user.delegates_to?(current_user) }
+    end
+
+    def tier2_budget_approvers
+      [Ncr::Mailboxes.ba61_tier2_budget, Ncr::Mailboxes.ba80_budget, Ncr::Mailboxes.ool_ba80_budget]
     end
 
     def current_user

--- a/app/services/ncr/work_order_reapproval_checker.rb
+++ b/app/services/ncr/work_order_reapproval_checker.rb
@@ -16,15 +16,11 @@ module Ncr
     private
 
     def budget_approver?
-      work_order.budget_approvers.include?(current_user) || tier2_budget_approver_delegates?
+      work_order.budget_approvers.include?(current_user) || shares_budget_approver_delegator?
     end
 
-    def tier2_budget_approver_delegates?
-      tier2_budget_approvers.any? { |tier2_user| tier2_user.delegates_to?(current_user) }
-    end
-
-    def tier2_budget_approvers
-      [Ncr::Mailboxes.ba61_tier2_budget, Ncr::Mailboxes.ba80_budget, Ncr::Mailboxes.ool_ba80_budget]
+    def shares_budget_approver_delegator?
+      Ncr::WorkOrder.all_system_approvers.any? { |delegator| delegator.delegates_to?(current_user) }
     end
 
     def current_user

--- a/spec/services/ncr/work_order_reapproval_checker_spec.rb
+++ b/spec/services/ncr/work_order_reapproval_checker_spec.rb
@@ -65,7 +65,7 @@ describe Ncr::WorkOrderReapprovalChecker do
     end
 
     it "returns false if a protected field is changed by a budget approver delegate" do
-      work_order = create(:ncr_work_order)
+      work_order = create(:ncr_work_order, function_code: "PG123")
       work_order.setup_approvals_and_observers
       budget_approver = work_order.steps.last.user
       delegate_user = create(:user)
@@ -77,6 +77,26 @@ describe Ncr::WorkOrderReapprovalChecker do
       work_order.update!(function_code: "PG789")
       checker = Ncr::WorkOrderReapprovalChecker.new(work_order)
 
+      expect(checker.requires_budget_reapproval?).to eq(false)
+    end
+
+    it "returns false if a protected field is changed by a budget approver delegate who did not complete the step" do
+      work_order = create(:ncr_work_order, function_code: "PG123")
+      work_order.setup_approvals_and_observers
+      budget_approver = work_order.steps.last.user
+      delegate_user = create(:user)
+      diff_delegate_user = create(:user)
+      create(:user_delegate, assigner: budget_approver, assignee: delegate_user)
+      create(:user_delegate, assigner: budget_approver, assignee: diff_delegate_user)
+      fully_complete(work_order.proposal, delegate_user)
+      work_order.reload
+
+      work_order.modifier = diff_delegate_user
+      work_order.update!(function_code: "PG789")
+      checker = Ncr::WorkOrderReapprovalChecker.new(work_order)
+
+      expect(work_order.budget_approvers).to_not include(diff_delegate_user)
+      expect(work_order.budget_approvers).to include(delegate_user)
       expect(checker.requires_budget_reapproval?).to eq(false)
     end
   end


### PR DESCRIPTION
trello: https://trello.com/c/95DTQOX4/307-reapprovals-a-modification-by-someone-in-budget-tier-1-or-tier-2-should-not-trigger-a-re-approval

QA: 

* full complete a NCR work order
* as a team mate (fellow delegate) of the final budget approver (but *not* the completer), edit the WO.
* verify no re-approval is triggered.