### PR TITLE
Fixed two bugs with observer card

### DIFF
--- a/app/assets/stylesheets/redesign/_card-observers.scss.erb
+++ b/app/assets/stylesheets/redesign/_card-observers.scss.erb
@@ -59,3 +59,8 @@ ul.observer-list{
   background-image: image-url('remove-x.png');
   opacity: .8;
 }
+
+.card-for-observers .selectize-dropdown{
+  position:relative !important;
+  top: 1px !important;
+}

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -14,7 +14,7 @@ class ObservationsController < ApplicationController
     proposal = observation.proposal
     DispatchFinder.run(proposal).on_observer_removed(observation.user)
     observation.destroy
-    flash[:success] = "Removed Observation for #{proposal.public_id}" 
+    flash[:success] = "Removed Observation for #{proposal.public_id}"
     if current_user == observation.user
       redirect_to_observer
     else
@@ -71,9 +71,9 @@ class ObservationsController < ApplicationController
 
   def redirect_to_observer
     respond_to do |format|
-        format.html { redirect_to proposals_path }
-        @redirect_path = proposals_path
-        format.js { render "shared/redirect"}
-      end
+      format.html { redirect_to proposals_path }
+      @redirect_path = proposals_path
+      format.js { render "shared/redirect" }
     end
+  end
 end

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -14,9 +14,9 @@ class ObservationsController < ApplicationController
     proposal = observation.proposal
     DispatchFinder.run(proposal).on_observer_removed(observation.user)
     observation.destroy
-    flash[:success] = "Removed Observation for #{proposal.public_id}"
+    flash[:success] = "Removed Observation for #{proposal.public_id}" 
     if current_user == observation.user
-      redirect_to proposals_path
+      redirect_to_observer
     else
       respond_to_observer
     end
@@ -68,4 +68,12 @@ class ObservationsController < ApplicationController
       format.js
     end
   end
+
+  def redirect_to_observer
+    respond_to do |format|
+        format.html { redirect_to proposals_path }
+        @redirect_path = proposals_path
+        format.js { render "shared/redirect"}
+      end
+    end
 end

--- a/app/views/observations/destroy.js.erb
+++ b/app/views/observations/destroy.js.erb
@@ -1,1 +1,3 @@
 window.c2.observerCardController.update('<%=j render partial: 'proposals/details/observer', locals: {proposal: @proposal} %>');
+
+

--- a/app/views/shared/redirect.js.erb
+++ b/app/views/shared/redirect.js.erb
@@ -1,0 +1,5 @@
+<% if @redirect_path %>
+  window.location = '<%= @redirect_path %>';
+<% else %>
+  window.location ='<%= proposals_path %>'
+<% end %>

--- a/spec/features/observer_spec.rb
+++ b/spec/features/observer_spec.rb
@@ -50,6 +50,19 @@ feature "Observers" do
     visit "/proposals/#{proposal.id}?detail=old"
   end
 
+  scenario "allows observers to remove self with javascript", js: true do 
+    observer = create(:user)
+    proposal = create(:proposal, observer: observer)
+    login_as(observer)
+
+    visit "/proposals/#{proposal.id}?detail=new"
+    delete_button = find('.observer-remove-button')
+    delete_button.click
+    wait_for_ajax
+    expect(page).to have_content("Removed Observation for")
+    visit "/proposals/#{proposal.id}?detail=old"
+  end
+
   scenario "allows observers to be added by other observers" do
     proposal = create(:proposal, :with_observer)
     observer1 = proposal.observers.first


### PR DESCRIPTION
  You can now delete yourself as an observer which redirects you like the original page did.
  The dropdown for observers is no longer cut off by the card.