### PR TITLE
Remove card header buttons on canceled state

### DIFF
--- a/app/views/proposals/details/_attachment.html.haml
+++ b/app/views/proposals/details/_attachment.html.haml
@@ -4,7 +4,8 @@
       .card-head.column
         %h2
           Attachments
-          <label for="attachment_file" class="button secondary attach-icon fr large attachment-label">Attach File</lable>
+          - if !@proposal.completed? && !@proposal.canceled?
+            <label for="attachment_file" class="button secondary attach-icon fr large attachment-label">Attach File</lable>
       .content-content.column
         .row
           .medium-12.column

--- a/app/views/proposals/details/_request_details.html.haml
+++ b/app/views/proposals/details/_request_details.html.haml
@@ -5,7 +5,7 @@
         .card-head.column
           %h2
             Request Details
-            - if !@proposal.completed?
+            - if !@proposal.completed? && !@proposal.canceled?
               = "<a class='edit-toggle button edit-icon'><span>Modify</span></a>".html_safe
 
         .content-content.column#view-request-details  


### PR DESCRIPTION
# What

On proposals in `canceled` state, dont show modify/add attachment buttons.

<img width="947" alt="screen shot 2016-05-25 at 12 48 13 pm" src="https://cloud.githubusercontent.com/assets/1332366/15548576/138618a4-2277-11e6-9447-2912c0784456.png">
