### PR TITLE
Move the edit/view trigger into the action bar

### DIFF
--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -133,7 +133,7 @@ C2 = (function() {
     this.triggerDirtyCheck()
     this.detailsRequestCard.toggleMode(mode)
     this.editMode.stateTo(mode);
-    this.actionBar.setMode(mode)
+    this.actionBar.setMode(mode);
   }
 
   /* End Form */ 
@@ -231,6 +231,9 @@ C2 = (function() {
     });
     this.actionBar.el.on("action-bar-clicked:save", function(){
       // triggers save_confirm-modal
+    });
+    this.actionBar.el.on("action-bar-clicked:edit", function(){
+      self.detailsMode('edit');
     });
   }
 

--- a/app/assets/javascripts/details/views/action_bar.js
+++ b/app/assets/javascripts/details/views/action_bar.js
@@ -18,6 +18,7 @@ ActionBar = (function() {
     this.saveButtonLadda = this.saveButton.ladda();
     this._setupActionBarClicked('save');
     this._setupActionBarClicked('cancel');
+    this._setupActionBarClicked('edit');
     this._saveTriggered();
   };
 
@@ -55,11 +56,11 @@ ActionBar = (function() {
     switch(mode){
       case "view":
         this.barState('.cancel-button', "disabled");
-        $('.action-bar-template').removeClass('edit-actions');
+        $('.action-bar-template').removeClass('edit-actions').addClass('view-actions');
         break;
       case "edit":
         this.barState('.cancel-button', false);
-        $('.action-bar-template').addClass('edit-actions');
+        $('.action-bar-template').removeClass('view-actions').addClass('edit-actions');
         break;
     }
   }

--- a/app/assets/javascripts/details/views/details_request_card.js
+++ b/app/assets/javascripts/details/views/details_request_card.js
@@ -5,7 +5,6 @@ DetailsRequestCard = (function(){
     this.el = $(el);
     this._setup();
     this.data = {
-      buttonText: "Modify",
       gridLayout: "two-column"
     }
     return this;
@@ -27,21 +26,14 @@ DetailsRequestCard = (function(){
   DetailsRequestCard.prototype.toggleMode = function(mode){
     switch (mode){
       case 'view':
-        this.data.buttonText = "Modify";
         this.data.gridLayout = "two-column";
         this.scrollUp();
         break;
       case 'edit':
-        this.data.buttonText = "Cancel";
         this.data.gridLayout = "one-column";
         break;
     }
     this.updateCard();
-  }
-
-  DetailsRequestCard.prototype.updateButton = function(){
-    text = this.data.buttonText;
-    this.toggleButtonText(text);
   }
 
   DetailsRequestCard.prototype.updateGrid = function(){
@@ -59,7 +51,6 @@ DetailsRequestCard = (function(){
 
   DetailsRequestCard.prototype.updateCard = function(){
     this.updateGrid();
-    this.updateButton();
   }
 
   DetailsRequestCard.prototype.toggleButtonText = function(text){

--- a/app/assets/stylesheets/redesign/_card-action.scss
+++ b/app/assets/stylesheets/redesign/_card-action.scss
@@ -112,6 +112,7 @@ $action-bar-wrapper-height-small: 60px;
   transform: translateY($action-bar-wrapper-height-small);
   transition: transform .3s ease-in;
   &.edit-actions,
+  &.view-actions,
   &.user-can-complete{
     transform: translateY(0px);  
   }

--- a/app/assets/stylesheets/redesign/_card-action.scss
+++ b/app/assets/stylesheets/redesign/_card-action.scss
@@ -108,6 +108,19 @@ $action-bar-wrapper-height-small: 60px;
   padding-top: 10px;
 }
 
+.edit-actions{
+  .edit-button{
+    display: none;
+  }
+}
+
+.view-actions{
+  .save-button,
+  .cancel-button{
+    display: none;
+  }
+}
+
 .action-bar-template{
   transform: translateY($action-bar-wrapper-height-small);
   transition: transform .3s ease-in;

--- a/app/views/proposals/details/_action.html.haml
+++ b/app/views/proposals/details/_action.html.haml
@@ -1,13 +1,12 @@
 - can_complete = policy(@proposal).can_complete?
 - can_edit = policy(@proposal).can_edit? && !@proposal.completed? && policy(@proposal).not_canceled?
+- can_complete_class = can_complete ? "user-can-complete" : ""
+- can_edit_class = can_edit ? "view-actions" : ""
 
-- if policy(@proposal).can_complete?
-  - can_complete_class = "user-can-complete"
-
-.action-bar-template#action-bar-status.action-bar-status{ class: can_complete_class }
+.action-bar-template#action-bar-status.action-bar-status{ class: can_complete_class + " " + can_edit_class }
   %ul
   
-.action-bar-template#action-bar-wrapper.action-bar-wrapper{ class: can_complete_class }
+.action-bar-template#action-bar-wrapper.action-bar-wrapper{ class: can_complete_class + " " + can_edit_class }
   .row
     .medium-12.column
       %ul#request-actions.request-actions.fr

--- a/app/views/proposals/details/_action.html.haml
+++ b/app/views/proposals/details/_action.html.haml
@@ -19,7 +19,7 @@
         - if can_edit
           %li.edit-button
             %button{ class: "button secondary", value: "Modify", disabled: false }
-              %span Edit
+              %span Modify
 
           %li.cancel-button
             %button{ class: "button secondary", value: "Cancel", disabled: true }

--- a/app/views/proposals/details/_action.html.haml
+++ b/app/views/proposals/details/_action.html.haml
@@ -1,3 +1,6 @@
+- can_complete = policy(@proposal).can_complete?
+- can_edit = policy(@proposal).can_edit? && !@proposal.completed? && policy(@proposal).not_canceled?
+
 - if policy(@proposal).can_complete?
   - can_complete_class = "user-can-complete"
 
@@ -8,13 +11,17 @@
   .row
     .medium-12.column
       %ul#request-actions.request-actions.fr
-        - if policy(@proposal).can_complete?
+        - if can_complete
           %li.fr.modify-button.action-default.action-approve
             = form_tag(complete_proposal_path(@proposal, method: "POST", remote: true)) do
               = submit_tag @proposal.step_text_for_user(:execute_button, current_user), class: "form-button button primary large"
               = hidden_field_tag :version, @proposal.version
 
-        - if policy(@proposal).can_edit? && !@proposal.completed? && policy(@proposal).not_canceled?
+        - if can_edit
+          %li.edit-button
+            %button{ class: "button secondary", value: "Modify", disabled: false }
+              %span Edit
+
           %li.cancel-button
             %button{ class: "button secondary", value: "Cancel", disabled: true }
               %span Cancel

--- a/app/views/proposals/details/_request_details.html.haml
+++ b/app/views/proposals/details/_request_details.html.haml
@@ -9,4 +9,3 @@
         .content-content.column#view-request-details  
           .row
             = render @current_user.client_slug + '/request_details'
-

--- a/app/views/proposals/details/_request_details.html.haml
+++ b/app/views/proposals/details/_request_details.html.haml
@@ -5,8 +5,6 @@
         .card-head.column
           %h2
             Request Details
-            - if !@proposal.completed? && !@proposal.canceled?
-              = "<a class='edit-toggle button edit-icon'><span>Modify</span></a>".html_safe
 
         .content-content.column#view-request-details  
           .row

--- a/app/views/proposals/details/_summary.html.haml
+++ b/app/views/proposals/details/_summary.html.haml
@@ -25,16 +25,12 @@
       .medium-12.column
         %h3
           = proposal.public_id
-        %h1.c2n_header.view-title
+        %h1.c2n_header.view-title#proposal_header
           %span.header-content
             %span.display-content
               = proposal.name
             %span.display-edit
               %input{ type: "text", value: proposal.name }/
-          %button#header-edit-text.header-edit-text
-            %span.edit-button
-              Edit title
-            %span.edit-icon
         .c2n_description
           %p
             Requested by:

--- a/spec/javascripts/details/shell/c2_spec.js.coffee
+++ b/spec/javascripts/details/shell/c2_spec.js.coffee
@@ -118,3 +118,13 @@ describe 'C2', ->
   describe 'trigger events on dirrty', -> 
     it "make sure dirrty is triggered on form", ->
     it "make sure dirrty is reinit on save", ->
+  
+  describe 'when request detail is interacted', -> 
+    it "clicking modify will load the view in edit mode", ->
+    it "clicking modify should not load any notifications", ->
+    it "clicking cancel button from modify will revert to view mode", ->
+    it "clicking cancel in action bar will revert to view mode", ->
+    it "clicking save in action bar will load modal for save confirm", ->
+    it "clicking cancel button in save confirm will close modal", ->
+    it "clicking -x- button in save confirm will close modal", ->
+    it "make sure dirrty is reinit on save", ->


### PR DESCRIPTION
<img width="1020" alt="screen shot 2016-05-26 at 3 42 02 pm" src="https://cloud.githubusercontent.com/assets/1332366/15587892/5c3afdca-2359-11e6-9d14-7c88f2e1431d.png">

# What

Edit/save modify button is moved into action bar.

# Why

Adding an edit feature into the title bar complicates the user interface. Previously, users would have had two places to go to initiate an "edit", but one place to go to initiate a "save". This makes a design changes to move all modification/save behavior into the action bar.

# Note

In the PR, the title bar is still not editable.