### PR TITLE
New Details Page "Edit mode

### DIFF
--- a/app/assets/javascripts/details/state/edit_mode.js
+++ b/app/assets/javascripts/details/state/edit_mode.js
@@ -1,0 +1,46 @@
+"use strict";
+
+var EditStateController = function (el) {
+  this.el = $(el);
+  this._setup();
+  return this;
+}
+
+EditStateController.prototype._setup = function () {
+  this.state = "view";
+  this._event();
+}
+
+EditStateController.prototype._event = function () {
+  this.el.on( "edit-mode:toggle", function( event ) {
+    var mode = $( this );
+    if ( mode.is( ".edit-mode" ) ) {
+      this.state = "edit";
+      this.el.trigger("edit-mode:on");
+    } else {
+      this.state = "view";
+      this.el.trigger("edit-mode:off");
+    }
+  });
+}
+
+EditStateController.prototype.getState = function () {
+  if(this.el.hasClass("edit-mode")){
+    return true;
+  } else {
+    return false;
+  }
+}
+
+EditStateController.prototype.toggleState = function () {
+  if ( this.el.is( ".edit-mode" ) ) {
+    this.state = "view";
+    this.el.addClass('view-mode').removeClass('edit-mode');
+    this.el.trigger("edit-mode:off");
+  } else {
+    this.state = "edit";
+    this.el.addClass('edit-mode').removeClass('view-mode');
+    this.el.trigger("edit-mode:on");
+  }
+  var state = this.state;
+}

--- a/app/assets/javascripts/details/state/edit_mode.js
+++ b/app/assets/javascripts/details/state/edit_mode.js
@@ -34,13 +34,25 @@ EditStateController.prototype.getState = function () {
 
 EditStateController.prototype.toggleState = function () {
   if ( this.el.is( ".edit-mode" ) ) {
-    this.state = "view";
-    this.el.addClass('view-mode').removeClass('edit-mode');
-    this.el.trigger("edit-mode:off");
-  } else {
-    this.state = "edit";
-    this.el.addClass('edit-mode').removeClass('view-mode');
-    this.el.trigger("edit-mode:on");
+    this.stateTo('view');
+  } else if ( this.el.is( ".view-mode" ) ){
+    this.stateTo('edit');
   }
   var state = this.state;
+}
+
+EditStateController.prototype.stateTo = function (state) {
+  this.state = state;
+  this.el.addClass(state + '-mode');
+  
+  switch(state) {
+    case "view":
+      this.el.removeClass('edit-mode');
+      this.el.trigger("edit-mode:off");
+      break;
+    case "edit":
+      this.el.removeClass('view-mode');
+      this.el.trigger("edit-mode:on");
+      break;
+  }
 }

--- a/app/views/proposals/show_next.html.haml
+++ b/app/views/proposals/show_next.html.haml
@@ -1,6 +1,6 @@
 = stylesheet_link_tag "redesign/app"
 
-= javascript_include_tag "details/app"
+= javascript_include_tag "details/state/edit_mode"
 
 #mode-parent.view-mode
   = render partial: "proposals/details/top_notification", locals: { proposal: @proposal }
@@ -10,17 +10,21 @@
   .row
     .medium-12.column.wrap-hard
       = render partial: "proposals/details/summary", locals: { proposal: @proposal }
+  
   .row.footer-buffer
     .medium-6.column
       = render partial: "proposals/details/approvals", locals: { proposal: @proposal }
       = render partial: "proposals/details/activity", locals: { proposal: @proposal, events: @events }
+  
     .medium-6.column
       = render partial: "proposals/details/request_details", locals: { proposal: @proposal }
       = render partial: "proposals/details/attachment", locals: { proposal: @proposal }
       = render partial: "proposals/details/observer", locals: { proposal: @proposal }
+  
       .row
         .medium-12.column.wrap-hard
           - if policy(@proposal).can_cancel?
             %div.fr.cancel-action
               = link_to "Cancel this request", cancel_form_proposal_path, class: "button secondary large cancel-request-button"
+  
   = render partial: "proposals/details/action", locals: { proposal: @proposal }

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,7 +1,7 @@
 # https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server
 
 workers 1
-threads_count = 3
+threads_count = 5
 
 threads threads_count, threads_count
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,7 +1,7 @@
 # https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server
 
 workers 1
-threads_count = Rails.env.test? ? 10 : 3
+threads_count = 3
 
 threads threads_count, threads_count
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,7 +1,7 @@
 # https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server
 
 workers 1
-threads_count = 5
+threads_count = 0, 16
 
 threads threads_count, threads_count
 

--- a/spec/javascripts/state/edit_mode_spec.js.coffee
+++ b/spec/javascripts/state/edit_mode_spec.js.coffee
@@ -1,6 +1,5 @@
 #= require jquery
 #= require details/state/edit_mode
-#= require spec_helper
 
 describe 'EditMode', ->
   getContent = ->

--- a/spec/javascripts/state/edit_mode_spec.js.coffee
+++ b/spec/javascripts/state/edit_mode_spec.js.coffee
@@ -1,0 +1,59 @@
+#= require jquery
+#= require details/state/edit_mode
+#= require spec_helper
+
+describe 'EditMode', ->
+  getContent = ->
+    $('
+      <div class="view-mode" id="mode-parent"></div>
+    ')
+
+  describe '#state', ->
+    it "on load it returns view", ->
+      mode = new EditStateController(getContent())  
+      expect(mode.state).to.eql('view')
+  
+  describe '#getState()', ->
+    it "check edit state", ->
+      mode = new EditStateController(getContent())  
+      expect(mode.getState()).to.eql(false)
+
+  describe '#toggleState()', ->
+    it "toggle state (1) from in view mode to edit", ->
+      mode = new EditStateController(getContent())  
+      mode.toggleState()
+      expect(mode.state).to.eql('edit')
+      expect(mode.getState()).to.eql(true)
+
+    it "toggle state multiple (4) times from in view mode to view", ->
+      mode = new EditStateController(getContent())  
+      mode.toggleState()
+      mode.toggleState()
+      mode.toggleState()
+      mode.toggleState()
+      expect(mode.state).to.eql('view')
+      expect(mode.getState()).to.eql(false)
+  
+  describe '#edit-mode event', ->
+    it "get the edit-mode:on", ->
+      mode = new EditStateController(getContent())  
+      flag = false
+      
+      mode.el.on 'edit-mode:on', ->
+        flag = true
+      
+      mode.toggleState()
+
+      expect(flag).to.eql(true)
+  
+    it "get the edit-mode:off", ->
+      mode = new EditStateController(getContent())  
+      flag = false
+      
+      mode.el.on 'edit-mode:off', ->
+        flag = true
+      
+      mode.toggleState()
+      mode.toggleState()
+
+      expect(flag).to.eql(true)


### PR DESCRIPTION
# What

Use the `.on` on the `#mode-parent` element to control page's edit/view mode.

## Note

This is a partial PR. The code is functional on its own and can be merged, but doesnt make sense without the following PRs.

## Trello

Not yet.