### PR TITLE
Move more step-related logic to StepManager concern

### DIFF
--- a/app/models/concerns/step_manager.rb
+++ b/app/models/concerns/step_manager.rb
@@ -21,6 +21,28 @@ module StepManager
     reset_status
   end
 
+  def reset_status
+    unless canceled?
+      if root_step.nil? || root_step.completed?
+        update(status: "completed")
+      else
+        update(status: "pending")
+      end
+    end
+  end
+
+  def root_step
+    steps.find_by(parent: nil)
+  end
+
+  def parallel?
+    root_step.type == "Steps::Parallel"
+  end
+
+  def serial?
+    root_step.type == "Steps::Serial"
+  end
+
   def clean_up_old_steps(old_steps, step_list)
     # destroy any old steps that are not a part of step list
     (old_steps - step_list).each do |step|

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -122,20 +122,12 @@ class Proposal < ActiveRecord::Base
     end
   end
 
-  def root_step
-    steps.where(parent: nil).first
-  end
-
-  def parallel?
-    root_step.type == "Steps::Parallel"
-  end
-
-  def serial?
-    root_step.type == "Steps::Serial"
-  end
-
   def delegate?(user)
     delegates.include?(user)
+  end
+
+  def existing_step_for(user)
+    steps.where(user: user).first
   end
 
   def existing_or_delegated_step_for(user)
@@ -164,10 +156,6 @@ class Proposal < ActiveRecord::Base
     ProposalQuery.new(self).purchasers
   end
 
-  def existing_step_for(user)
-    steps.where(user: user).first
-  end
-
   def subscribers
     results = approvers + purchasers + observers + delegates + [requester]
     results.compact.uniq
@@ -175,16 +163,6 @@ class Proposal < ActiveRecord::Base
 
   def subscribers_except_delegates
     subscribers - delegates
-  end
-
-  def reset_status
-    unless canceled?
-      if root_step.nil? || root_step.completed?
-        update(status: "completed")
-      else
-        update(status: "pending")
-      end
-    end
   end
 
   def has_subscriber?(user)

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -22,14 +22,14 @@ FactoryGirl.define do
 
     trait :with_serial_approvers do
       after :create do |proposal, evaluator|
-        ind = 2.times.map{ Steps::Approval.new(user: create(:user, client_slug: evaluator.client_slug)) }
+        ind = 2.times.map { Steps::Approval.new(user: create(:user, client_slug: evaluator.client_slug)) }
         proposal.add_initial_steps(ind)
       end
     end
 
     trait :with_parallel_approvers do
       after :create do |proposal, evaluator|
-        ind = 2.times.map{ Steps::Approval.new(user: create(:user, client_slug: evaluator.client_slug)) }
+        ind = 2.times.map { Steps::Approval.new(user: create(:user, client_slug: evaluator.client_slug)) }
         proposal.root_step = Steps::Parallel.new(child_steps: ind)
       end
     end
@@ -69,7 +69,7 @@ FactoryGirl.define do
 
       if evaluator.delegate
         user = evaluator.approver_user || create(:user, client_slug: evaluator.client_slug)
-        proposal.add_initial_steps([Steps::Approval.new(user: user)])
+        proposal.add_initial_steps([build(:approval_step, user: user)])
         user.add_delegate(evaluator.delegate)
       end
 

--- a/spec/models/concerns/step_manager_spec.rb
+++ b/spec/models/concerns/step_manager_spec.rb
@@ -17,26 +17,24 @@ describe StepManager do
     end
   end
 
-  describe '#root_step=' do
-    it 'sets initial approvers' do
+  describe "#root_step=" do
+    it "sets initial approvers" do
       proposal = create(:proposal)
-      approvers = 3.times.map{ create(:user) }
-      individuals = approvers.map{ |u| Steps::Approval.new(user: u) }
+      approvers = create_list(:user, 3)
+      individuals = approvers.map{ |user| build(:approval_step, user: user) }
 
-      proposal.root_step = Steps::Parallel.new(child_steps: individuals)
+      proposal.root_step = build(:parallel_step, child_steps: individuals)
 
       expect(proposal.steps.count).to be 4
       expect(proposal.approvers).to eq approvers
     end
 
