### PR TITLE
Fix the work order not to exceed

### DIFF
--- a/config/locales/decorators/en.yml
+++ b/config/locales/decorators/en.yml
@@ -55,6 +55,7 @@ en:
       emergency: "Emergency"
       expense_type: "Expense Type"
       function_code: "Function Code"
+      not_to_exceed: "Not to exceed"
       not_to_exceed_amount: "Not to exceed / Amount"
       org_code: "Org Code"
       ncr_organization_id: "Org Code"


### PR DESCRIPTION
# What

Add decorator field for not to exceed.

https://trello.com/c/GC7bnpI9/571-activity-message-is-not-human-readable-for-updates-to-not-to-exceed-value