### PR TITLE
Reindex on new observer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,7 @@ group :test do
   gem "shoulda-matchers"
   gem "simplecov"
   gem "site_prism"
+  gem "test_after_commit"
   gem "timecop"
   gem "webmock", require: false
   gem "zonebie"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -485,6 +485,8 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    test_after_commit (1.0.0)
+      activerecord (>= 3.2)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
@@ -597,6 +599,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   sprockets-rails (< 3)
+  test_after_commit
   timecop
   turbolinks
   uglifier

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -5,19 +5,25 @@ module Searchable
     include Elasticsearch::Model
 
     after_commit on: [:create] do
-      unless Rails.env.test?
+      if Rails.env.test?
+        self.class.reindexed << self.id
+      else
         delay.reindex
       end
     end
 
     after_commit on: [:update] do
-      unless Rails.env.test?
+      if Rails.env.test?
+        self.class.reindexed << self.id
+      else
         delay.reindex
       end
     end
 
     after_commit on: [:destroy] do
-      unless Rails.env.test?
+      if Rails.env.test?
+        self.class.track_reindex(self, false)
+      else
         delay.remove_from_index
       end
     end
@@ -28,6 +34,19 @@ module Searchable
 
     def remove_from_index
       __elasticsearch__.destroy_document
+    end
+
+    def self.reindexed
+      @@reindexed ||= []
+    end
+
+    def self.removed_from_index
+      @@removed_from_index ||= []
+    end
+
+    def self.clear_index_tracking
+      @@reindexed = []
+      @@removed_from_index = []
     end
 
     def self.rebuild_index

--- a/app/models/proposal_role.rb
+++ b/app/models/proposal_role.rb
@@ -2,7 +2,7 @@ class ProposalRole < ActiveRecord::Base
   has_paper_trail class_name: "C2Version"
 
   belongs_to :user
-  has_one :proposal
+  belongs_to :proposal, touch: true
   has_one :role
 
   validates :user, presence: true

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -444,4 +444,14 @@ describe Proposal do
       expect(proposal.status).to eq 'completed'
     end
   end
+
+  describe "searchable callbacks" do
+    it "should reindex when observer is added without comment" do
+      Proposal.clear_index_tracking
+      proposal = create(:proposal)
+      observation = create(:observation, proposal: proposal)
+
+      expect(Proposal.reindexed.count).to eq(2)
+    end
+  end
 end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -19,6 +19,7 @@ RSpec.configure do |config|
 
   config.after(:each) do
     ActionMailer::Base.deliveries.clear
+    Proposal.clear_index_tracking
     DatabaseCleaner.clean
     if Capybara.current_driver != :rack_test
       Rails.application.load_seed


### PR DESCRIPTION
ticket: https://18f.uservoice.com/admin/tickets/184

Proposals are automatically updated in the search index whenever they, or their associated records, change.

Associated observers were not triggering that automatic reindexing.

This PR adds tests for reindexing, and fixes the reindex-on-observation-change bug.