### PR TITLE
Admin tasks no email

### DIFF
--- a/app/admin/proposal.rb
+++ b/app/admin/proposal.rb
@@ -50,6 +50,10 @@ ActiveAdmin.register Proposal do
     link_to "Complete", fully_complete_admin_proposal_path(proposal), "data-method" => :post, title: "Fully complete this proposal"
   end
 
+  action_item :fully_complete_no_email, only: [:show] do
+    link_to "Complete without notifications", fully_complete_no_email_admin_proposal_path(proposal), "data-method" => :post, title: "Fully complete this proposal without sending notifications to affected subscribers"
+  end
+
   member_action :reindex, method: :post do
     resource.delay.reindex
     flash[:alert] = "Re-index scheduled!"
@@ -58,6 +62,12 @@ ActiveAdmin.register Proposal do
 
   member_action :fully_complete, method: :post do
     resource.fully_complete!(current_user)
+    flash[:alert] = "Completed!"
+    redirect_to admin_proposal_path(resource)
+  end
+
+  member_action :fully_complete_no_email, method: :post do
+    resource.fully_complete!(current_user, true)
     flash[:alert] = "Completed!"
     redirect_to admin_proposal_path(resource)
   end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -266,10 +266,11 @@ class Proposal < ActiveRecord::Base
     DispatchFinder.run(self).deliver_new_proposal_emails
   end
 
-  def fully_complete!(completer = nil)
+  def fully_complete!(completer = nil, skip_notifications = false)
     individual_steps.each do |step|
       step.reload
       next if step.completed?
+      step.skip_notifications = skip_notifications
       step.complete!
       if completer
         step.update(completer: completer)

--- a/app/models/steps/individual.rb
+++ b/app/models/steps/individual.rb
@@ -7,6 +7,8 @@ module Steps
     validates :user, presence: true
     delegate :full_name, :email_address, to: :user, prefix: true
 
+    attr_accessor :skip_notifications
+
     self.abstract_class = true
 
     workflow do
@@ -29,7 +31,9 @@ module Steps
         on_entry do
           update(completed_at: Time.zone.now)
           notify_parent_completed
-          DispatchFinder.run(self.proposal).step_complete(self)
+          unless skip_notifications
+            DispatchFinder.run(self.proposal).step_complete(self)
+          end
         end
 
         event :initialize, transitions_to: :actionable do

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -81,6 +81,19 @@ describe "admin" do
     expect(proposal).to be_completed
   end
 
+  it "does not trigger actions on Complete Without Notifications button click" do
+    user = login_as_admin_user
+    proposal = create(:proposal, :with_serial_approvers)
+
+    deliveries.clear
+    visit admin_proposal_path(proposal)
+    click_link "Complete without notifications"
+
+    expect(deliveries.count).to eq(0)
+    proposal.reload
+    expect(proposal).to be_completed
+  end
+
   it "triggers actions on Step edit" do
     user = login_as_admin_user
     proposal = create(:proposal, :with_serial_approvers)

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -239,6 +239,15 @@ describe Proposal do
 
       expect(proposal.status).to eq "completed"
     end
+
+    it "does not send notifications if explicitly prevented" do
+      proposal = create(:proposal, :with_serial_approvers)
+      deliveries.clear
+      proposal.fully_complete!(nil, true)
+
+      expect(proposal.status).to eq "completed"
+      expect(deliveries.count).to eq 0
+    end
   end
 
   describe "searchable callbacks" do

--- a/spec/models/steps/individual_spec.rb
+++ b/spec/models/steps/individual_spec.rb
@@ -59,4 +59,16 @@ describe Steps::Individual do
       expect(step.completed_by).to eq(assigned_user)
     end
   end
+
+  describe "#skip_notifications" do
+    it "does not dispatch emails when set to true" do
+      approval = create(:approval_step)
+      approval.skip_notifications = true
+      deliveries.clear
+
+      approval.initialize!
+      approval.complete!
+      expect(deliveries.count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
trello: https://trello.com/c/OUj6cUMt/317-as-an-admin-i-can-bypass-email-sends-when-updating-the-overall-status-or-specific-step-status-of-a-request-so-that-i-can-perform

Fully completing a Proposal will, by default, send email to all affected subscribers. This adds a second button that completes without notifying.

NOTE that editing the status of a Step directly via the admin UI does **not** generate any email.