### PR TITLE
New details page/notification fix again

### DIFF
--- a/app/assets/javascripts/details/views/notifications.js
+++ b/app/assets/javascripts/details/views/notifications.js
@@ -22,7 +22,7 @@ Notifications = (function(){
       var flash = $(flashes[i]);
       var param = {
         title: "",
-        content: flash.attr("content"),
+        content: flash.attr("message"),
         type: flash.attr("type")
       }
       this.create(param);

--- a/app/assets/javascripts/details/views/notifications.js
+++ b/app/assets/javascripts/details/views/notifications.js
@@ -19,13 +19,11 @@ Notifications = (function(){
     var notices = [];
     var flashes = $('meta[name="flash-message"]');
     for (var i = flashes.length - 1; i >= 0; i--) {
-      var flash = $(flashes[i]);
-      var param = {
+      this.create({
         title: "",
-        content: flash.attr("message"),
-        type: flash.attr("type")
-      }
-      this.create(param);
+        content: $(flashes[i]).attr("content"),
+        type: $(flashes[i]).attr("type")
+      });
     }
   }
 

--- a/app/views/layouts/_meta_notice.html.haml
+++ b/app/views/layouts/_meta_notice.html.haml
@@ -1,2 +1,2 @@
 - flash.each do |key, value|
-  %meta{name: "flash-message", type: key, message: value}
+  %meta{name: "flash-message", type: key, content: value}


### PR DESCRIPTION
# What

Fix blank notification on page load for details

# How

Unified the naming convention for how the meta tags stored flash messages.