-    it 'initates parallel' do
-      approver1 = create(:user)
-      approver2 = create(:user)
-      approver3 = create(:user)
+    it "initates parallel" do
+      users = create_list(:user, 3)
       proposal = create(:proposal)
-      individuals = [approver1, approver2, approver3].map{ |u| Steps::Approval.new(user: u)}
+      individuals = users.map { |user| build(:approval_step, user: user) }
 
-      proposal.root_step = Steps::Parallel.new(child_steps: individuals)
+      proposal.root_step = build(:parallel_step, child_steps: individuals)
 
       expect(proposal.approvers.count).to be 3
       expect(proposal.steps.count).to be 4
@@ -44,14 +42,12 @@ describe StepManager do
       expect(proposal.steps.actionable.count).to be 4
     end
 
-    it 'initates linear' do
-      approver1 = create(:user)
-      approver2 = create(:user)
-      approver3 = create(:user)
+    it "initates linear" do
       proposal = create(:proposal)
-      individuals = [approver1, approver2, approver3].map{ |u| Steps::Approval.new(user: u)}
+      users = create_list(:user, 3)
+      individuals = users.map { |user| build(:approval_step, user: user) }
 
-      proposal.root_step = Steps::Serial.new(child_steps: individuals)
+      proposal.root_step = build(:serial_step, child_steps: individuals)
 
       expect(proposal.approvers.count).to be 3
       expect(proposal.steps.count).to be 4
@@ -59,52 +55,43 @@ describe StepManager do
       expect(proposal.steps.actionable.count).to be 2
     end
 
-    it 'fixes modified parallel proposal approvals' do
-      approver1 = create(:user)
-      approver2 = create(:user)
-      approver3 = create(:user)
+    it "fixes modified parallel proposal approvals" do
+      users = create_list(:user, 3)
       proposal = create(:proposal)
-      individuals = [Steps::Approval.new(user: approver1)]
-      proposal.root_step = Steps::Parallel.new(child_steps: individuals)
+      individual = [build(:approval_step, user: users[0])]
+      proposal.root_step = build(:parallel_step, child_steps: individual)
 
       expect(proposal.steps.actionable.count).to be 2
       expect(proposal.individual_steps.actionable.count).to be 1
 
-      individuals = individuals + [approver2, approver3].map{ |u| Steps::Approval.new(user: u)}
-      proposal.root_step = Steps::Parallel.new(child_steps: individuals)
+      individuals = users.map { |user| build(:approval_step, user: user) }
+      proposal.root_step = build(:parallel_step, child_steps: individuals)
 
       expect(proposal.steps.actionable.count).to be 4
       expect(proposal.individual_steps.actionable.count).to be 3
     end
 
-    it 'fixes modified linear proposal steps' do
-      approver1 = create(:user)
-      approver2 = create(:user)
-      approver3 = create(:user)
+    it "fixes modified linear proposal approvals" do
+      users = create_list(:user, 3)
       proposal = create(:proposal)
-      approver1, approver2, approver3 = 3.times.map{ create(:user) }
-      individuals = [approver1, approver2].map{ |u| Steps::Approval.new(user: u) }
-      proposal.root_step = Steps::Serial.new(child_steps: individuals)
+      individuals = [users[0], users[1]].map { |user| build(:approval_step, user: user) }
+      proposal.root_step = build(:serial_step, child_steps: individuals)
 
       expect(proposal.steps.actionable.count).to be 2
       expect(proposal.individual_steps.actionable.count).to be 1
 
       individuals.first.complete!
-      individuals[1] = Steps::Approval.new(user: approver3)
-      proposal.root_step = Steps::Serial.new(child_steps: individuals)
+      individuals[1] = build(:approval_step, user: users[2])
+      proposal.root_step = build(:serial_step, child_steps: individuals)
 
       expect(proposal.steps.completed.count).to be 1
       expect(proposal.steps.actionable.count).to be 2
       expect(proposal.individual_steps.actionable.count).to be 1
-      expect(proposal.individual_steps.actionable.first.user).to eq approver3
+      expect(proposal.individual_steps.actionable.first.user).to eq users[2]
     end
 
