### PR TITLE
Clarified how active_observer was being used

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -46,17 +46,4 @@ class Comment < ActiveRecord::Base
   def add_user_as_observer
     proposal.add_observer(user)
   end
-
-  # All of the users who should be notified when a comment is created
-  # This is basically Proposal.users _minus_ future approvers
-  def listeners
-    users_to_notify = Set.new
-    users_to_notify += proposal.currently_awaiting_step_users
-    users_to_notify += proposal.individual_steps.completed.map(&:user)
-    users_to_notify += proposal.observers
-    users_to_notify << proposal.requester
-    # Creator of comment doesn't need to be notified
-    users_to_notify.delete(user)
-    users_to_notify
-  end
 end

--- a/app/models/ncr_dispatcher.rb
+++ b/app/models/ncr_dispatcher.rb
@@ -51,7 +51,7 @@ class NcrDispatcher < Dispatcher
   end
 
   def notify_observers(needs_review, comment)
-    proposal.only_observers.each do |observer|
+    only_observers.each do |observer|
       unless user_is_modifier?(observer, comment.user)
         if observer.role_on(proposal).observer_only?
           if needs_review == true

--- a/app/models/ncr_dispatcher.rb
+++ b/app/models/ncr_dispatcher.rb
@@ -41,7 +41,7 @@ class NcrDispatcher < Dispatcher
   def notify_pending_approvers(comment)
     proposal.currently_awaiting_steps.each do |step|
       unless user_is_modifier?(step.user, comment.user)
-        if step_user_already_notifier_about_proposal?(step)
+        if step_user_already_notified_about_proposal?(step)
           ProposalMailer.proposal_updated_while_step_pending(step, comment).deliver_later
         else
           StepMailer.proposal_notification(step).deliver_later
@@ -51,9 +51,9 @@ class NcrDispatcher < Dispatcher
   end
 
   def notify_observers(needs_review, comment)
-    proposal.observers.each do |observer|
+    proposal.only_observers.each do |observer|
       unless user_is_modifier?(observer, comment.user)
-        if observer.role_on(proposal).active_observer?
+        if observer.role_on(proposal).observer_only?
           if needs_review == true
             ProposalMailer.
               proposal_updated_needs_re_review(observer, proposal, comment).
@@ -72,7 +72,7 @@ class NcrDispatcher < Dispatcher
     user == comment_user
   end
 
-  def step_user_already_notifier_about_proposal?(step)
+  def step_user_already_notified_about_proposal?(step)
     step.api_token.present?
   end
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -173,6 +173,11 @@ class Proposal < ActiveRecord::Base
     results.compact.uniq
   end
 
+  def subscribers_except_future_step_users
+    results = currently_awaiting_step_users + individual_steps.completed.map(&:user) + observers + [requester]
+    results.compact.uniq
+  end
+
   def subscribers_except_delegates
     subscribers - delegates
   end

--- a/app/services/role_picker.rb
+++ b/app/services/role_picker.rb
@@ -6,7 +6,7 @@ class RolePicker
     @proposal = proposal
   end
 
-  def active_observer?
+  def observer_only?
     observer? && !active_step_user? && !requester?
   end
 

--- a/spec/features/comment_spec.rb
+++ b/spec/features/comment_spec.rb
@@ -1,5 +1,5 @@
-describe "commenting" do
-  it "saves the comment" do
+feature "commenting" do
+  scenario "saves the comment" do
     proposal = create_and_visit_proposal
     comment_text = "this is a great comment"
 
@@ -10,7 +10,7 @@ describe "commenting" do
     expect(page).to have_content("You successfully added a comment")
   end
 
-  it "disables attachments if none is selected", js: true do
+  scenario "disables attachments if none is selected", js: true do
     create_and_visit_proposal
 
     expect(find("#add_a_comment").disabled?).to be(true)
@@ -18,8 +18,8 @@ describe "commenting" do
     expect(find("#add_a_comment").disabled?).to be(false)
   end
 
-  describe "when user is not yet an observer" do
-    it "adds current user to the observers list" do
+  context "when user is not yet an observer" do
+    scenario "adds current user to the observers list" do
       proposal = create(:proposal, :with_parallel_approvers)
       approver = proposal.approvers.first
       user = create(:user)

