### PR TITLE
Removed code checking for cookie

### DIFF
--- a/app/views/layouts/_notices.html.haml
+++ b/app/views/layouts/_notices.html.haml
@@ -1,4 +1,4 @@
-- if cookies[:detail] != "new"
+- unless current_page?(proposal_path(params[:id] || 0)) && current_user.beta_detail?
   .inset.flash-container
     - flash_list.each do |key, value|
       .row.alert{ class: "alert-" + key + " " + bootstrap_alert_class(key) }


### PR DESCRIPTION
## What

Code was stopping notices from showing when you had the detail cookie set to new. 

## Notes

https://trello.com/c/y65WhdCj/493-sign-in-notification-is-displayed-over-page