-    it 'does not modify a full completed parallel proposal' do
-      approver1 = create(:user)
-      approver2 = create(:user)
-      proposal = create(:proposal)
-      individuals = [approver1, approver2].map{ |u| Steps::Approval.new(user: u)}
-      proposal.root_step = Steps::Parallel.new(child_steps: individuals)
+    it "does not modify a full approved parallel proposal" do
+      proposal = create(:proposal, :with_parallel_approvers)
 
       proposal.individual_steps.first.complete!
       proposal.individual_steps.second.complete!
@@ -112,12 +99,8 @@ describe StepManager do
       expect(proposal.steps.actionable).to be_empty
     end
 
-    it 'does not modify a full completed linear proposal' do
-      approver1 = create(:user)
-      approver2 = create(:user)
-      proposal = create(:proposal)
-      individuals = [approver1, approver2].map{ |u| Steps::Approval.new(user: u)}
-      proposal.root_step = Steps::Serial.new(child_steps: individuals)
+    it "does not modify a full approved linear proposal" do
+      proposal = create(:proposal, :with_serial_approvers)
 
       proposal.individual_steps.first.complete!
       proposal.individual_steps.second.complete!
@@ -125,12 +108,121 @@ describe StepManager do
       expect(proposal.steps.actionable).to be_empty
     end
 
-    it 'deletes approvals' do
+    it "deletes approvals" do
       proposal = create(:proposal, :with_parallel_approvers)
       approval1, approval2 = proposal.individual_steps
-      proposal.root_step = Steps::Serial.new(child_steps: [approval2])
+      proposal.root_step = build(:serial_step, child_steps: [approval2])
 
       expect(Step.exists?(approval1.id)).to be false
+    end
+  end
+
+  describe "#reset_status" do
+    it "sets status as completed if there are no approvals" do
+      proposal = create(:proposal)
+      expect(proposal.pending?).to be true
+      proposal.reset_status
+      expect(proposal.completed?).to be true
+    end
+
+    it "keeps status as canceled if the proposal has been canceled" do
+      proposal = create(:proposal, :with_parallel_approvers)
+      proposal.individual_steps.first.complete!
+      expect(proposal.pending?).to be true
+      proposal.cancel!
+
+      proposal.reset_status
+      expect(proposal.canceled?).to be true
+    end
+
+    it "reverts to pending if a step is added" do
+      proposal = create(:proposal, :with_parallel_approvers)
+      proposal.individual_steps.first.complete!
+      proposal.individual_steps.second.complete!
+      expect(proposal.reload.completed?).to be true
+      individuals = proposal.root_step.child_steps + [build(:approval_step, user: create(:user))]
+      proposal.root_step = build(:parallel_step, child_steps: individuals)
+
+      proposal.reset_status
+      expect(proposal.pending?).to be true
+    end
+
+    it "does not move out of the pending state unless all are completed" do
+      proposal = create(:proposal, :with_parallel_approvers)
+      proposal.reset_status
+      expect(proposal.pending?).to be true
+      proposal.individual_steps.first.complete!
+
+      proposal.reset_status
+      expect(proposal.pending?).to be true
+      proposal.individual_steps.second.complete!
+
+      proposal.reset_status
+      expect(proposal.completed?).to be true
+    end
+  end
+
+  describe "#root_step" do
+    it "returns the step without a parent" do
+      step = create(:serial_step, parent_id: nil)
+      proposal = create(:proposal, steps: [step])
+
+      expect(proposal.root_step).to eq step
+    end
+  end
+
+  describe "#parallel?" do
+    it "is true if the root step is a parallel step" do
+      proposal = create(:proposal, steps: [create(:parallel_step)])
+
+      expect(proposal).to be_parallel
+    end
+
+    it "is false if the root step is not a parallel step" do
+      proposal = create(:proposal, steps: [create(:serial_step)])
+
+      expect(proposal).not_to be_parallel
+    end
+  end
+
+  describe "#serial?" do
+    it "is true if the root step is a serial step" do
+      proposal = create(:proposal, steps: [create(:serial_step)])
+
+      expect(proposal).to be_serial
+    end
+
+    it "is false if the root step is not a serial step" do
+      proposal = create(:proposal, steps: [create(:parallel_step)])
+
+      expect(proposal).not_to be_serial
+    end
+  end
+
+  describe "#currently_awaiting_step_users" do
+    it "gives a consistently ordered list when in parallel" do
+      proposal = create(:proposal, :with_parallel_approvers)
+      approver1, approver2 = proposal.approvers
+      expect(proposal.currently_awaiting_step_users).to eq([approver1, approver2])
+
+      proposal.individual_steps.first.update_attribute(:position, 5)
+      expect(proposal.currently_awaiting_step_users).to eq([approver2, approver1])
+    end
+
+    it "gives only the first approver when linear" do
+      proposal = create(:proposal, :with_serial_approvers)
+      approver1, approver2 = proposal.approvers
+      expect(proposal.currently_awaiting_step_users).to eq([approver1])
+
+      proposal.individual_steps.first.complete!
+      expect(proposal.currently_awaiting_step_users).to eq([approver2])
+    end
+  end
+
+  describe "#ineligible_approvers" do
+    it "identifies ineligible approvers" do
+      proposal = create(:proposal)
+      expect(proposal.ineligible_approvers).to eq([proposal.requester])
     end
   end
 end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -15,7 +15,7 @@ describe Proposal do
     it "disallows requester from also being approver" do
       user = create(:user)
       expect {
-        create(:proposal, :with_approver, requester: user, approver_user: user) 
+        create(:proposal, :with_approver, requester: user, approver_user: user)
       }.to raise_error(ActiveRecord::RecordNotSaved)
     end
 
