### PR TITLE
Add padding when no reason present Obs Email

### DIFF
--- a/app/views/observer_mailer/observer_added_notification.html.haml
+++ b/app/views/observer_mailer/observer_added_notification.html.haml
@@ -10,6 +10,9 @@
   - if @reason.present?
     = render partial: "mail_shared/call_to_action/subheader",
       locals: { bold: "not-bold", subheader: cta_subheader, vertical: "" }
+  - else
+    = render partial: "mail_shared/call_to_action/subheader",
+      locals: { bold: "not-bold", subheader: "", vertical: "" }
 
   = render partial: "mail_shared/approval/chain",
     locals: { proposal: @proposal }


### PR DESCRIPTION
 Added spacing between header and steps in
 observer_added email when no reason present
 https://trello.com/c/Xslq7XpY/279-spacing-on-the-added-as-an-observer-with-no-reason-email