### PR TITLE
Fixes the attachment display

### DIFF
--- a/app/mailers/proposal_mailer.rb
+++ b/app/mailers/proposal_mailer.rb
@@ -22,7 +22,7 @@ class ProposalMailer < ApplicationMailer
   def proposal_created_confirmation(proposal)
     @proposal = proposal.decorate
     @recipient = @proposal.requester
-    add_proposal_attributes_icons(@proposal)
+    add_approval_chain_attachments(@proposal)
     add_inline_attachment("icon-page-circle.png")
     assign_threading_headers(@proposal)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,44 +1,46 @@
-require 'codeclimate-test-reporter'
+require "codeclimate-test-reporter"
+
 SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   CodeClimate::TestReporter::Formatter
 ]
-SimpleCov.start 'rails' do
-  if ENV['CIRCLE_ARTIFACTS']
-    dir = File.join(ENV['CIRCLE_ARTIFACTS'], 'coverage')
+SimpleCov.start "rails" do
+  if ENV["CIRCLE_ARTIFACTS"]
+    dir = File.join(ENV["CIRCLE_ARTIFACTS"], "coverage")
     coverage_dir(dir)
   end
 end
 
-require 'zonebie'
+require "zonebie"
 Zonebie.set_random_timezone
 
-require 'webmock/rspec'
+require "webmock/rspec"
 # localhost needed for omniauth
-WebMock.disable_net_connect!(allow_localhost: true, allow: 'codeclimate.com:443')
+WebMock.disable_net_connect!(allow_localhost: true, allow: "codeclimate.com:443")
 
-require 'rack_session_access/capybara'
+require "rack_session_access/capybara"
 
-require 'capybara/poltergeist'
+require "capybara/poltergeist"
 Capybara.register_driver :poltergeist do |app|
   options = {
     timeout: 60,
-    debug: ENV['CAPYBARA_DEBUG'] || false
+    debug: ENV["CAPYBARA_DEBUG"] || false
   }
   Capybara::Poltergeist::Driver.new(app, options)
 end
 Capybara.javascript_driver = :poltergeist
 Capybara.default_max_wait_time = 10
 Capybara.server do |app, port|
-  require 'rack/handler/puma'
+  require "rack/handler/puma"
   Rack::Handler::Puma.run(app, Port: port)
 end
+
 puts "phantomjs -v"
 system("phantomjs -v")
 
-require 'pundit/rspec'
-require 'factory_girl_rails'
-require 'site_prism'
+require "pundit/rspec"
+require "factory_girl_rails"
+require "site_prism"
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
Fixes [Attachment display in initial email](https://trello.com/c/3MUWkqrh/405-attachment-display-in-initial-email). 

The problem was that we were including an extra icon — the 'attachment' icon — but not referencing it in the email html. The browser then rendered it explicitly like the screenshot shows. Fixed by not including it by calling `add_approval_chain_attachments` directly. 