@@ -34,49 +34,12 @@ describe Proposal do
     end
   end
 
-  describe 'CLIENT_MODELS' do
+  describe "CLIENT_MODELS" do
     it "contains multiple models" do
       expect(Proposal::CLIENT_MODELS.size).to_not eq(0)
       Proposal::CLIENT_MODELS.each do |model|
         expect(model.ancestors).to include(ActiveRecord::Base)
       end
-    end
-  end
-
-  describe "#root_step" do
-    it "returns the step without a parent" do
-      step = create(:serial_step, parent_id: nil)
-      proposal = create(:proposal, steps: [step])
-
-      expect(proposal.root_step).to eq step
-    end
-  end
-
-  describe "#parallel?" do
-    it "is true if the root step is a parallel step" do
-      proposal = create(:proposal, steps: [create(:parallel_step)])
-
-      expect(proposal).to be_parallel
-    end
-
-    it "is false if the root step is not a parallel step" do
-      proposal = create(:proposal, steps: [create(:serial_step)])
-
-      expect(proposal).not_to be_parallel
-    end
-  end
-
-  describe "#serial?" do
-    it "is true if the root step is a serial step" do
-      proposal = create(:proposal, steps: [create(:serial_step)])
-
-      expect(proposal).to be_serial
-    end
-
-    it "is false if the root step is not a serial step" do
-      proposal = create(:proposal, steps: [create(:parallel_step)])
-
-      expect(proposal).not_to be_serial
     end
   end
 
@@ -100,26 +63,6 @@ describe Proposal do
     end
   end
 
-  describe '#currently_awaiting_step_users' do
-    it "gives a consistently ordered list when in parallel" do
-      proposal = create(:proposal, :with_parallel_approvers)
-      approver1, approver2 = proposal.approvers
-      expect(proposal.currently_awaiting_step_users).to eq([approver1, approver2])
-
-      proposal.individual_steps.first.update_attribute(:position, 5)
-      expect(proposal.currently_awaiting_step_users).to eq([approver2, approver1])
-    end
-
-    it "gives only the first approver when linear" do
-      proposal = create(:proposal, :with_serial_approvers)
-      approver1, approver2 = proposal.approvers
-      expect(proposal.currently_awaiting_step_users).to eq([approver1])
-
-      proposal.individual_steps.first.complete!
-      expect(proposal.currently_awaiting_step_users).to eq([approver2])
-    end
-  end
-
   describe "#name" do
     it "delegates to client data" do
       proposal = build(:proposal)
@@ -136,7 +79,7 @@ describe Proposal do
     end
   end
 
-  describe '#subscribers' do
+  describe "#subscribers" do
     it "returns all approvers, purchasers, observers, and the requester" do
       requester = create(:user)
       proposal = create(:proposal, :with_approval_and_purchase, :with_observers, requester: requester)
@@ -178,13 +121,6 @@ describe Proposal do
     end
   end
 
