### PR TITLE
switch diff logic in proposal history.

### DIFF
--- a/lib/c2_version.rb
+++ b/lib/c2_version.rb
@@ -13,16 +13,12 @@ class C2Version < PaperTrail::Version
     end
   end
 
+  def live_version
+    item
+  end
+
   def diff
-    case event
-    when "create"
-      HashDiff.diff({}, attributes)
-    when "update"
-      prev = previous or fail("No previous version for #{self.pretty_inspect}")
-      HashDiff.diff(prev.attributes, attributes)
-    else
-      # not sure what makes the most sense here...
-      nil
-    end
+    next_version = self.next || live_version
+    HashDiff.diff((attributes || {}), next_version.attributes)
   end
 end

--- a/lib/c2_version.rb
+++ b/lib/c2_version.rb
@@ -13,12 +13,8 @@ class C2Version < PaperTrail::Version
     end
   end
 
-  def live_version
-    item
-  end
-
   def diff
-    next_version = self.next || live_version
+    next_version = self.next || item
     HashDiff.diff((attributes || {}), next_version.attributes)
   end
 end

--- a/spec/features/proposals/history_spec.rb
+++ b/spec/features/proposals/history_spec.rb
@@ -1,7 +1,6 @@
 describe 'View history for a proposal' do
-  let(:user) { create(:user) }
-
   it "displays the model information" do
+    user = create(:user)
     PaperTrail.whodunnit = user.id.to_s
     proposal = create(:proposal, requester: user)
     login_as(user)
@@ -9,5 +8,38 @@ describe 'View history for a proposal' do
     visit history_proposal_path(proposal)
 
     expect(page).to have_content('Proposal')
+  end
+
+  describe "History diffs" do
+    it "correctly shows changes per user" do
+      ncr_work_order = create(:ncr_work_order, :with_approvers)
+      proposal = ncr_work_order.proposal
+      requester = ncr_work_order.requester
+
+      edit_path = edit_ncr_work_order_path(ncr_work_order)
+
+      login_as(requester)
+      visit edit_path
+      fill_in "Description", with: "changed by requester"
+      click_on "Update"
+
+      approver = ncr_work_order.approvers.first
+      login_as(approver)
+      visit proposal_path(proposal)
+      click_on "Approve"
+
+      expect(current_path).to eq(proposal_path(proposal))
+      expect(page).to have_content("You have approved #{proposal.public_id}")
+
+      visit edit_path
+      fill_in "Description", with: "changed by approver"
+      click_on "Update"
+
+      expect(current_path).to eq(proposal_path(proposal))
+      expect(page).to have_content("changed by approver")
+
+      visit history_proposal_path(proposal)
+      expect(page).to have_content("changed by approver")
+    end
   end
 end

--- a/spec/lib/c2_version_spec.rb
+++ b/spec/lib/c2_version_spec.rb
@@ -1,0 +1,12 @@
+describe C2Version do
+  describe "#diff" do
+    it "compares this version (before) with the next (after)" do
+      test_client_request = create(:test_client_request)
+      test_client_request.project_title = "something different"
+      test_client_request.save!
+      versions = test_client_request.versions
+      expect(versions.count).to eq(2)
+      expect(versions.last.diff[1]).to eq(["~", "project_title", "I am a test request", "something different"])
+    end
+  end
+end


### PR DESCRIPTION
papertrail gem stores "before" version, so switch diff logic
to always compare the version record against what comes next,
not what came before. This allows the current live record
to be included in the history.

trello: https://trello.com/c/TC59Hwop/325-look-into-comment-history-vs-admin-history-disrepancy

before:
![history-fix-before](https://cloud.githubusercontent.com/assets/1205061/14568778/ad77f284-0300-11e6-9a3e-5ab481753677.png)

after:
![history-fix-after](https://cloud.githubusercontent.com/assets/1205061/14568786/b4a814ee-0300-11e6-8910-327c2d84741e.png)
