### PR TITLE
Remove the "on load" alert/notice bar for new details

### DIFF
--- a/app/views/layouts/_notices.html.haml
+++ b/app/views/layouts/_notices.html.haml
@@ -1,0 +1,7 @@
+- if false
+
+- else
+  .inset.flash-container
+    - flash_list.each do |key, value|
+      .row.alert{ class: "alert-" + key + " " + bootstrap_alert_class(key) }
+        = value

--- a/app/views/layouts/_notices.html.haml
+++ b/app/views/layouts/_notices.html.haml
@@ -1,6 +1,4 @@
-- if false
-
-- else
+- if cookies[:detail] != "new"
   .inset.flash-container
     - flash_list.each do |key, value|
       .row.alert{ class: "alert-" + key + " " + bootstrap_alert_class(key) }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,11 +19,7 @@
     <%= render "peek/bar" %>
     <%= render "layouts/c2_header" %>
 
-    <div class="inset flash-container">
-      <% flash_list.each do |key, value| %>
-        <div class="row alert alert-<%= key %> <%= bootstrap_alert_class(key) %>"><%= value %></div>
-      <% end %>
-    </div>
+    <%= render "layouts/notices" %>
 
     <%= content_for?(:content) ? yield(:content) : yield %>
 


### PR DESCRIPTION
# What

Create a filter that checks for the "new design" cookie before loading the on page load alert/notice bar.