### PR TITLE
Remove unused / duplicate client data methods

### DIFF
--- a/app/controllers/client_data_controller.rb
+++ b/app/controllers/client_data_controller.rb
@@ -106,8 +106,9 @@ class ClientDataController < ApplicationController
     params.permit(attachments: [])[:attachments] || []
   end
 
-  # Hook for adding additional approvers
   def add_steps
-    @client_data_instance.initialize_steps
+    if errors.empty?
+      @client_data_instance.initialize_steps
+    end
   end
 end

--- a/app/controllers/gsa18f/procurements_controller.rb
+++ b/app/controllers/gsa18f/procurements_controller.rb
@@ -9,12 +9,5 @@ module Gsa18f
     def permitted_params
       Gsa18f::Procurement.permitted_params(params, @client_data_instance)
     end
-
-    def add_steps
-      super
-      if errors.empty?
-        @client_data_instance.add_steps
-      end
-    end
   end
 end

--- a/app/controllers/ncr/work_orders_controller.rb
+++ b/app/controllers/ncr/work_orders_controller.rb
@@ -49,12 +49,5 @@ module Ncr
     def permitted_params
       Ncr::WorkOrder.permitted_params(params, work_order)
     end
-
-    def add_steps
-      super
-      if errors.empty?
-        work_order.setup_approvals_and_observers
-      end
-    end
   end
 end

--- a/app/models/gsa18f/procurement.rb
+++ b/app/models/gsa18f/procurement.rb
@@ -48,15 +48,7 @@ module Gsa18f
     validates :purchase_type, presence: true
     validates :recurring_interval, presence: true, if: :recurring
 
-    def fields_for_display
-      Gsa18f::ProcurementFields.new(self).display
-    end
-
     def initialize_steps
-      add_steps
-    end
-
-    def add_steps
       steps = [
         Steps::Approval.new(user: User.for_email(Gsa18f::Procurement.approver_email)),
         Steps::Purchase.new(user: User.for_email(Gsa18f::Procurement.purchaser_email)),

--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -59,10 +59,6 @@ module Ncr
       ]
     end
 
-    def fields_for_display
-      Ncr::WorkOrderFields.new(self).display
-    end
-
     def approver_email_frozen?
       approval = individual_steps.first
       approval && !approval.actionable?

--- a/spec/factories/gsa18f/procurements.rb
+++ b/spec/factories/gsa18f/procurements.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
     association :proposal, client_slug: "gsa18f"
 
     trait :with_steps do
-      after(:create) { |procurement| procurement.add_steps }
+      after(:create) { |procurement| procurement.initialize_steps }
     end
   end
 end


### PR DESCRIPTION
* `fields_for_display` is defined/used in decorators (no longer needed
  def in `Ncr::WorkOrder`...was left in accidentally)
* `add_steps` in client-specific controllers was setting up approvers a
  second time (called `super` which did setup first time in parent
  controller)