### PR TITLE
Remove default notices on beta_mode

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
     
     <%= render "layouts/c2_header" %>
 
-    <% if !@current_user.beta_user? && !@current_user.beta_detail? %>
+    <% if !@current_user.beta_user? && !@current_user.beta_detail? && controller_name == "proposals" && params[:action] == "show" %>
       <%= render "layouts/notices" %>
     <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,9 @@
     
     <%= render "layouts/c2_header" %>
 
-    <%= render "layouts/notices" %>
+    <% if !@current_user.beta_user? && !@current_user.beta_detail? %>
+      <%= render "layouts/notices" %>
+    <% end %>
 
     <%= content_for?(:content) ? yield(:content) : yield %>
 


### PR DESCRIPTION
# What

On beta_mode users, disable the default notifications.

# Note

Currently, this is specified to the proposal's show page.