-  describe "#ineligible_approvers" do
-    it "identifies ineligible approvers" do
-      proposal = create(:proposal)
-      expect(proposal.ineligible_approvers).to eq([proposal.requester])
-    end
-  end
-
   describe "#subscribers_except_delegates" do
     it "excludes delegates" do
       delegate = create(:user)
@@ -193,168 +129,6 @@ describe Proposal do
       expect(proposal.subscribers_except_delegates).to match_array(
         proposal.subscribers - [delegate]
       )
-    end
-  end
-
-  describe '#root_step=' do
-    it 'sets initial approvers' do
-      proposal = create(:proposal)
-      approvers = 3.times.map{ create(:user) }
-      individuals = approvers.map{ |u| Steps::Approval.new(user: u) }
-
-      proposal.root_step = Steps::Parallel.new(child_steps: individuals)
-
-      expect(proposal.steps.count).to be 4
-      expect(proposal.approvers).to eq approvers
-    end
-
-    it 'initates parallel' do
-      approver1 = create(:user)
-      approver2 = create(:user)
-      approver3 = create(:user)
-      proposal = create(:proposal)
-      individuals = [approver1, approver2, approver3].map{ |u| Steps::Approval.new(user: u)}
-
-      proposal.root_step = Steps::Parallel.new(child_steps: individuals)
-
-      expect(proposal.approvers.count).to be 3
-      expect(proposal.steps.count).to be 4
-      expect(proposal.individual_steps.actionable.count).to be 3
-      expect(proposal.steps.actionable.count).to be 4
-    end
-
-    it 'initates linear' do
-      approver1 = create(:user)
-      approver2 = create(:user)
-      approver3 = create(:user)
-      proposal = create(:proposal)
-      individuals = [approver1, approver2, approver3].map{ |u| Steps::Approval.new(user: u)}
-
-      proposal.root_step = Steps::Serial.new(child_steps: individuals)
-
-      expect(proposal.approvers.count).to be 3
-      expect(proposal.steps.count).to be 4
-      expect(proposal.individual_steps.actionable.count).to be 1
-      expect(proposal.steps.actionable.count).to be 2
-    end
-
-    it "fixes modified parallel proposal approvals" do
-      approver1 = create(:user)
-      approver2 = create(:user)
-      approver3 = create(:user)
-      proposal = create(:proposal)
-      individuals = [Steps::Approval.new(user: approver1)]
-      proposal.root_step = Steps::Parallel.new(child_steps: individuals)
-
-      expect(proposal.steps.actionable.count).to be 2
-      expect(proposal.individual_steps.actionable.count).to be 1
-
-      individuals = individuals + [approver2, approver3].map{ |u| Steps::Approval.new(user: u)}
-      proposal.root_step = Steps::Parallel.new(child_steps: individuals)
-
-      expect(proposal.steps.actionable.count).to be 4
-      expect(proposal.individual_steps.actionable.count).to be 3
-    end
-
-    it "fixes modified proposal approvals with serial steps" do
-      approver1 = create(:user)
-      approver2 = create(:user)
-      approver3 = create(:user)
-      proposal = create(:proposal)
-      approver1, approver2, approver3 = 3.times.map{ create(:user) }
-      individuals = [approver1, approver2].map{ |u| Steps::Approval.new(user: u) }
-      proposal.root_step = Steps::Serial.new(child_steps: individuals)
-
-      expect(proposal.steps.actionable.count).to be 2
-      expect(proposal.individual_steps.actionable.count).to be 1
-
-      individuals.first.complete!
-      individuals[1] = Steps::Approval.new(user: approver3)
-      proposal.root_step = Steps::Serial.new(child_steps: individuals)
-
-      expect(proposal.steps.completed.count).to be 1
-      expect(proposal.steps.actionable.count).to be 2
-      expect(proposal.individual_steps.actionable.count).to be 1
-      expect(proposal.individual_steps.actionable.first.user).to eq approver3
-    end
-
-    it "does not modify a fully completed proposal with parallel steps" do
-      approver1 = create(:user)
-      approver2 = create(:user)
-      proposal = create(:proposal)
-      individuals = [approver1, approver2].map{ |u| Steps::Approval.new(user: u)}
-      proposal.root_step = Steps::Parallel.new(child_steps: individuals)
-
-      proposal.individual_steps.first.complete!
-      proposal.individual_steps.second.complete!
-
-      expect(proposal.steps.actionable).to be_empty
-    end
-
-    it "does not modify a fully completed proposal with serial steps" do
-      approver1 = create(:user)
-      approver2 = create(:user)
-      proposal = create(:proposal)
-      individuals = [approver1, approver2].map{ |u| Steps::Approval.new(user: u)}
-      proposal.root_step = Steps::Serial.new(child_steps: individuals)
-
-      proposal.individual_steps.first.complete!
-      proposal.individual_steps.second.complete!
-
-      expect(proposal.steps.actionable).to be_empty
-    end
-
-    it "deletes approvals" do
-      proposal = create(:proposal, :with_parallel_approvers)
-      approval1, approval2 = proposal.individual_steps
-      proposal.root_step = Steps::Serial.new(child_steps: [approval2])
-
-      expect(Step.exists?(approval1.id)).to be false
-    end
-  end
-
-  describe '#reset_status' do
-    it 'sets status as completed if there are no approvals' do
-      proposal = create(:proposal)
-      expect(proposal.pending?).to be true
-      proposal.reset_status()
-      expect(proposal.completed?).to be true
-    end
-
-    it "keeps status as canceled if the proposal has been canceled" do
-      proposal = create(:proposal, :with_parallel_approvers)
-      proposal.individual_steps.first.complete!
-      expect(proposal.pending?).to be true
-      proposal.cancel!
-
-      proposal.reset_status()
-      expect(proposal.canceled?).to be true
-    end
-
-    it 'reverts to pending if a step is added' do
-      proposal = create(:proposal, :with_parallel_approvers)
-      proposal.individual_steps.first.complete!
-      proposal.individual_steps.second.complete!
-      expect(proposal.reload.completed?).to be true
-      individuals = proposal.root_step.child_steps + [Steps::Approval.new(user: create(:user))]
-      proposal.root_step = Steps::Parallel.new(child_steps: individuals)
-
-      proposal.reset_status()
-      expect(proposal.pending?).to be true
-    end
-
-    it 'does not move out of the pending state unless all are completed' do
-      proposal = create(:proposal, :with_parallel_approvers)
-      proposal.reset_status()
-      expect(proposal.pending?).to be true
-      proposal.individual_steps.first.complete!
-
-      proposal.reset_status()
-      expect(proposal.pending?).to be true
-      proposal.individual_steps.second.complete!
-
-      proposal.reset_status()
-      expect(proposal.completed?).to be true
     end
   end
 
