### PR TITLE
Update total value on gsa18f proposals

### DIFF
--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -105,7 +105,7 @@ C2 = (function() {
       total = parseInt(data['quantity'], 10) * parseInt(data['cost_per_unit'], 10);
       params = { field: ".total_price-wrapper .detail-value", value: total };
       console.log(params);
-      self.updateView.el.trigger("update:textField", params);
+      self.updateView.el.trigger("update:textfield", params);
     }
   }
 

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -98,13 +98,11 @@ C2 = (function() {
   }
 
   C2.prototype.checkClientSpecific = function(data){
-    console.log(data);
     var self = this;
     var total, params;
     if(data['quantity'] !== undefined && data['cost_per_unit'] !== undefined){
       total = parseInt(data['quantity'], 10) * parseInt(data['cost_per_unit'], 10);
       params = { field: ".total_price-wrapper .detail-value", value: total };
-      console.log(params);
       self.updateView.el.trigger("update:textfield", params);
     }
   }

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -93,7 +93,18 @@ C2 = (function() {
     var self = this;
     this.detailsRequestCard.el.on('form:updated', function(event, data){
       self.detailsSaved(data);
+      self.checkClientSpecific(data);
     });
+  }
+
+  C2.prototype.checkClientSpecific = function(data){
+    var self = this;
+    var total, data;
+    if(data['quantity'] === undefined && data['cost_per_unit'] === undefined){
+      total = parseInt(data['quantity'], 10) * parseInt(data['cost_per_unit'], 10);
+      data = { field: ".total_price-wrapper .detail-value", value: total };
+      self.updateView.el.trigger("update:textField", data);
+    }
   }
 
   C2.prototype._setupEditToggle = function(){

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -101,8 +101,8 @@ C2 = (function() {
     var self = this;
     var total, params;
     if(data['quantity'] !== undefined && data['cost_per_unit'] !== undefined){
-      total = parseInt(data['quantity'], 10) * parseInt(data['cost_per_unit'], 10);
-      params = { field: ".total_price-wrapper .detail-value", value: total };
+      total = parseFloat(data['quantity'], 10) * parseFloat(data['cost_per_unit'], 10);
+      params = { field: ".total_price-wrapper .detail-value", value: total.toFixed(2) };
       self.updateView.el.trigger("update:textfield", params);
     }
   }

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -23,9 +23,24 @@ C2 = (function() {
   }
 
   C2.prototype._blastOff = function(){
-    this._setupStates();
-    this._setupViews();
-    this._setupData();
+    var config = this.config;
+    // Data
+    this.detailsSave = new DetailsSave(config.detailsSave, config.detailsSaveAll);
+    this.updateView = new UpdateView(config.updateView);
+
+    // State
+    this.editMode = new EditStateController(config.editMode);
+    this.formState = new FormChangeState(config.formState);
+
+    // Views
+    this.detailsRequestCard = new DetailsRequestCard(config.detailsForm);
+    this.attachmentCardController = new AttachmentCardController(config.attachmentCard);
+    this.observerCardController = new ObserverCardController(config.observerCard);
+    this.activityCardController = new ActivityCardController(config.activityCard);
+    this.modals = new ModalController(config.modalCard);
+    this.actionBar = new ActionBar(config.actionBar);
+    this.notification = new Notifications(config.notifications);
+    this.summaryBar = new SummaryBar(config.summaryBar);
     this._setupEvents();
   }
 
@@ -37,30 +52,6 @@ C2 = (function() {
       }
     });
     this.config = opt;
-  }
-
-  C2.prototype._setupData = function(){
-    var config = this.config;
-    this.detailsSave = new DetailsSave(config.detailsSave, config.detailsSaveAll);
-    this.updateView = new UpdateView(config.updateView);
-  }
-
-  C2.prototype._setupStates = function(){
-    var config = this.config;
-    this.editMode = new EditStateController(config.editMode);
-    this.formState = new FormChangeState(config.formState);
-  }
-
-  C2.prototype._setupViews = function(){
-    var config = this.config;
-    this.detailsRequestCard = new DetailsRequestCard(config.detailsForm);
-    this.attachmentCardController = new AttachmentCardController(config.attachmentCard);
-    this.observerCardController = new ObserverCardController(config.observerCard);
-    this.activityCardController = new ActivityCardController(config.activityCard);
-    this.modals = new ModalController(config.modalCard);
-    this.actionBar = new ActionBar(config.actionBar);
-    this.notification = new Notifications(config.notifications);
-    this.summaryBar = new SummaryBar(config.summaryBar);
   }
 
   C2.prototype._setupEvents = function(){

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -99,11 +99,11 @@ C2 = (function() {
 
   C2.prototype.checkClientSpecific = function(data){
     var self = this;
-    var total, data;
+    var total, params;
     if(data['quantity'] === undefined && data['cost_per_unit'] === undefined){
       total = parseInt(data['quantity'], 10) * parseInt(data['cost_per_unit'], 10);
-      data = { field: ".total_price-wrapper .detail-value", value: total };
-      self.updateView.el.trigger("update:textField", data);
+      params = { field: ".total_price-wrapper .detail-value", value: total };
+      self.updateView.el.trigger("update:textField", params);
     }
   }
 

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -98,11 +98,13 @@ C2 = (function() {
   }
 
   C2.prototype.checkClientSpecific = function(data){
+    console.log(data);
     var self = this;
     var total, params;
-    if(data['quantity'] === undefined && data['cost_per_unit'] === undefined){
+    if(data['quantity'] !== undefined && data['cost_per_unit'] !== undefined){
       total = parseInt(data['quantity'], 10) * parseInt(data['cost_per_unit'], 10);
       params = { field: ".total_price-wrapper .detail-value", value: total };
+      console.log(params);
       self.updateView.el.trigger("update:textField", params);
     }
   }

--- a/app/assets/javascripts/details/views/details_request_card.js
+++ b/app/assets/javascripts/details/views/details_request_card.js
@@ -90,7 +90,7 @@ DetailsRequestCard = (function(){
         self.updateField(fieldTarget, value, "textfield");
       }
     });
-    this.el.trigger("form:updated");
+    this.el.trigger("form:updated", data['response']);
   }
 
   DetailsRequestCard.prototype.setMode = function(type){

--- a/app/assets/stylesheets/redesign/_card-request_details.scss
+++ b/app/assets/stylesheets/redesign/_card-request_details.scss
@@ -22,8 +22,10 @@
   background: #FFFDE8;
 }
 
-.cost_per_unit-wrapper .detail-display .detail-value:before {
-  content: "$";
+.cost_per_unit-wrapper, .total_price-wrapper {
+  .detail-display .detail-value:before{
+    content: "$";
+  }
 }
 
 .detail-element{


### PR DESCRIPTION
# What

Update the total_price field on 18f proposals, when making frontend updates.

# How

Pass the data response into the success trigger for the proposal update event. If the object contains the amount and quantity fields, then process the total_price value and update.

# Reference

https://trello.com/c/coe76G0f/565-updating-the-quantity-or-cost-of-a-18f-proposal-item-does-not-update-the-total-price-field-without-refresh