### PR TITLE
Expand the Puma thread tool during testing

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -11,8 +11,10 @@ default: &default
 development:
   <<: *default
   database: c2_development
+  pool: 10
 test:
   <<: *default
+  pool: 10
 # use 'url' rather than 'database' so that DATABASE_URL env var is not merged in.
 # see URL at top of this file for docs.
   url: <%= (ENV["TEST_DATABASE_URL"] || "postgresql://localhost/c2_test") %>

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,7 +1,8 @@
 # https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server
 
 workers 1
-threads_count = 3
+threads_count = Rails.env.test? ? 10 : 3
+
 threads threads_count, threads_count
 
 preload_app!


### PR DESCRIPTION
New JS tests are failing consistently. Increasing thread pool resolves the issues.