### PR TITLE
fixes bug where the same approval shows twice in activity feed

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -17,7 +17,7 @@ class CommentsController < ApplicationController
   end
 
   def update_feed
-    events = HistoryList.new(proposal).events
+    events = HistoryList.new(proposal).filtered_approvals
     @proposal = proposal
     render partial: "proposals/details/activity", locals: { events: events }
   end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -21,7 +21,7 @@ class ProposalsController < ApplicationController
   def show_next
     @client_data_instance ||= proposal.client_data
     @subscriber_list = SubscriberList.new(@proposal).triples
-    @events = HistoryList.new(proposal).events
+    @events = HistoryList.new(proposal).filtered_approvals
     render "show_next"
   end
 

--- a/app/presenters/history_list.rb
+++ b/app/presenters/history_list.rb
@@ -6,6 +6,14 @@ class HistoryList
     @events = make_events(ProposalVersionsQuery.new(proposal).container.query)
   end
 
+  def filtered_approvals
+    @events.reject! do |event|
+      event.item_type == "Steps::Approval" && 
+        event.object.include?("status: actionable")
+    end
+    @events
+  end
+
   private
 
   def filter_versions(versions)
@@ -35,4 +43,5 @@ class HistoryList
       HistoryEvent.new(version)
     end
   end
+
 end

--- a/app/presenters/history_list.rb
+++ b/app/presenters/history_list.rb
@@ -8,7 +8,7 @@ class HistoryList
 
   def filtered_approvals
     @events.reject! do |event|
-      event.item_type == "Steps::Approval" && 
+      event.item_type == "Steps::Approval" &&
         event.object.include?("status: actionable")
     end
     @events
@@ -43,5 +43,4 @@ class HistoryList
       HistoryEvent.new(version)
     end
   end
-
 end


### PR DESCRIPTION
## What

On the redesign page, the activity feed shows the approval entry twice

## Note

Approvals created two entries in the change log, one updating who was doing the approval, and another that marked the step as complete. This update just filters out the first case since we aren't showing that information in the feed. 

https://trello.com/c/cgIK47ON/519-status-check-marks-not-matching-timeline-steps