### PR TITLE
Emergency attribute update

### DIFF
--- a/app/assets/javascripts/field_filter.js.coffee
+++ b/app/assets/javascripts/field_filter.js.coffee
@@ -12,7 +12,7 @@ class @FieldFilter
     @$fieldOrWrappers.attr("disabled", !enableOrDisable)
 
   toggleChildInputs: (enableOrDisable) ->
-    @$fieldOrWrappers.find(":input").attr("disabled", !enableOrDisable)
+    @$fieldOrWrappers.find(":input").not(".respect-disabled").attr("disabled", !enableOrDisable)
 
   toggle: (showOrHide) ->
     @toggleVisibility(showOrHide)

--- a/app/assets/javascripts/ncr_work_orders.js
+++ b/app/assets/javascripts/ncr_work_orders.js
@@ -6,10 +6,10 @@ $(document).ready( function() {
     if (radio.attr("id").match(/_ba60$/)) {
       buildingPicker.removeClass("required");
       buildingPicker.find("*").removeClass("required");
-    }   
+    }
     else {
       buildingPicker.addClass("required");
       buildingPicker.find("*").addClass("required");
-    }   
-  })  
+    }
+  })
 });

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -31,7 +31,7 @@ module Ncr
       with: /\ACL\d{7}\z/,
       message: "must start with 'CL', followed by seven numbers"
     }, allow_blank: true
