### PR TITLE
Add save confirmation notice before processing edit changes

### DIFF
--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -67,6 +67,7 @@ C2 = (function() {
     this._setupNotifications();
     this._setupActivityEvent();
     this._setupObserverEvent();
+    this._setupSaveModal();
   }
   
   
@@ -224,10 +225,10 @@ C2 = (function() {
     this.modals.el.on("save_confirm-modal:confirm", function(){
       self.actionBar.el.trigger("action-bar-clicked:saving");
       self.detailsSave.el.trigger("details-form:save");
-      self.modals.el.on("modal:close");
+      self.modals.el.trigger("modal:close");
     });
     this.modals.el.on("save_confirm-modal:cancel", function(){
-      self.modals.el.on("modal:close");
+      self.modals.el.trigger("modal:close");
     });
   }
 

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -215,8 +215,18 @@ C2 = (function() {
       self.detailsCancelled();
     });
     this.actionBar.el.on("action-bar-clicked:save", function(){
+      
+    });
+  }
+
+  C2.prototype._setupSaveModal = function(){
+    var self = this;
+    this.modals.el.on("save_confirm-modal:confirmed", function(){
       self.actionBar.el.trigger("action-bar-clicked:saving");
       self.detailsSave.el.trigger("details-form:save");
+    });
+    this.modals.el.on("save_confirm-modal:canceled", function(){
+      
     });
   }
 

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -230,11 +230,14 @@ C2 = (function() {
       self.detailsSave.el.trigger("details-form:save");
     });
     this.modals.el.on("save_confirm-modal:cancel", function(){
-      self.modals.el.trigger("modal:close");
-      self.actionBar.saveButtonLadda.ladda( 'stop' );
+      this._closeModal();
     });
   }
 
