### PR TITLE
Add the notification bar functionality

### DIFF
--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -95,7 +95,6 @@ C2 = (function() {
     var self = this;  
     this.detailsRequestCard.el.on('form:updated', function(event, data){
       self.detailsSaved(data);
-      self.actionBar.el.trigger("action-bar-clicked:saved");
     });
   }
 

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -106,6 +106,7 @@ C2 = (function() {
 
     this.detailsSave.el.on('details-form:error', function(event, data){
       self.handleSaveError(data);
+      self.actionBar.saveButtonLadda.ladda( 'stop' );
     });
   }
 

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -4,13 +4,14 @@ C2 = (function() {
   function C2(config){
     config = config || {};
     this.config = {
-      actionBar:      '.action-bar-wrapper',
+      actionBar:      '#action-bar-wrapper',
       attachmentCard: '.card-for-attachments',
       detailsForm:    '#request-details-card',
       detailsSave:    '#request-details-card',
       editMode:       '#mode-parent',
       formState:      '#request-details-card',
       undoCheck:      '#request-details-card form',
+      notifications:  '#action-bar-status',
       observerCard:   '.card-for-observers'
     }
     this._overrideTestConfig(config);

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -105,7 +105,7 @@ C2 = (function() {
     });
 
     this.detailsSave.el.on('details-form:error', function(event, data){
-      console.log('error: ', data);
+      self.handleSaveError(data);
     });
   }
 
@@ -118,6 +118,14 @@ C2 = (function() {
       } else {
         self.detailsView();
       }
+    });
+  }
+
+  C2.prototype.handleSaveError = function(data){
+    this.notification.trigger('notification:create', {
+      title: "Request Not Saved",
+      content: data['response'][0],
+      status: "alert"
     });
   }
 
@@ -149,6 +157,11 @@ C2 = (function() {
     this.actionBar.viewMode();
     this.actionBar.cancelDisable();
     this.undoCheck.viewed = true;
+    this.notification.trigger('notification:create', {
+      title: "Canceled Change",
+      content: "",
+      status: "notice"
+    });
   }
  
   C2.prototype.processSaveRequest = function(){
@@ -158,7 +171,11 @@ C2 = (function() {
     this.undoCheck.el.trigger("undo-check:save");
     this.actionBar.el.trigger("action-bar-clicked:saved");
     this.detailsView();
-    this.notification.create(data);
+    this.notification.trigger('notification:create', {
+      title: "Changes Saved",
+      content: "Your changes were saved.",
+      status: "success"
+    });
   }
   
   C2.prototype.detailsEditMode = function(){

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -118,7 +118,11 @@ C2 = (function() {
       if(!self.editMode.getState()){
         self.detailsEditMode();
       } else {
-        self.detailsView();
+        if(self.undoCheck.hasChanged()){
+          self.detailsCancelled();
+        } else {
+          self.detailsView();
+        }
       }
     });
   }
@@ -145,7 +149,7 @@ C2 = (function() {
   C2.prototype._setupActionBar = function(){
     var self = this;
     this.actionBar.el.on("action-bar-clicked:cancel", function(){
-      self.detailsView();
+      self.detailsCancelled();
     });
     this.actionBar.el.on("action-bar-clicked:save", function(){
       self.actionBar.el.trigger("action-bar-clicked:saving");

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -128,10 +128,12 @@ C2 = (function() {
   }
 
   C2.prototype.handleSaveError = function(data){
-    this.notification.el.trigger('notification:create', {
-      title: "Request Not Saved",
-      content: data['response'][0],
-      type: "alert"
+    $.each(data['response'], function(i, item){
+      this.notification.el.trigger('notification:create', {
+        title: "Request Not Saved",
+        content: item,
+        type: "alert"
+      });
     });
   }
 

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -54,6 +54,7 @@ C2 = (function() {
     this.attachmentCardController = new AttachmentCardController(config.attachmentCard);
     this.observerCardController = new ObserverCardController(config.observerCard);
     this.actionBar = new ActionBar(config.actionBar);
+    this.notification = new NotificationBars(config.notifications);
   }
 
   C2.prototype._setupEvents = function(){
@@ -78,7 +79,7 @@ C2 = (function() {
   C2.prototype._setupDetailsForm = function(){
     var self = this;  
     this.detailsRequestCard.el.on('form:updated', function(event, data){
-      self.detailsSaved();
+      self.detailsSaved(data);
       self.actionBar.el.trigger("action-bar-clicked:saved");
     });
   }
@@ -139,10 +140,11 @@ C2 = (function() {
   C2.prototype.processSaveRequest = function(){
   }
   
-  C2.prototype.detailsSaved = function(){
+  C2.prototype.detailsSaved = function(data){
     this.undoCheck.el.trigger("undo-check:save");
     this.actionBar.el.trigger("action-bar-clicked:saved");
     this.detailsView();
+    this.notification.create(data);
   }
   
   C2.prototype.detailsEditMode = function(){

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -116,7 +116,7 @@ C2 = (function() {
     for (var i = response.length - 1; i >= 0; i--) {
       this.notification.el.trigger('notification:create', {
         title: "Request Not Saved",
-        content: response[i]['content'],
+        content: response[i],
         type: "alert"
       });
     }

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -111,13 +111,15 @@ C2 = (function() {
   }
 
   C2.prototype.handleSaveError = function(data){
-    $.each(data['response'], function(i, item){
+    console.log("C2.prototype.handleSaveError: ", data);
+    var response = data['response'];
+    for (var i = response.length - 1; i >= 0; i--) {
       this.notification.el.trigger('notification:create', {
         title: "Request Not Saved",
-        content: item,
+        content: response[i]['content'],
         type: "alert"
       });
-    });
+    }
   }
 
   C2.prototype._setupEditToggle = function(){

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -64,8 +64,22 @@ C2 = (function() {
     this._setupDetailsData();
     this._setupDetailsForm();
     this._setupEditMode();
+    this._setupNotifications();
   }
   
+  /**
+   * data['title']
+   * data['content']
+   * data['status']
+   * data['timeout'] (optional)
+   */
+  C2.prototype._setupNotifications = function(){
+    var self = this;  
+    this.notification.el.on('notification:create', function(data){
+      self.notification.create(data);
+    });
+  }
+
   C2.prototype._setupEditMode = function(){
     var self = this;  
     this.editMode.el.on('edit-mode:has-changed', function(){

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -54,7 +54,7 @@ C2 = (function() {
     this.attachmentCardController = new AttachmentCardController(config.attachmentCard);
     this.observerCardController = new ObserverCardController(config.observerCard);
     this.actionBar = new ActionBar(config.actionBar);
-    this.notification = new NotificationBars(config.notifications);
+    this.notification = new Notifications(config.notifications);
   }
 
   C2.prototype._setupEvents = function(){

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -111,6 +111,16 @@ C2 = (function() {
     });
   }
 
+  C2.prototype.handleSaveError = function(data){
+    $.each(data['response'], function(i, item){
+      this.notification.el.trigger('notification:create', {
+        title: "Request Not Saved",
+        content: item,
+        type: "alert"
+      });
+    });
+  }
+
   C2.prototype._setupEditToggle = function(){
     var self = this;
     this.detailsRequestCard.el.on('edit-toggle:trigger', function(){
@@ -124,16 +134,6 @@ C2 = (function() {
           self.detailsView();
         }
       }
-    });
-  }
-
-  C2.prototype.handleSaveError = function(data){
-    $.each(data['response'], function(i, item){
-      this.notification.el.trigger('notification:create', {
-        title: "Request Not Saved",
-        content: item,
-        type: "alert"
-      });
     });
   }
 

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -75,7 +75,8 @@ C2 = (function() {
    */
   C2.prototype._setupNotifications = function(){
     var self = this;  
-    this.notification.el.on('notification:create', function(data){
+    this.notification.el.on('notification:create', function(event, data){
+      console.log('Notification: ', data);
       self.notification.create(data);
     });
   }
@@ -123,10 +124,10 @@ C2 = (function() {
   }
 
   C2.prototype.handleSaveError = function(data){
-    this.notification.trigger('notification:create', {
+    this.notification.el.trigger('notification:create', {
       title: "Request Not Saved",
       content: data['response'][0],
-      status: "alert"
+      type: "alert"
     });
   }
 
@@ -158,10 +159,10 @@ C2 = (function() {
     this.actionBar.viewMode();
     this.actionBar.cancelDisable();
     this.undoCheck.viewed = true;
-    this.notification.trigger('notification:create', {
+    this.notification.el.trigger('notification:create', {
       title: "Canceled Change",
       content: "",
-      status: "notice"
+      type: "notice"
     });
   }
  
@@ -172,10 +173,10 @@ C2 = (function() {
     this.undoCheck.el.trigger("undo-check:save");
     this.actionBar.el.trigger("action-bar-clicked:saved");
     this.detailsView();
-    this.notification.trigger('notification:create', {
+    this.notification.el.trigger('notification:create', {
       title: "Changes Saved",
       content: "Your changes were saved.",
-      status: "success"
+      type: "success"
     });
   }
   

--- a/app/assets/javascripts/details/views/notifications.js
+++ b/app/assets/javascripts/details/views/notifications.js
@@ -21,17 +21,23 @@ NotificationBars = (function(){
     this._postNotification(notice);
   }
 
+  NotificationBars.prototype._closeHook = function(el){
+    var $notice = $(el).parent();
+    $notice.animate({
+      "min-height": "0px", 
+      height: "0px"
+    }, 500, 
+    function(){ 
+      $notice.remove();
+    });
+  }
+
   NotificationBars.prototype._postNotification = function(notice){
+    var self = this;
     this.el.find('ul').append(function() {
       return $(notice).find('.close').on('click', function(){
-        $(this).parent().animate({
-          "min-height": "0px", 
-          height: "0px"
-        }, 
-        500, 
-        function(){ 
-          $(this).remove() 
-        });
+        var el = this;
+        self._closeHook(el);
       });
     })
   }

--- a/app/assets/javascripts/details/views/notifications.js
+++ b/app/assets/javascripts/details/views/notifications.js
@@ -15,6 +15,36 @@ NotificationBars = (function(){
 
   }
 
+  NotificationBars.prototype.create = function(params){
+    var notice = this._prepare(params);
+    this.postNotification(notice);
+  }
+
+  NotificationBars.prototype.postNotification = function(notice){
+    this.el.find('ul').append(notice);
+  }
+
+  NotificationBars.prototype._prepare = function(params){
+    var type    = (params['type']) ? params['type'] : 'primary';
+    var title   = (params['title']) ? params['title'] : '';
+    var content = (params['content']) ? params['content'] : '';
+    var timeout = (params['timeout']) ? params['timeout'] : false;
+    
+    var notice = '<li class="notice-type-' + type + ' notification-bar-el" data-timeout="' + timeout + '">' +
+      '<div><h4>' + title + '</h4><p>' + content + '</p></div>' + 
+    '</li>';
+    
+    return notice
+  }
+
+  NotificationBars.prototype.clearAll = function(){
+  }
+
+  // Use the ID to select which to clear
+  NotificationBars.prototype.clearOne = function(id){
+    
+  }
+
   return NotificationBars;
 
 }());

--- a/app/assets/javascripts/details/views/notifications.js
+++ b/app/assets/javascripts/details/views/notifications.js
@@ -1,27 +1,27 @@
-var NotificationBars;
+var Notifications;
 
-NotificationBars = (function(){
-  function NotificationBars(el) {
+Notifications = (function(){
+  function Notifications(el) {
     this.el = $(el);
     this._setup();
     return this;
   }
   
-  NotificationBars.prototype._setup = function(){
+  Notifications.prototype._setup = function(){
     this._events();
   }
 
-  NotificationBars.prototype._events = function(){
+  Notifications.prototype._events = function(){
     this._closeButton()
   }
 
-  NotificationBars.prototype.create = function(params){
+  Notifications.prototype.create = function(params){
     console.log('Notification created');
     var notice = this._prepare(params);
     this._postNotification(notice);
   }
 
-  NotificationBars.prototype._closeButton = function(el){
+  Notifications.prototype._closeButton = function(el){
     this.el.delegate('.close', 'click', function(){
       var el = this;
       var $notice = $(el).closest('.notification-bar-el');
@@ -35,14 +35,14 @@ NotificationBars = (function(){
     })
   }
 
-  NotificationBars.prototype._postNotification = function(notice){
+  Notifications.prototype._postNotification = function(notice){
     var self = this;
     this.el.find('ul').append(function() {
       return $(notice);
     })
   }
 
-  NotificationBars.prototype._prepare = function(params){
+  Notifications.prototype._prepare = function(params){
     var type    = (params['type']) ? params['type'] : 'primary';
     var title   = (params['title']) ? params['title'] : '';
     var content = (params['content']) ? params['content'] : '';
@@ -58,16 +58,16 @@ NotificationBars = (function(){
     return notice
   }
 
-  NotificationBars.prototype.clearAll = function(){
+  Notifications.prototype.clearAll = function(){
   }
 
   // Use the ID to select which to clear
-  NotificationBars.prototype.clearOne = function(id){
+  Notifications.prototype.clearOne = function(id){
     
   }
 
-  return NotificationBars;
+  return Notifications;
 
 }());
 
-window.NotificationBars = NotificationBars;
+window.Notifications = Notifications;

--- a/app/assets/javascripts/details/views/notifications.js
+++ b/app/assets/javascripts/details/views/notifications.js
@@ -1,0 +1,22 @@
+var NotificationBars;
+
+NotificationBars = (function(){
+  function NotificationBars(el) {
+    this.el = $(el);
+    this._setup();
+    return this;
+  }
+  
+  NotificationBars.prototype._setup = function(){
+    this._events();
+  }
+
+  NotificationBars.prototype._events = function(){
+
+  }
+
+  return NotificationBars;
+
+}());
+
+window.NotificationBars = NotificationBars;

--- a/app/assets/javascripts/details/views/notifications.js
+++ b/app/assets/javascripts/details/views/notifications.js
@@ -59,11 +59,14 @@ Notifications = (function(){
   }
 
   Notifications.prototype.clearAll = function(){
-  }
-
-  // Use the ID to select which to clear
-  Notifications.prototype.clearOne = function(id){
-    
+    var $notices = this.el.find('.notification-bar-el');
+    $notices.animate({
+      "min-height": "0px", 
+      height: "0px"
+    }, 500, 
+    function(){ 
+      $notices.remove();
+    });
   }
 
   return Notifications;

--- a/app/assets/javascripts/details/views/notifications.js
+++ b/app/assets/javascripts/details/views/notifications.js
@@ -22,7 +22,18 @@ NotificationBars = (function(){
   }
 
   NotificationBars.prototype._postNotification = function(notice){
-    this.el.find('ul').append(notice);
+    this.el.find('ul').append(function() {
+      return $(notice).find('.close').on('click', function(){
+        $(this).parent().animate({
+          "min-height": "0px", 
+          height: "0px"
+        }, 
+        500, 
+        function(){ 
+          $(this).remove() 
+        });
+      });
+    })
   }
 
   NotificationBars.prototype._prepare = function(params){
@@ -32,7 +43,10 @@ NotificationBars = (function(){
     var timeout = (params['timeout']) ? params['timeout'] : false;
     
     var notice = '<li class="notice-type-' + type + ' notification-bar-el" data-timeout="' + timeout + '">' +
-      '<div class="row"><span class="notification-title">' + title + '</span><span class="notification-content">' + content + '</span></div>' + 
+      '<div class="row">' +
+        '<span class="notification-title">' + title + '</span><span class="notification-content">' + content + '</span>' +
+        '<button class="close">Close</button>' +
+      '</div>' +
     '</li>';
     
     return notice

--- a/app/assets/javascripts/details/views/notifications.js
+++ b/app/assets/javascripts/details/views/notifications.js
@@ -16,11 +16,12 @@ NotificationBars = (function(){
   }
 
   NotificationBars.prototype.create = function(params){
+    console.log('Notification created');
     var notice = this._prepare(params);
-    this.postNotification(notice);
+    this._postNotification(notice);
   }
 
-  NotificationBars.prototype.postNotification = function(notice){
+  NotificationBars.prototype._postNotification = function(notice){
     this.el.find('ul').append(notice);
   }
 
@@ -31,7 +32,7 @@ NotificationBars = (function(){
     var timeout = (params['timeout']) ? params['timeout'] : false;
     
     var notice = '<li class="notice-type-' + type + ' notification-bar-el" data-timeout="' + timeout + '">' +
-      '<div><h4>' + title + '</h4><p>' + content + '</p></div>' + 
+      '<div class="row"><span class="notification-title">' + title + '</span><span class="notification-content">' + content + '</span></div>' + 
     '</li>';
     
     return notice

--- a/app/assets/javascripts/details/views/notifications.js
+++ b/app/assets/javascripts/details/views/notifications.js
@@ -12,7 +12,7 @@ NotificationBars = (function(){
   }
 
   NotificationBars.prototype._events = function(){
-
+    this._closeButton()
   }
 
   NotificationBars.prototype.create = function(params){
@@ -21,24 +21,24 @@ NotificationBars = (function(){
     this._postNotification(notice);
   }
 
-  NotificationBars.prototype._closeHook = function(el){
-    var $notice = $(el).parent();
-    $notice.animate({
-      "min-height": "0px", 
-      height: "0px"
-    }, 500, 
-    function(){ 
-      $notice.remove();
-    });
+  NotificationBars.prototype._closeButton = function(el){
+    this.el.delegate('.close', 'click', function(){
+      var el = this;
+      var $notice = $(el).closest('.notification-bar-el');
+      $notice.animate({
+        "min-height": "0px", 
+        height: "0px"
+      }, 500, 
+      function(){ 
+        $notice.remove();
+      });
+    })
   }
 
   NotificationBars.prototype._postNotification = function(notice){
     var self = this;
     this.el.find('ul').append(function() {
-      return $(notice).find('.close').on('click', function(){
-        var el = this;
-        self._closeHook(el);
-      });
+      return $(notice);
     })
   }
 
@@ -48,12 +48,12 @@ NotificationBars = (function(){
     var content = (params['content']) ? params['content'] : '';
     var timeout = (params['timeout']) ? params['timeout'] : false;
     
-    var notice = '<li class="notice-type-' + type + ' notification-bar-el" data-timeout="' + timeout + '">' +
-      '<div class="row">' +
-        '<span class="notification-title">' + title + '</span><span class="notification-content">' + content + '</span>' +
-        '<button class="close">Close</button>' +
-      '</div>' +
-    '</li>';
+    var notice =  '<li class="notice-type-' + type + ' notification-bar-el" data-timeout="' + timeout + '">' +
+                    '<div class="row">' +
+                      '<span class="notification-title">' + title + '</span><span class="notification-content">' + content + '</span>' +
+                      '<button class="close">Close</button>' +
+                    '</div>' +
+                  '</li>';
     
     return notice
   }

--- a/app/assets/stylesheets/redesign/_card-action.scss
+++ b/app/assets/stylesheets/redesign/_card-action.scss
@@ -44,7 +44,7 @@ ul#request-actions{
 }
 
 $action-bar-wrapper-height-small: 60px;
-.action-bar-status{
+#action-bar-status{
   display: none;
   bottom:  $action-bar-wrapper-height-small;
   &.show{
@@ -52,28 +52,28 @@ $action-bar-wrapper-height-small: 60px;
   }
 }
 
-.action-bar-wrapper{
+#action-bar-wrapper{
   height: $action-bar-wrapper-height-small;
   padding-top: 10px;
 }
 
 @media screen and ( min-height: 700px ){
   $action-bar-wrapper-height: 110px;
-  .action-bar-status{
+  #action-bar-status{
     .status-bar{
       padding-top: 7px;
     }
     bottom:  $action-bar-wrapper-height;
   }
 
-  .action-bar-wrapper{
+  #action-bar-wrapper{
     height: $action-bar-wrapper-height;
     padding-top: 20px;
   }
 }
 
 
-.action-bar-status{
+#action-bar-status{
   .status-bar{
     padding-top: 7px;
   }
@@ -83,7 +83,7 @@ $action-bar-wrapper-height-small: 60px;
   font-weight: bold;
 }
 
-.action-bar-wrapper{
+#action-bar-wrapper{
   bottom:  0px;
   background: #f2f4f5;
   > div{

--- a/app/assets/stylesheets/redesign/_card-action.scss
+++ b/app/assets/stylesheets/redesign/_card-action.scss
@@ -89,7 +89,7 @@ $action-bar-wrapper-height-small: 60px;
     &.notice-type-notice{
       background: $secondary-color;
       border-top: 2px solid darken($secondary-color, 5%);
-    },
+    }
     &.notice-type-alert{
       background: $alert-color;
       border-top: 2px solid darken($alert-color, 5%);

--- a/app/assets/stylesheets/redesign/_card-action.scss
+++ b/app/assets/stylesheets/redesign/_card-action.scss
@@ -45,7 +45,11 @@ ul#request-actions{
 
 $action-bar-wrapper-height-small: 60px;
 #action-bar-status{
-  display: none;
+  ul{
+    margin: 0px;
+    li{
+    }
+  }
   bottom:  $action-bar-wrapper-height-small;
   &.show{
     display: block;
@@ -74,13 +78,15 @@ $action-bar-wrapper-height-small: 60px;
 
 
 #action-bar-status{
-  .status-bar{
+  .notification-bar-el{
     padding-top: 7px;
+    min-height: 40px;
+    background: #589D42;
+    color: white;
+    font-weight: bold;
+    opacity: .9;
+    border-top: 2px solid #4A8C35;
   }
-  height: 40px;
-  background: #589D42;
-  color: white;
-  font-weight: bold;
 }
 
 #action-bar-wrapper{

--- a/app/assets/stylesheets/redesign/_card-action.scss
+++ b/app/assets/stylesheets/redesign/_card-action.scss
@@ -86,6 +86,14 @@ $action-bar-wrapper-height-small: 60px;
     font-weight: bold;
     opacity: .9;
     border-top: 2px solid #4A8C35;
+    &.notice-type-notice{
+      background: $secondary-color;
+      border-top: 2px solid darken($secondary-color, 5%);
+    },
+    &.notice-type-alert{
+      background: $alert-color;
+      border-top: 2px solid darken($alert-color, 5%);
+    }
   }
 }
 

--- a/app/views/layouts/_new_javascript.html.haml
+++ b/app/views/layouts/_new_javascript.html.haml
@@ -1,6 +1,7 @@
 = javascript_include_tag "details/views/action_bar"
 = javascript_include_tag "details/views/attachment_card"
 = javascript_include_tag "details/views/observer_card"
+= javascript_include_tag "details/views/notifications"
 = javascript_include_tag "details/views/details_request_card"
 
 = javascript_include_tag "details/state/details_request_form_state"

--- a/app/views/proposals/details/_action.html.haml
+++ b/app/views/proposals/details/_action.html.haml
@@ -1,9 +1,5 @@
 .action-bar-template#action-bar-status
-  .medium-12.column.status-bar
-    %ul#request-actions.centered
-      %li.fl.modify-button.action-default
-        %span.action-status-value
-          Your updates have been saved.
+  %ul
   
 .action-bar-template#action-bar-wrapper
   .medium-12.column

--- a/app/views/proposals/details/_action.html.haml
+++ b/app/views/proposals/details/_action.html.haml
@@ -1,11 +1,11 @@
-.action-bar-template.action-bar-status
+.action-bar-template#action-bar-status
   .medium-12.column.status-bar
     %ul#request-actions.centered
       %li.fl.modify-button.action-default
         %span.action-status-value
           Your updates have been saved.
   
-.action-bar-template.action-bar-wrapper
+.action-bar-template#action-bar-wrapper
   .medium-12.column
     %ul#request-actions.fr
       - if policy(@proposal).can_complete?

--- a/spec/javascripts/details/details_helper.js.coffee
+++ b/spec/javascripts/details/details_helper.js.coffee
@@ -15,6 +15,15 @@
     <div class="view-mode" id="mode-parent"></div>
   ')
 
+@getNotificationContent = ->
+  $('
+    <div class="action-bar-template" id="action-bar-status">
+      <ul>
+        <div></div>
+      </ul>
+    </div>
+  ')
+
 @getAttachmentContent = ->
   $('
     <div class="card-for-attachments"></div>

--- a/spec/javascripts/details/details_helper.js.coffee
+++ b/spec/javascripts/details/details_helper.js.coffee
@@ -30,7 +30,7 @@
 
 @getActionBarContent = ->
   $(
-    '<div class="action-bar-template action-bar-wrapper">
+    '<div class="action-bar-template" id="action-bar-wrapper">
       <ul id="request-actions">
         <li class="cancel-button">
           <button value="Cancel">

--- a/spec/javascripts/details/details_helper.js.js
+++ b/spec/javascripts/details/details_helper.js.js
@@ -20,7 +20,7 @@ this.getAttachmentContent = function() {
 };
 
 this.getActionBarContent = function() {
-  return $('<div class="action-bar-template action-bar-wrapper"> <ul id="request-actions"> <li class="cancel-button"> <input type="button" value="Cancel"> </li> <li class="save-button"> <input type="button" value="Save"> </li> </ul> </div>');
+  return $('<div class="action-bar-template"" id="action-bar-wrapper"> <ul id="request-actions"> <li class="cancel-button"> <input type="button" value="Cancel"> </li> <li class="save-button"> <input type="button" value="Save"> </li> </ul> </div>');
 };
 
 this.getRequestDetailsForm = function() {

--- a/spec/javascripts/details/shell/c2_spec.js.coffee
+++ b/spec/javascripts/details/shell/c2_spec.js.coffee
@@ -8,6 +8,7 @@
 #= require details/views/attachment_card
 #= require details/views/details_request_card
 #= require details/views/observer_card
+#= require details/views/notifications
 #= require details/data/details_save
 #= require details/data/undo_check
 #= require details/shell/c2

--- a/spec/javascripts/details/shell/c2_spec.js.coffee
+++ b/spec/javascripts/details/shell/c2_spec.js.coffee
@@ -98,3 +98,8 @@ describe 'C2', ->
         flag = true
       c2.detailsSave.el.trigger('details-form:save')
       expect(flag).to.eql(true)
+
+  describe '#events notification', -> 
+    it "checks for one success response", ->
+    it "checks for one errors", ->
+    it "checks for multiple errors", ->

--- a/spec/javascripts/details/shell/c2_spec.js.coffee
+++ b/spec/javascripts/details/shell/c2_spec.js.coffee
@@ -99,7 +99,12 @@ describe 'C2', ->
       c2.detailsSave.el.trigger('details-form:save')
       expect(flag).to.eql(true)
 
-  describe '#events notification', -> 
-    it "checks for one success response", ->
+  describe '#events _setupNotifications', -> 
+    it "create the event hook that notification triggers", ->
+  
+  describe '#handleSaveError', -> 
     it "checks for one errors", ->
     it "checks for multiple errors", ->
+
+  describe '#events notification', -> 
+    it "checks for one success response", ->

--- a/spec/javascripts/details/views/notification_bar_spec.js.coffee
+++ b/spec/javascripts/details/views/notification_bar_spec.js.coffee
@@ -12,5 +12,18 @@ describe 'Notification', ->
       notification = new Notifications(getNotificationContent())  
       expect(true).to.eql(false)
   
-  describe '#create', ->
-    it "set in view mode", ->
+  describe '#_postNotification', ->
+    it "create a notification", ->
+
+  describe '#_closeButton', ->
+    it "make sure the close button deletes the notification", ->
+  
+  describe '#_prepare', ->
+    it "prepare a notification", ->
+    it "handle a notification without a title", ->
+    it "handle a notification without a content", ->
+    it "handle a notification without a type", ->
+    it "handle a notification with a timeout", ->
+  
+  describe '#clearAll', ->
+    it "remove all four notifications", ->

--- a/spec/javascripts/details/views/notification_bar_spec.js.coffee
+++ b/spec/javascripts/details/views/notification_bar_spec.js.coffee
@@ -1,0 +1,16 @@
+#= require jquery
+#= require ladda/ladda.min
+#= require ladda/ladda.jquery.min
+#= require details/views/notifications
+#= require details/details_helper
+#= require ladda/spin.min
+
+describe 'Notification', ->
+
+  describe '#setup', ->
+    it "set in view mode", ->
+      notification = new Notifications(getNotificationContent())  
+      expect(true).to.eql(false)
+  
+  describe '#create', ->
+    it "set in view mode", ->

--- a/spec/javascripts/details/views/notification_bar_spec.js.coffee
+++ b/spec/javascripts/details/views/notification_bar_spec.js.coffee
@@ -10,7 +10,7 @@ describe 'Notification', ->
   describe '#setup', ->
     it "set in view mode", ->
       notification = new Notifications(getNotificationContent())  
-      expect(true).to.eql(false)
+      expect(notification instanceof Notifications).to.eql(true)
   
   describe '#_postNotification', ->
     it "create a notification", ->


### PR DESCRIPTION

![save not](https://cloud.githubusercontent.com/assets/1332366/15199798/3f9af842-17af-11e6-9268-6d039f85759f.gif)


# What

Add the ability for a notification bar to be generated. The notification takes three parameters and one optional parameter. 

To use the notification in the `shell/c2`, a user can call the notification event. The notification takes an object containing the four parameters above.

This currently contains test **stubs**. The tests will be written when the styles are implemented next.