@@ -368,14 +142,14 @@ describe Proposal do
       end
     end
 
-    describe '.closed' do
+    describe ".closed" do
       it "returns completed and and canceled proposals" do
         expect(Proposal.closed.pluck(:status).sort).to eq(%w(canceled completed))
       end
     end
   end
 
-  describe '#restart' do
+  describe "#restart" do
     it "creates new API tokens" do
       proposal = create(:proposal, :with_parallel_approvers)
       create(:ncr_work_order, proposal: proposal)
@@ -423,7 +197,7 @@ describe Proposal do
   describe "#as_indexed_json" do
     it "counts attachments" do
       proposal = create(:proposal)
-      attachment = create(:attachment, proposal: proposal, user: proposal.requester)
+      create(:attachment, proposal: proposal, user: proposal.requester)
 
       expect(proposal.as_indexed_json[:num_attachments]).to eq(1)
     end
@@ -441,7 +215,7 @@ describe Proposal do
 
       proposal.fully_complete!
 
-      expect(proposal.status).to eq 'completed'
+      expect(proposal.status).to eq "completed"
     end
   end
 
@@ -449,7 +223,7 @@ describe Proposal do
     it "should reindex when observer is added without comment" do
       Proposal.clear_index_tracking
       proposal = create(:proposal)
-      observation = create(:observation, proposal: proposal)
+      create(:observation, proposal: proposal)
 
       expect(Proposal.reindexed.count).to eq(2)
     end


### PR DESCRIPTION
* Remove duplicate specs (were in both Proposal and StepManager spec
  files)
* Move specs to StepManager spec when for method in StepManager
* Use factories in specs rather than initializing objects