### PR TITLE
turn off sidebar filters on /admin/user_delegates because un-needed and slow

### DIFF
--- a/app/admin/user_delegate.rb
+++ b/app/admin/user_delegate.rb
@@ -1,4 +1,6 @@
 ActiveAdmin.register UserDelegate do
+  config.filters = false
+
   actions :index, :new, :show, :create, :destroy
 
   permit_params :assigner_id, :assignee_id


### PR DESCRIPTION
filters are useless on the `/admin/user_delegates` index page and just slow down response time.