### PR TITLE
Changed pending color to default with 50% opacity

### DIFF
--- a/app/assets/stylesheets/redesign/_card-approvals.scss
+++ b/app/assets/stylesheets/redesign/_card-approvals.scss
@@ -18,8 +18,7 @@
     display: block;
     line-height: 30px;
     &.status-pending {
-      border-color: #9c9c9c;
-      color: #9c9c9c;
+      opacity: 0.5;
     }
     &.status-completed{
       background: #8ecc76;


### PR DESCRIPTION
## WHAT 
Adjust styling of pending steps

## WHY
Better distinction of events
https://trello.com/c/oX1xyRBN/533-as-a-user-i-understand-next-step-and-future-steps-through-visual-cues

<img width="570" alt="c2" src="https://cloud.githubusercontent.com/assets/5296248/16281735/b08593e6-3893-11e6-8a17-84b63826853c.png">