+  C2.prototype._closeModal = function(){
+    this.modals.el.trigger("modal:close");
+    this.actionBar.saveButtonLadda.ladda( 'stop' );
+  }
   /* End Action Bar */ 
 
   return C2;

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -13,7 +13,7 @@ C2 = (function() {
       formState:      '#request-details-card form',
       notifications:  '#action-bar-status',
       observerCard:   '#card-for-observers',
-      modalCard:      '#card-for-modal'
+      modalCard:      '#modal-wrapper'
     }
     this._overrideTestConfig(config);
     this._blastOff();

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -221,12 +221,13 @@ C2 = (function() {
 
   C2.prototype._setupSaveModal = function(){
     var self = this;
-    this.modals.el.on("save_confirm-modal:confirmed", function(){
+    this.modals.el.on("save_confirm-modal:confirm", function(){
       self.actionBar.el.trigger("action-bar-clicked:saving");
       self.detailsSave.el.trigger("details-form:save");
+      self.modals.el.on("modal:close");
     });
-    this.modals.el.on("save_confirm-modal:canceled", function(){
-      
+    this.modals.el.on("save_confirm-modal:cancel", function(){
+      self.modals.el.on("modal:close");
     });
   }
 

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -229,6 +229,7 @@ C2 = (function() {
     });
     this.modals.el.on("save_confirm-modal:cancel", function(){
       self.modals.el.trigger("modal:close");
+      self.actionBar.saveButtonLadda.ladda( 'stop' );
     });
   }
 

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -138,10 +138,13 @@ C2 = (function() {
     var self = this;
     this.detailsSave.el.on('details-form:success', function(event, data){
       self.detailsRequestCard.updateViewModeContent(data);
+      self.actionBar.saveButtonLadda.ladda( 'stop' );
+      self.modals.el.trigger("modal:close");
     });
 
     this.detailsSave.el.on('details-form:error', function(event, data){
       self.handleSaveError(data);
+      self.modals.el.trigger("modal:close");
       self.actionBar.saveButtonLadda.ladda( 'stop' );
     });
   }
@@ -216,7 +219,7 @@ C2 = (function() {
       self.detailsCancelled();
     });
     this.actionBar.el.on("action-bar-clicked:save", function(){
-      
+      // triggers save_confirm-modal
     });
   }
 
@@ -225,8 +228,6 @@ C2 = (function() {
     this.modals.el.on("save_confirm-modal:confirm", function(){
       self.actionBar.el.trigger("action-bar-clicked:saving");
       self.detailsSave.el.trigger("details-form:save");
-      self.modals.el.trigger("modal:close");
-      self.actionBar.saveButtonLadda.ladda( 'stop' );
     });
     this.modals.el.on("save_confirm-modal:cancel", function(){
       self.modals.el.trigger("modal:close");

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -226,6 +226,7 @@ C2 = (function() {
       self.actionBar.el.trigger("action-bar-clicked:saving");
       self.detailsSave.el.trigger("details-form:save");
       self.modals.el.trigger("modal:close");
+      self.actionBar.saveButtonLadda.ladda( 'stop' );
     });
     this.modals.el.on("save_confirm-modal:cancel", function(){
       self.modals.el.trigger("modal:close");

--- a/app/assets/javascripts/details/views/modal_card.js
+++ b/app/assets/javascripts/details/views/modal_card.js
@@ -7,7 +7,8 @@ ModalController = (function(){
     this.data = { 
       id: 1,
       modal: {
-        cancel: ".cancel-modal-content"
+        cancel: ".cancel-modal-content",
+        save_confirm: ".save_confirm-modal-content"
       }
     }
     return this;

--- a/app/assets/javascripts/details/views/modal_card.js
+++ b/app/assets/javascripts/details/views/modal_card.js
@@ -47,8 +47,11 @@ ModalController = (function(){
     var self = this;
     $(el).find('[data-modal-event]').each(function(i, item){
       var event = $(item).attr('data-modal-event');
+      console.log('Running over ', item);
       $(item).on('click', function(){
-        self.el.trigger(modalType + '-modal:' + event);
+        var eventName = modalType + '-modal:' + event;
+        console.log('Set up ', eventName);
+        self.el.trigger(eventName);
       });
     })
   }

--- a/app/assets/javascripts/details/views/modal_card.js
+++ b/app/assets/javascripts/details/views/modal_card.js
@@ -4,6 +4,7 @@ ModalController = (function(){
   
   function ModalController(el, opts){
     this._setup(el, opts);
+    this.el = $(el);
     this.data = { 
       id: 1,
       modal: {

--- a/app/assets/javascripts/details/views/modal_card.js
+++ b/app/assets/javascripts/details/views/modal_card.js
@@ -32,11 +32,25 @@ ModalController = (function(){
       var modalType = $(el).attr('data-modal-type');
       self.create(modalType);
     });
+    this.el.on("modal:close", function(){
+      self._closeModal();
+    });
   }
 
-  ModalController.prototype._modalEvents = function(el){
+  ModalController.prototype._modalEvents = function(el, modalType){
     this._undoButtonSetup(el);
     this._buttonDependence(el);
+    this._createCustomEvents(el, modalType);
+  }
+
+  ModalController.prototype._createCustomEvents = function(el, modalType){
+    var self = this;
+    $(el).find('[data-modal-event]').each(function(i, item){
+      var event = $(item).attr('data-modal-event');
+      $(item).on('click', function(){
+        self.el.trigger(modalType + '-modal:' + event);
+      });
+    })
   }
 
   ModalController.prototype._buttonDependence = function(el){
@@ -91,7 +105,7 @@ ModalController = (function(){
     this.clear();
     var modal = this._setupModal(modalType);
     $('#modal-wrapper').append(modal);
-    this._modalEvents(modal);
+    this._modalEvents(modal, modalType);
     this._animate();
     $('#modal-wrapper').addClass('visible');
   }

--- a/app/assets/javascripts/details/views/modal_card.js
+++ b/app/assets/javascripts/details/views/modal_card.js
@@ -7,11 +7,7 @@ ModalController = (function(){
     this.data = { 
       id: 1,
       modal: {
-        cancel: {
-          title: "You are about to cancel this request.", 
-          desc: "Cancelling a request permenantly removes it from C2 and notifies all approvers and observers.",
-          content: ".cancel-modal-content"
-        }
+        cancel: ".cancel-modal-content"
       }
     }
     return this;
@@ -82,14 +78,10 @@ ModalController = (function(){
   }
 
   ModalController.prototype._setupModal = function(modalType){
-    var data = this.data.modal[modalType];
-    var title = data["title"] || false;
-    var description = data["desc"] || false;
-    var content = $(data["content"]).clone() || false;
+    var selector = this.data.modal[modalType];
+    var content = $(selector).clone() || false;
     var id = this.getId();
     var modal = $('#modal-template').clone().attr('id', "modal-el-" + id).removeClass('modal-template');
-    modal.find('.popup-content-label').html(title);
-    modal.find('.popup-content-desc').html(description);
     modal.find('.additional-content').html(content);
     return modal;
   }

--- a/app/assets/javascripts/details/views/modal_card.js
+++ b/app/assets/javascripts/details/views/modal_card.js
@@ -47,10 +47,8 @@ ModalController = (function(){
     var self = this;
     $(el).find('[data-modal-event]').each(function(i, item){
       var event = $(item).attr('data-modal-event');
-      console.log('Running over ', item);
       $(item).on('click', function(){
         var eventName = modalType + '-modal:' + event;
-        console.log('Set up ', eventName);
         self.el.trigger(eventName);
       });
     })

--- a/app/assets/javascripts/details/views/modal_card.js
+++ b/app/assets/javascripts/details/views/modal_card.js
@@ -3,7 +3,6 @@ var ModalController;
 ModalController = (function(){
   
   function ModalController(el, opts){
-    this._setup(el, opts);
     this.el = $(el);
     this.data = { 
       id: 1,
@@ -12,12 +11,12 @@ ModalController = (function(){
         save_confirm: ".save_confirm-modal-content"
       }
     }
+    this._setup(el, opts);
     return this;
   }
 
   ModalController.prototype._setup = function(el, opts){
     $.extend(this, opts);
-    this.el = typeof el === "string" ? $(el) : el;
     this.cancelButton = this.cancelButton || $(".cancel-request-button");
   }
   

--- a/app/views/proposals/details/_action.html.haml
+++ b/app/views/proposals/details/_action.html.haml
@@ -20,5 +20,5 @@
               %span Cancel
 
           %li.save-button
-            %button{ class: "ladda-button button large primary", value: "Save", disabled: true, data: { style: "expand-right" } }
+            %button{ class: "ladda-button button large primary", value: "Save", disabled: true, data: { "modal-type": "save_confirm", style: "expand-right" } }
               %span Save

--- a/app/views/proposals/details/_modal.html.haml
+++ b/app/views/proposals/details/_modal.html.haml
@@ -2,6 +2,7 @@
 #modal-template.modal-template
   = render partial: "proposals/details/modals/template", locals: { proposal: @proposal }  
 #modal-content.modal-content
+  = render partial: "proposals/details/modals/save_confirm", locals: { proposal: @proposal }
   = render partial: "proposals/details/modals/cancel", locals: { proposal: @proposal }
 
 

--- a/app/views/proposals/details/modals/_cancel.html.haml
+++ b/app/views/proposals/details/modals/_cancel.html.haml
@@ -1,4 +1,8 @@
 .cancel-modal-content
+  %h4{class: "popup-content-label"}
+    You are about to cancel this request.
+  %p{class: "popup-content-desc"}
+    Cancelling a request permenantly removes it from C2 and notifies all approvers and observers.
   = form_tag(cancel_proposal_path(@proposal), method: :post) do
     = label_tag(:reason_input, "Please provide a reason for cancelation.")
     = text_area_tag "reason_input", nil, size: "15x5"

--- a/app/views/proposals/details/modals/_cancel.html.haml
+++ b/app/views/proposals/details/modals/_cancel.html.haml
@@ -1,8 +1,8 @@
 - title = t("proposals.details.notification.cancel.title")
 - desc = t("proposals.details.notification.cancel.desc")
 - form_reason = t("proposals.details.notification.cancel.form_reason")
-- cancel_button = t("proposals.details.notification.cancel.save_button")
-- save_button = t("proposals.details.notification.cancel.cancel_button")
+- save_button = t("proposals.details.notification.cancel.save_button")
+- cancel_button = t("proposals.details.notification.cancel.cancel_button")
 
 .cancel-modal-content
   %h4{class: "popup-content-label"}

--- a/app/views/proposals/details/modals/_cancel.html.haml
+++ b/app/views/proposals/details/modals/_cancel.html.haml
@@ -1,11 +1,17 @@
+- title = t("proposals.details.notification.cancel.title")
+- desc = t("proposals.details.notification.cancel.desc")
+- form_reason = t("proposals.details.notification.cancel.form_reason")
+- cancel_button = t("proposals.details.notification.cancel.save_button")
+- save_button = t("proposals.details.notification.cancel.cancel_button")
+
 .cancel-modal-content
   %h4{class: "popup-content-label"}
-    You are about to cancel this request.
+    = title
   %p{class: "popup-content-desc"}
-    Cancelling a request permenantly removes it from C2 and notifies all approvers and observers.
+    = desc
   = form_tag(cancel_proposal_path(@proposal), method: :post) do
-    = label_tag(:reason_input, "Please provide a reason for cancelation.")
+    = label_tag(:reason_input, form_reason)
     = text_area_tag "reason_input", nil, size: "15x5"
     %p
-      = button_tag "NO, TAKE ME BACK", class: "cancel-cancel-link form-button cancel-button"
-      = submit_tag "  YES, CANCEL  ", data: { "disable-if-empty" => "reason_input" }, class: "form-button"
+      = button_tag cancel_button, class: "cancel-cancel-link form-button cancel-button"
+      = submit_tag save_button, data: { "disable-if-empty" => "reason_input" }, class: "form-button"

--- a/app/views/proposals/details/modals/_save_confirm.html.haml
+++ b/app/views/proposals/details/modals/_save_confirm.html.haml
@@ -1,0 +1,1 @@
+.save_confirm-modal-content 

--- a/app/views/proposals/details/modals/_save_confirm.html.haml
+++ b/app/views/proposals/details/modals/_save_confirm.html.haml
@@ -9,5 +9,5 @@
   %p{class: "popup-content-desc"}
     = desc
   %p
-    = button_tag cancel_button, class: "cancel-cancel-link form-button cancel-button"
-    = button_tag save_button, class: "form-button"
+    = button_tag cancel_button, class: "cancel-cancel-link form-button cancel-button", data: { "modal-event": "cancel" }
+    = button_tag save_button, class: "form-button", data: { "modal-event": "confirm" }

--- a/app/views/proposals/details/modals/_save_confirm.html.haml
+++ b/app/views/proposals/details/modals/_save_confirm.html.haml
@@ -1,5 +1,5 @@
 - title = t("proposals.details.notification.save.title")
-- desc = t("proposals.details.notification.save.desc", count: @@subscriber_list.count)
+- desc = t("proposals.details.notification.save.desc", count: @subscriber_list.count)
 - cancel_button = t("proposals.details.notification.save.save_button")
 - save_button = t("proposals.details.notification.save.cancel_button")
 

--- a/app/views/proposals/details/modals/_save_confirm.html.haml
+++ b/app/views/proposals/details/modals/_save_confirm.html.haml
@@ -1,1 +1,13 @@
+- title = t("proposals.details.notification.save.title")
+- desc = t("proposals.details.notification.save.desc", count: @@subscriber_list.count)
+- cancel_button = t("proposals.details.notification.save.save_button")
+- save_button = t("proposals.details.notification.save.cancel_button")
+
 .save_confirm-modal-content 
+  %h4{class: "popup-content-label"}
+    = title
+  %p{class: "popup-content-desc"}
+    = desc
+  %p
+    = button_tag cancel_button, class: "cancel-cancel-link form-button cancel-button"
+    = button_tag save_button, class: "form-button"

--- a/app/views/proposals/details/modals/_save_confirm.html.haml
+++ b/app/views/proposals/details/modals/_save_confirm.html.haml
@@ -1,7 +1,7 @@
 - title = t("proposals.details.notification.save.title")
 - desc = t("proposals.details.notification.save.desc", count: @subscriber_list.count)
-- cancel_button = t("proposals.details.notification.save.save_button")
-- save_button = t("proposals.details.notification.save.cancel_button")
+- cancel_button = t("proposals.details.notification.save.cancel_button")
+- save_button = t("proposals.details.notification.save.save_button")
 
 .save_confirm-modal-content 
   %h4{class: "popup-content-label"}

--- a/app/views/proposals/details/modals/_template.html.haml
+++ b/app/views/proposals/details/modals/_template.html.haml
@@ -1,5 +1,3 @@
 .popup-content{role: "dialog", "aria-labelledby" => "popup-content-label", "aria-describedby" => "popup-content-desc" }
   = button_tag "X", class: "cancel-cancel-link cancel-close-button"
-  %h4{class: "popup-content-label"}
-  %p{class: "popup-content-desc"}
   .additional-content

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -1,6 +1,16 @@
 en:
   proposals:
     details:
+      notification:
+        save:
+          title: Save your changes?
+          desc: Click Cancel to discard changes, or Save to update the request. Saving will notify %{count} observers.
+          cancel_button: Cancel
+          save_button: Save
+        cancel:
+          title:
+          desc:
+          verification:
       activity:
         header: Timeline
         comment_form:

--- a/config/locales/views/en.yml
+++ b/config/locales/views/en.yml
@@ -8,9 +8,12 @@ en:
           cancel_button: Cancel
           save_button: Save
         cancel:
-          title:
-          desc:
-          verification:
+          title: You are about to cancel this request.
+          desc: Cancelling a request permenantly removes it from C2 and notifies all approvers and observers.
+          form_reason: Please provide a reason for cancelation.
+          cancel_button: NO, TAKE ME BACK
+          save_button: YES, CANCEL
+
       activity:
         header: Timeline
         comment_form:


### PR DESCRIPTION
# What

Add a confirmation modal that confirms changes on request details edits.

![saved](https://cloud.githubusercontent.com/assets/1332366/15523194/bc1d92c6-21e6-11e6-85bb-e41e5a58f73f.gif)
