### PR TITLE
Create the option to user text instead of images for approvals

### DIFF
--- a/app/assets/stylesheets/redesign/_card-approvals.scss
+++ b/app/assets/stylesheets/redesign/_card-approvals.scss
@@ -6,6 +6,27 @@
 
 .step-row{
   position: relative;
+  
+  span.circle-wrapper {
+    font-weight: 500;
+    font-size: 17px;
+    width: 35px;
+    height: 35px;
+    background: white;
+    border: 2px solid #3A6E93;
+    border-radius: 40px;
+    display: block;
+    line-height: 30px;
+    &.status-pending {
+      border-color: #9c9c9c;
+      color: #9c9c9c;
+    }
+    &.status-completed{
+      background: #8ecc76;
+      border-color: #8ecc76;
+      color: white;
+    }
+  }
 
   &:last-child .step-status-wrapper:before {
     display: none !important;
@@ -19,7 +40,7 @@
     margin: auto;
     right: 0px;
     left: 0px;
-    z-index: 1;
+    z-index: -1;
     display: block;
   }
   .step-status-wrapper{

--- a/app/views/proposals/details/_approvals.html.haml
+++ b/app/views/proposals/details/_approvals.html.haml
@@ -16,12 +16,11 @@
                 - index = index + 1
                 .row.step-row.column.medium-table-row{class: "step-status-" + step.status}
                   .medium-icon-col.text-center.medium-table-cell.step-status-wrapper
-                    - if step.status == "completed"
-                      = image_tag 'numbers/icon-completed-green.png'
-                    - elsif step.status == "actionable"
-                      = image_tag 'numbers/icon-completed-activity-' + index.to_s + '.png'
-                    - elsif step.status == "pending"
-                      = image_tag 'numbers/icon-pending-activity-' + index.to_s + '.png'
+                    %span.circle-wrapper{ class: "status-" + step.status }
+                      - if step.status != "completed"
+                        = index.to_s
+                      - else
+                        = "✔"
                   .medium-auto-column.step-content-wrapper.medium-table-cell
                     %span.step-index.step-data
                       Step #{step.position - 1}


### PR DESCRIPTION
# What

Swap out the numerical indicators on approval steps with text/css.

<img width="412" alt="screen shot 2016-05-25 at 3 32 31 pm" src="https://cloud.githubusercontent.com/assets/1332366/15553645/00cd35aa-228e-11e6-93c1-f0d8a8737fc8.png">
<img width="484" alt="screen shot 2016-05-25 at 3 32 27 pm" src="https://cloud.githubusercontent.com/assets/1332366/15553646/00d14ec4-228e-11e6-8928-c614a5c8040f.png">
