### PR TITLE
link directly to the chat room

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,12 @@ If you would prefer to use C2 as as hosted software solution for your
 organization, we would be happy to give you a demo.
 
 Please submit a [support ticket](https://cap.18f.gov/feedback) or join our
-[public Slack channel](https://chat.18f.gov/) (select "cap-public" from the
-dropdown) to learn more.
+[public Slack channel](https://chat.18f.gov/?channel=cap-public) to learn more.
 
 ## Links
 
 * [Issue tracker](https://trello.com/b/kAW72R3m/c2-birthday-cake)
-* [Chat with us](https://chat.18f.gov/) (select "cap-public" from the dropdown)
+* [Chat with us](https://chat.18f.gov/?channel=cap-public)
 
 ## Documentation
 


### PR DESCRIPTION
https://chat.18f.gov now supports linking directly to the channel! See https://github.com/18F/chat/pull/5 for more information.