### PR TITLE
Attatchment form available on completed requests

### DIFF
--- a/app/views/proposals/details/_attachment.html.haml
+++ b/app/views/proposals/details/_attachment.html.haml
@@ -4,7 +4,7 @@
       .card-head.column
         %h2
           Attachments
-          - if !@proposal.completed? && !@proposal.canceled?
+          - if !@proposal.canceled?
             <label for="attachment_file" class="button secondary attach-icon fr large attachment-label">Attach File</lable>
       .content-content.column
         .row


### PR DESCRIPTION
https://trello.com/c/LUnO7x4Y/495-no-attachment-option-on-completed-request-should-be-able-to-add-attachments-post-completion