-    validates :expense_type, inclusion: {in: EXPENSE_TYPES}, presence: true
+    validates :expense_type, inclusion: { in: EXPENSE_TYPES }, presence: true
     validates :function_code, format: {
       with: /\APG[A-Z0-9]{3}\z/,
       message: "must start with 'PG', followed by three letters or numbers"

--- a/app/views/ncr/work_orders/_form.html.haml
+++ b/app/views/ncr/work_orders/_form.html.haml
@@ -17,7 +17,8 @@
       = expense_type_radio_button(f, "BA61")
       = f.input :emergency,
         disabled: @client_data_instance.persisted?,
-        wrapper_html: { data: { filter_key: "expense-type", filter_value: "BA61" } }
+        wrapper_html: { data: { filter_key: "expense-type", filter_value: "BA61" } },
+        input_html: { value: @client_data_instance.emergency }
       = expense_type_radio_button(f, "BA80")
       = render partial: "ba_80_fields",
         locals: { f: f }

--- a/app/views/ncr/work_orders/_form.html.haml
+++ b/app/views/ncr/work_orders/_form.html.haml
@@ -18,7 +18,7 @@
       = f.input :emergency,
         disabled: @client_data_instance.persisted?,
         wrapper_html: { data: { filter_key: "expense-type", filter_value: "BA61" } },
-        input_html: { value: @client_data_instance.emergency }
+        input_html: { class: "respect-disabled", value: @client_data_instance.emergency }
       = expense_type_radio_button(f, "BA80")
       = render partial: "ba_80_fields",
         locals: { f: f }

--- a/spec/controllers/ncr/work_orders_controller_spec.rb
+++ b/spec/controllers/ncr/work_orders_controller_spec.rb
@@ -32,21 +32,21 @@ describe Ncr::WorkOrdersController do
     end
   end
 
-  describe '#edit' do
+  describe "#edit" do
     let (:work_order) { create(:ncr_work_order, :with_approvers) }
     let (:requester) { work_order.proposal.requester }
     before do
       login_as(requester)
     end
 
-    it 'does not display a message when the proposal is not fully approved' do
-      get :edit, {id: work_order.id}
+    it "does not display a message when the proposal is not fully approved" do
+      get :edit, { id: work_order.id }
       expect(flash[:warning]).not_to be_present
     end
 
-    it 'displays a warning message when editing a fully-approved proposal' do
+    it "displays a warning message when editing a fully-approved proposal" do
       fully_complete(work_order.proposal)
-      get :edit, {id: work_order.id}
+      get :edit, { id: work_order.id }
       expect(flash[:warning]).to be_present
     end
 
@@ -61,19 +61,17 @@ describe Ncr::WorkOrdersController do
     end
   end
 
-  describe '#update' do
-    let (:work_order) { create(:ncr_work_order) }
-    let (:requester) { work_order.proposal.requester }
-    before do
+  describe "#update" do
+    it "does not modify the work order when there is a bad edit" do
+      work_order = create(:ncr_work_order)
+      requester = work_order.proposal.requester
       login_as(requester)
-    end
-
-    it 'does not modify the work order when there is a bad edit' do
       approving_official = create(:user, client_slug: "ncr")
+
       post :update, {
         id: work_order.id,
         ncr_work_order: {
-          expense_type: 'BA61',
+          expense_type: "BA61",
           amount: 999999,
           approving_official_id: approving_official.id
         }
@@ -85,30 +83,28 @@ describe Ncr::WorkOrdersController do
       expect(work_order.amount).not_to eq(999999)
     end
 
-    it 'respects FY start date for setting default max amount' do
-      Timecop.freeze(Time.zone.parse('2015-10-02')) do
+    it "respects FY start date for setting default max amount" do
+      work_order = create(:ncr_work_order)
+      requester = work_order.proposal.requester
+      login_as(requester)
 
-        # must reload class for time travel to affect validations
-        ['EXPENSE_TYPES', 'BUILDING_NUMBERS', 'WorkOrder'].each do |const|
-          Ncr.send(:remove_const, const)
-        end
-        load 'app/models/ncr/work_order.rb'
-
-        approving_official = create(:user, client_slug: "ncr")
-        post :update, {
-          id: work_order.id,
-          ncr_work_order: {
-            expense_type: 'BA61',
-            amount: 99999,
-            approving_official_id: approving_official.id
-          }
+      approving_official = create(:user, client_slug: "ncr")
+      post :update, {
+        id: work_order.id,
+        ncr_work_order: {
+          expense_type: "BA61",
+          amount: 99999,
+          approving_official_id: approving_official.id
         }
-        expect(flash[:success]).not_to be_present
-        expect(flash[:error]).to eq(["Amount must be less than or equal to $3,500.00"])
-      end
+      }
+      expect(flash[:success]).not_to be_present
+      expect(flash[:error]).to eq(["Amount must be less than or equal to $3,500.00"])
     end
 
     it "allows the project title to be edited" do
+      work_order = create(:ncr_work_order)
+      requester = work_order.proposal.requester
+      login_as(requester)
       new_title = "new title"
       post :update, {
         id: work_order.id,
@@ -122,13 +118,16 @@ describe Ncr::WorkOrdersController do
     end
 
     it "allows the approver to be edited" do
+      work_order = create(:ncr_work_order)
+      requester = work_order.proposal.requester
+      login_as(requester)
       work_order.setup_approvals_and_observers
       approving_official = create(:user, client_slug: "ncr")
 
       post :update, {
         id: work_order.id,
         ncr_work_order: {
-         expense_type: 'BA61',
+         expense_type: "BA61",
          approving_official_id: approving_official.id
         }
       }
@@ -138,6 +137,9 @@ describe Ncr::WorkOrdersController do
     end
 
     it "does not modify the approver if already approved" do
+      work_order = create(:ncr_work_order)
+      requester = work_order.proposal.requester
+      login_as(requester)
       work_order.setup_approvals_and_observers
       work_order.reload.individual_steps.first.complete!
       approving_official = create(:user, client_slug: "ncr")
@@ -145,7 +147,7 @@ describe Ncr::WorkOrdersController do
       post :update, {
         id: work_order.id,
         ncr_work_order: {
-         expense_type: 'BA61',
+         expense_type: "BA61",
          approving_official_id: approving_official.id
         }
       }
@@ -155,6 +157,9 @@ describe Ncr::WorkOrdersController do
     end
 
     it "will not modify emergency status on non-emergencies" do
+      work_order = create(:ncr_work_order)
+      requester = work_order.proposal.requester
+      login_as(requester)
       work_order.setup_approvals_and_observers
       expect(work_order.steps.empty?).to be false
       expect(work_order.observers.empty?).to be true
@@ -162,19 +167,21 @@ describe Ncr::WorkOrdersController do
       post :update, {
         id: work_order.id,
         ncr_work_order: {
-         expense_type: 'BA61',
-         emergency: '1',
+         expense_type: "BA61",
+         emergency: "1",
          approving_official_id: work_order.approvers.first.id
         }
       }
 
       work_order.reload
-      expect(work_order.emergency).to be false
-      expect(work_order.steps.empty?).to be false
-      expect(work_order.observers.empty?).to be true
+      expect(work_order).not_to be_emergency
+      expect(work_order.steps).not_to be_empty
+      expect(work_order.observers).to be_empty
     end
 
     it "will not modify emergency status on emergencies" do
+      requester = create(:user, client_slug: "ncr")
+      login_as(requester)
       work_order = create(:ncr_work_order, :is_emergency, requester: requester)
       expect(work_order.steps.empty?).to be true
       expect(work_order.observers.empty?).to be false

--- a/spec/features/ncr/work_orders/create_spec.rb
+++ b/spec/features/ncr/work_orders/create_spec.rb
@@ -37,7 +37,7 @@ feature "Creating an NCR work order", :js do
 
       visit new_ncr_work_order_path
       fill_in "Project title", with: "test"
-      choose "BA60"
+      choose "BA61"
       fill_in_selectized("ncr_work_order_vendor", "ACME")
       fill_in 'Amount', with: 123.45
       click_on "Submit for approval"

--- a/spec/features/ncr/work_orders/requester_edit_spec.rb
+++ b/spec/features/ncr/work_orders/requester_edit_spec.rb
@@ -196,11 +196,14 @@ feature "Requester edits their NCR work order", :js do
     expect(work_order.soc_code).to eq("789")
   end
 
-  scenario "disables the emergency field" do
+  scenario "disables the emergency field", :js do
     visit edit_ncr_work_order_path(work_order)
 
     within(".ncr_work_order_emergency") do
       expect(page).to have_css(".disabled")
+      checkbox = page.find("input[type=checkbox]")
+      expect(checkbox["class"]).to include("respect-disabled")
+      expect(checkbox["disabled"]).to eq(true)
     end
   end
 end


### PR DESCRIPTION
trello: https://trello.com/c/B8655SyP/253-on-update-cannot-set-request-to-emergency

fixes javascript to actually disable the checkbox on Edit