--- a/spec/features/proposals/complete_spec.rb
+++ b/spec/features/proposals/complete_spec.rb
@@ -1,20 +1,4 @@
-describe "Approving a proposal" do
-  it "can be done by an approver" do
-    Timecop.freeze do
-      proposal = create(:proposal, :with_approver)
-      login_as(proposal.approvers.first)
-      visit "/proposals/#{proposal.id}"
-      click_on("Approve")
-
-      expect(current_path).to eq("/proposals/#{proposal.id}")
-      expect(page).to have_content("You have approved #{proposal.public_id}")
-
-      approval = Proposal.last.individual_steps.first
-      expect(approval.status).to eq("completed")
-      expect(approval.completed_at.utc.to_s).to eq(Time.now.utc.to_s)
-    end
-  end
-
+describe "Completing a proposal" do
   it "distinguishes user with multiple actionable steps" do
     proposal = create(:proposal, :with_serial_approvers)
     first_approver = proposal.approvers.first
@@ -25,20 +9,20 @@ describe "Approving a proposal" do
     visit proposal_path(proposal)
     click_on("Approve")
 
-    expect(current_path).to eq("/proposals/#{proposal.id}")
+    expect(current_path).to eq(proposal_path(proposal))
     expect(page).to have_content("You have approved #{proposal.public_id}")
 
     login_as(second_approver)
     visit proposal_path(proposal)
     click_on("Approve")
 
-    expect(current_path).to eq("/proposals/#{proposal.id}")
+    expect(current_path).to eq(proposal_path(proposal))
     expect(page).to have_content("You have approved #{proposal.public_id}")
   end
 
   it "sends email to observers and requester when proposal is complete" do
     proposal = create(:proposal, :with_approver)
-    proposal.add_observer(proposal.approvers.first)
+    proposal.add_observer(create(:user))
 
     login_as(proposal.approvers.first)
     visit proposal_path(proposal)

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,34 +1,4 @@
 describe Comment do
-  describe "#listeners" do
-    let (:proposal) { create(:proposal, :with_serial_approvers, :with_observers) }
-    let (:comment) { create(:comment, proposal: proposal) }
-
-    it "includes the requester" do
-      expect(comment.listeners).to include(proposal.requester)
-    end
-
-    it "includes an observer" do
-      expect(comment.listeners).to include(proposal.observers.first)
-    end
-
-    it "includes approved approvers" do
-      individuals = proposal.individual_steps
-      individuals += [Steps::Approval.new(user: create(:user))]
-      proposal.root_step = Steps::Serial.new(child_steps: individuals)
-
-      expect(proposal.approvers.length).to eq(3)
-      proposal.individual_steps.first.complete!
-      expect(comment.listeners).to include(proposal.approvers[0])
-      expect(comment.listeners).to include(proposal.approvers[1])
-      expect(comment.listeners).not_to include(proposal.approvers[2])
-    end
-
-    it "does not include the comment creator" do
-      proposal.requester = comment.user
-      expect(comment.listeners).not_to include(proposal.requester)
-    end
-  end
-
   describe "#create_without_callback" do
     it "does not create observer" do
       proposal = create(:proposal)

--- a/spec/services/proposal_update_recorder_spec.rb
+++ b/spec/services/proposal_update_recorder_spec.rb
@@ -90,7 +90,7 @@ describe ProposalUpdateRecorder do
       expect(comment.user).to eq(modifier)
     end
 
-    it "does not send a comment email for the update comment to proposal listeners" do
+    it "does not send a comment email for the update comment to proposal subscribers" do
       work_order = create(:ncr_work_order, vendor: "old")
       listener = create(:user, client_slug: "ncr")
       work_order.proposal.add_observer(listener)

--- a/spec/services/role_picker_spec.rb
+++ b/spec/services/role_picker_spec.rb
@@ -69,7 +69,7 @@ describe RolePicker do
       end
     end
 
-    describe "#active_observer?" do
+    describe "#observer_only?" do
       it "is true when user is observer and not active approver" do
         observer = create(:user)
         observation = create(:observation, user: observer)
@@ -77,7 +77,7 @@ describe RolePicker do
 
         roles = RolePicker.new(observer, proposal)
 
-        expect(roles).to be_active_observer
+        expect(roles).to be_observer_only
       end
     end
   end


### PR DESCRIPTION
 Changed active_observer to only_observers
 Changed activ_observer? to observer_only?
 Move comment listeners method to proposal as subscribers_except_future_step_users
 Use only_observers where appropriate
 https://trello.com/c/3KFzjQCC/261-investigate-use-of-active-observers