### PR TITLE
redirect to proposals list view after cancel

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -12,11 +12,8 @@ class ProposalsController < ApplicationController
 
   def show
     @proposal = proposal.decorate
-    unless params[:detail].blank?
-      cookies[:detail] = params[:detail]
-    end
-    mode = cookies[:detail]
-    if mode == "new"
+
+    if new_mode
       show_next
     end
   end
@@ -53,7 +50,11 @@ class ProposalsController < ApplicationController
     if params[:reason_input].present?
       cancel_proposal_and_send_cancelation_emails
       flash[:success] = "Your request has been canceled"
-      redirect_to proposal_path(proposal)
+      if new_mode
+        redirect_to proposals_path
+      else
+        redirect_to proposal_path(proposal)
+      end
     else
       redirect_to(
         cancel_form_proposal_path(params[:id]),
@@ -207,5 +208,12 @@ class ProposalsController < ApplicationController
     step.update_attributes!(completer: current_user)
     step.complete!
     flash[:success] = "You have approved #{proposal.public_id}."
+  end
+
+  def new_mode
+    unless params[:detail].blank?
+      cookies[:detail] = params[:detail]
+    end
+    cookies[:detail] == "new"
   end
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -48,13 +48,7 @@ class ProposalsController < ApplicationController
 
   def cancel
     if params[:reason_input].present?
-      cancel_proposal_and_send_cancelation_emails
-      flash[:success] = "Your request has been canceled"
-      if new_mode
-        redirect_to proposals_path
-      else
-        redirect_to proposal_path(proposal)
-      end
+      cancel_proposal
     else
       redirect_to(
         cancel_form_proposal_path(params[:id]),
@@ -215,5 +209,12 @@ class ProposalsController < ApplicationController
       cookies[:detail] = params[:detail]
     end
     cookies[:detail] == "new"
+  end
+
+  def cancel_proposal
+    cancel_proposal_and_send_cancelation_emails
+    flash[:success] = "Your request has been canceled"
+    redirect_path = new_mode ? proposals_path : proposal_path(proposal)
+    redirect_to redirect_path
   end
 end


### PR DESCRIPTION
After canceling a proposal in the new view, user is redirected to the list view