### PR TITLE
Remove option to change emergency field

### DIFF
--- a/app/views/ncr/fields/_emergency.html.haml
+++ b/app/views/ncr/fields/_emergency.html.haml
@@ -9,6 +9,4 @@
       %label.detail-element
         = t(t_slug + key) 
       %span.detail-value
-        = f.input :emergency,
-          disabled: @client_data_instance.persisted?,
-          wrapper_html: { data: { filter_key: "expense-type", filter_value: "BA61" } }
+        = client_data[key]


### PR DESCRIPTION
# What

Remove the input fields for the emergency checkbox and replace with value.

# Reference

https://trello.com/c/CIvM5KYu/517-as-a-user-i-am-not-allowed-to-change-a-ba61-request-to-an-emergency-request-after-submitting-it