### PR TITLE
Removed default scope from Step

### DIFF
--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -15,11 +15,17 @@ class Step < ActiveRecord::Base
   acts_as_list scope: :proposal
   belongs_to :parent, class_name: "Step"
 
-  has_many :child_steps, class_name: "Step", foreign_key: "parent_id", dependent: :destroy
+  has_many :child_steps, 
+    -> { order("position ASC") },
+    class_name: "Step",
+    foreign_key: "parent_id",
+    dependent: :destroy
 
   validates :proposal, presence: true
   validates :user_id, uniqueness: { scope: :proposal_id }, allow_blank: true
-  scope :individual, -> { where.not(type: ["Steps::Serial", "Steps::Parallel"]).order("position ASC") }
+
+  scope :individual, 
+    -> { where.not(type: ["Steps::Serial", "Steps::Parallel"]).order("position ASC") }
   scope :with_users, -> { includes :user }
 
   statuses.each do |status|
@@ -27,8 +33,6 @@ class Step < ActiveRecord::Base
   end
   scope :non_pending, -> { where.not(status: "pending") }
   scope :outstanding, -> { where.not(status: "completed") }
-
-  default_scope { order("position ASC") }
 
   def pre_order_tree_traversal
     [self] + child_steps.flat_map(&:pre_order_tree_traversal)

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -15,22 +15,29 @@ class Step < ActiveRecord::Base
   acts_as_list scope: :proposal
   belongs_to :parent, class_name: "Step"
 
-  has_many :child_steps, 
-    -> { order("position ASC") },
+  has_many(
+    :child_steps,
+    -> { position_order },
     class_name: "Step",
     foreign_key: "parent_id",
     dependent: :destroy
+  )
 
   validates :proposal, presence: true
   validates :user_id, uniqueness: { scope: :proposal_id }, allow_blank: true
 
-  scope :individual, 
-    -> { where.not(type: ["Steps::Serial", "Steps::Parallel"]).order("position ASC") }
+  scope(
+    :individual,
+    -> { where.not(type: ["Steps::Serial", "Steps::Parallel"]).position_order }
+  )
+
+  scope :position_order, -> { order(position: :asc) }
   scope :with_users, -> { includes :user }
 
   statuses.each do |status|
     scope status, -> { where(status: status) }
   end
+
   scope :non_pending, -> { where.not(status: "pending") }
   scope :outstanding, -> { where.not(status: "completed") }
 

--- a/spec/models/steps/serial_spec.rb
+++ b/spec/models/steps/serial_spec.rb
@@ -19,4 +19,14 @@ describe Steps::Serial do
     expect(first.reload.status).to eq('completed')
     expect(second.reload.status).to eq('completed')
   end
+
+  it 'returns child_steps in the correct position order' do
+    first_step = create(:approval_step, position: 1)
+    second_step = create(:approval_step, position: 2)
+    third_step = create(:approval_step, position: 3)
+    root_step = create(:serial_step, child_steps: [first_step, third_step, second_step])
+    root_step.reload
+
+    expect(root_step.child_steps).to eq([first_step, second_step, third_step])
+  end
 end


### PR DESCRIPTION
  Having a default scope is problematic,
  even more so when using a non unique trait.
  Placed scoping on child_step `position ASC`
  Added test
  see:
  http://stackoverflow.com/questions/25087336/why-is-using-the-rails-default-scope-often-recommend-against/25087337#25087337
  https://trello.com/c/P5og2Pr8/394-remove-default-scoping-on-steps