### PR TITLE
Disable email with spec metadata

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -15,11 +15,18 @@ class ApplicationMailer < ActionMailer::Base
 
   default reply_to: proc { reply_to_email }
 
+  # Allow email to be disabled in test by setting
+  # `ActionMailer::Base.perform_deliveries = false`
+  #
+  # @Overrides ActionMailer::Base#mail
+  def mail(headers, &hash)
+    return if Rails.env.test? && !ActionMailer::Base.perform_deliveries
+    super
+  end
+
   protected
 
   def send_email(to:, proposal:, from: default_sender_email)
-    return if Rails.env.test? && ENV["DISABLE_EMAIL"]
-
     mail(
       to: email_to_user(to),
       subject: subject(proposal),

--- a/doc/test_config_and_fixing.md
+++ b/doc/test_config_and_fixing.md
@@ -14,7 +14,7 @@ Common Fixes to Try
 * Enable email sending by adding the `email` flag to the test or group. For example:
 
 ```ruby
-describe "MyEmailSenderClass", email: true do
+describe "MyEmailSenderClass", :email do
   ...
 end
 ```

--- a/doc/test_config_and_fixing.md
+++ b/doc/test_config_and_fixing.md
@@ -11,11 +11,12 @@ cause the later ones to fail.
 Common Fixes to Try
 -------------------
 * Change a `before(:all)` to `before(:each)`.
-* Enable email sending with this code at the top of the spec file:
+* Enable email sending by adding the `email` flag to the test or group. For example:
 
 ```ruby
-before(:all) { ENV["DISABLE_EMAIL"] = nil }
-after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
+describe "MyEmailSenderClass", email: true do
+  ...
+end
 ```
 
 * Enable `:truncation` Database Cleaner strategy.

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -14,16 +14,12 @@ describe CommentsController do
         expect(response).to redirect_to(proposal)
       end
 
-      it "sends a comment email to approvers and observers" do
-        ENV["DISABLE_EMAIL"] = nil
-
+      it "sends a comment email to approvers and observers", email: true do
         login_as(proposal.requester)
 
         expect do
           post :create, params
         end.to change { deliveries.length }.from(0).to(4)
-
-        ENV["DISABLE_EMAIL"] = "Yes"
       end
     end
 

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -14,7 +14,7 @@ describe CommentsController do
         expect(response).to redirect_to(proposal)
       end
 
-      it "sends a comment email to approvers and observers", email: true do
+      it "sends a comment email to approvers and observers", :email do
         login_as(proposal.requester)
 
         expect do

--- a/spec/controllers/feedback_controller_spec.rb
+++ b/spec/controllers/feedback_controller_spec.rb
@@ -1,4 +1,4 @@
-describe FeedbackController do
+describe FeedbackController, :email do
   describe '#create' do
     # it 'sends an email when feedback is submitted' do
     #   post :create, {

--- a/spec/controllers/ncr/work_orders_controller_spec.rb
+++ b/spec/controllers/ncr/work_orders_controller_spec.rb
@@ -1,10 +1,7 @@
 describe Ncr::WorkOrdersController do
   include ProposalSpecHelper
 
-  describe "#create" do
-    before(:all) { ENV["DISABLE_EMAIL"] = nil }
-    after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
-
+  describe "#create", email: true do
     it "sends an email to the first approver" do
       approving_official = create(:user, client_slug: "ncr")
       params = {

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -49,8 +49,7 @@ describe ReportsController do
   end
 
   describe "#preview", :elasticsearch do
-    it "sends email with report to current user" do
-      deliveries.clear
+    it "sends email with report to current user", :email do
       my_report = create(:report, user: user)
       es_execute_with_retries 3 do
         post :preview, id: my_report.id

--- a/spec/db/chores/expired_record_cleaner_spec.rb
+++ b/spec/db/chores/expired_record_cleaner_spec.rb
@@ -39,7 +39,7 @@ describe ExpiredRecordCleaner do
   end
 
   describe ".vacuum_proposal" do
-    it "cleans up specific proposal", email: true do
+    it "cleans up specific proposal", :email do
       proposal = create(:proposal)
       cleaner = ExpiredRecordCleaner.new(Time.zone.now, ok_to_act: true)
       cleaner.vacuum_proposal(proposal)

--- a/spec/db/chores/expired_record_cleaner_spec.rb
+++ b/spec/db/chores/expired_record_cleaner_spec.rb
@@ -1,9 +1,6 @@
 require "#{Rails.root}/db/chores/expired_record_cleaner"
 
 describe ExpiredRecordCleaner do
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
-
   describe "fiscal year" do
     it "parses fiscal start date" do
       Timecop.freeze(Time.zone.parse("2015-10-02")) do
@@ -42,7 +39,7 @@ describe ExpiredRecordCleaner do
   end
 
   describe ".vacuum_proposal" do
-    it "cleans up specific proposal" do
+    it "cleans up specific proposal", email: true do
       proposal = create(:proposal)
       cleaner = ExpiredRecordCleaner.new(Time.zone.now, ok_to_act: true)
       cleaner.vacuum_proposal(proposal)

--- a/spec/db/chores/expired_record_cleaner_spec.rb
+++ b/spec/db/chores/expired_record_cleaner_spec.rb
@@ -38,8 +38,8 @@ describe ExpiredRecordCleaner do
     # end
   end
 
-  describe ".vacuum_proposal" do
-    it "cleans up specific proposal", :email do
+  describe ".vacuum_proposal", :email do
+    it "cleans up specific proposal" do
       proposal = create(:proposal)
       cleaner = ExpiredRecordCleaner.new(Time.zone.now, ok_to_act: true)
       cleaner.vacuum_proposal(proposal)

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -1,7 +1,4 @@
 describe "admin" do
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
-
   it "does not allow Delete of Users" do
     login_as_admin_user
 
@@ -79,7 +76,7 @@ describe "admin" do
     expect(page).to_not have_content("(GMT-05:00) Eastern Time (US & Canada)")
   end
 
-  it "triggers actions on Complete button click" do
+  it "triggers actions on Complete button click", email: true do
     login_as_admin_user
     proposal = create(:proposal, :with_serial_approvers)
 

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -76,7 +76,7 @@ describe "admin" do
     expect(page).to_not have_content("(GMT-05:00) Eastern Time (US & Canada)")
   end
 
-  it "triggers actions on Complete button click", email: true do
+  it "triggers actions on Complete button click", :email do
     login_as_admin_user
     proposal = create(:proposal, :with_serial_approvers)
 

--- a/spec/features/cancel_spec.rb
+++ b/spec/features/cancel_spec.rb
@@ -1,7 +1,4 @@
 describe "Canceling a request" do
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
-
   it "shows a cancel link for the requester" do
     proposal = create(:proposal)
     login_as(proposal.requester)
@@ -93,7 +90,7 @@ describe "Canceling a request" do
     end
   end
 
-  context "email" do
+  context "email", email: true do
     context "proposal without approver" do
       it "sends cancelation email to requester" do
         proposal = create(:proposal)

--- a/spec/features/cancel_spec.rb
+++ b/spec/features/cancel_spec.rb
@@ -90,7 +90,7 @@ describe "Canceling a request" do
     end
   end
 
-  context "email", email: true do
+  context "email", :email do
     context "proposal without approver" do
       it "sends cancelation email to requester" do
         proposal = create(:proposal)

--- a/spec/features/gsa18f/procurements/approve_spec.rb
+++ b/spec/features/gsa18f/procurements/approve_spec.rb
@@ -1,7 +1,7 @@
 feature "Approve a Gsa18F procurement" do
   context "when signed in as the approver" do
     context "last step is completed" do
-      it "sends one email to the requester", email: true do
+      it "sends one email to the requester", :email do
         purchaser = Gsa18f::Procurement.user_with_role("gsa18f_purchaser")
         procurement = create(:gsa18f_procurement, :with_steps)
         proposal = procurement.proposal

--- a/spec/features/gsa18f/procurements/approve_spec.rb
+++ b/spec/features/gsa18f/procurements/approve_spec.rb
@@ -1,10 +1,7 @@
 feature "Approve a Gsa18F procurement" do
   context "when signed in as the approver" do
     context "last step is completed" do
-      before(:all) { ENV["DISABLE_EMAIL"] = nil }
-      after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
-
-      it "sends one email to the requester" do
+      it "sends one email to the requester", email: true do
         purchaser = Gsa18f::Procurement.user_with_role("gsa18f_purchaser")
         procurement = create(:gsa18f_procurement, :with_steps)
         proposal = procurement.proposal

--- a/spec/features/ncr/work_orders/approve_spec.rb
+++ b/spec/features/ncr/work_orders/approve_spec.rb
@@ -1,7 +1,7 @@
 feature "Approve a NCR work order" do
   context "when signed in as the approver" do
     context "last step is completed" do
-      it "sends one email to the requester", email: true do
+      it "sends one email to the requester", :email do
         work_order = create(:ncr_work_order, :with_approvers)
         approver = work_order.individual_steps.last.user
         work_order.individual_steps.first.complete!

--- a/spec/features/ncr/work_orders/approve_spec.rb
+++ b/spec/features/ncr/work_orders/approve_spec.rb
@@ -1,10 +1,7 @@
 feature "Approve a NCR work order" do
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
-
   context "when signed in as the approver" do
     context "last step is completed" do
-      it "sends one email to the requester" do
+      it "sends one email to the requester", email: true do
         work_order = create(:ncr_work_order, :with_approvers)
         approver = work_order.individual_steps.last.user
         work_order.individual_steps.first.complete!

--- a/spec/features/ncr/work_orders/change_work_oder_to_whsc_spec.rb
+++ b/spec/features/ncr/work_orders/change_work_oder_to_whsc_spec.rb
@@ -1,7 +1,4 @@
 feature "Requester switches work order to WHSC", :js do
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
-
   let(:work_order) { create(:ncr_work_order) }
   let(:ncr_proposal) { work_order.proposal }
 
@@ -12,7 +9,7 @@ feature "Requester switches work order to WHSC", :js do
   end
 
   context "as a BA61" do
-    scenario "notifies the removed approver" do
+    scenario "notifies the removed approver", email: true do
       whsc_org = create(:whsc_organization)
       expect(work_order).to_not be_for_whsc_organization
       deliveries.clear

--- a/spec/features/ncr/work_orders/change_work_oder_to_whsc_spec.rb
+++ b/spec/features/ncr/work_orders/change_work_oder_to_whsc_spec.rb
@@ -9,7 +9,7 @@ feature "Requester switches work order to WHSC", :js do
   end
 
   context "as a BA61" do
-    scenario "notifies the removed approver", email: true do
+    scenario "notifies the removed approver", :email do
       whsc_org = create(:whsc_organization)
       expect(work_order).to_not be_for_whsc_organization
       deliveries.clear

--- a/spec/features/ncr/work_orders/post_approval_modification_spec.rb
+++ b/spec/features/ncr/work_orders/post_approval_modification_spec.rb
@@ -15,7 +15,7 @@ feature "post-approval modification" do
     expect(work_order.status).to eq("completed")
   end
 
-  scenario "can do end-to-end re-approval", email: true do
+  scenario "can do end-to-end re-approval", :email do
     work_order = create(:ncr_work_order)
     work_order.setup_approvals_and_observers
     fully_complete(work_order.proposal)

--- a/spec/features/ncr/work_orders/post_approval_modification_spec.rb
+++ b/spec/features/ncr/work_orders/post_approval_modification_spec.rb
@@ -15,9 +15,7 @@ feature "post-approval modification" do
     expect(work_order.status).to eq("completed")
   end
 
-  scenario "can do end-to-end re-approval" do
-    ENV["DISABLE_EMAIL"] = nil
-
+  scenario "can do end-to-end re-approval", email: true do
     work_order = create(:ncr_work_order)
     work_order.setup_approvals_and_observers
     fully_complete(work_order.proposal)
@@ -66,8 +64,6 @@ feature "post-approval modification" do
       user: work_order.budget_approvers.second.full_name
     ).delete("`")
     expect(page).to have_content(completed_comment)
-
-    ENV["DISABLE_EMAIL"] = "Yes"
   end
 
   scenario "budget approver does not trigger re-approval" do

--- a/spec/features/ncr/work_orders/requester_edit_spec.rb
+++ b/spec/features/ncr/work_orders/requester_edit_spec.rb
@@ -65,7 +65,7 @@ feature "Requester edits their NCR work order", :js do
     )
   end
 
-  scenario "notifies observers of changes", email: true do
+  scenario "notifies observers of changes", :email do
     user = create(:user, client_slug: "ncr", email_address: "observer@example.com")
     @work_order.add_observer(user)
     visit edit_ncr_work_order_path(@work_order)
@@ -77,7 +77,7 @@ feature "Requester edits their NCR work order", :js do
     expect(deliveries.last).to have_content(user.full_name)
   end
 
-  scenario "does not resave unchanged requests", email: true do
+  scenario "does not resave unchanged requests", :email do
     visit edit_ncr_work_order_path(@work_order)
     click_on "Update"
 
@@ -110,7 +110,7 @@ feature "Requester edits their NCR work order", :js do
     expect(proposal.approvers.second.email_address).to eq(Ncr::Mailboxes.ba80_budget.email_address)
   end
 
-  context "proposal changes from BA80 to BA61", email: true do
+  context "proposal changes from BA80 to BA61", :email do
     scenario "removed tier 1 approver is notified if approval is not pending" do
       @work_order.update(expense_type: "BA61")
       tier_one_approver = Ncr::Mailboxes.ba61_tier1_budget

--- a/spec/features/ncr/work_orders/requester_edit_spec.rb
+++ b/spec/features/ncr/work_orders/requester_edit_spec.rb
@@ -1,9 +1,6 @@
 feature "Requester edits their NCR work order", :js do
   include ProposalSpecHelper
 
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
-
   def requester
     @work_order.requester
   end
@@ -68,7 +65,7 @@ feature "Requester edits their NCR work order", :js do
     )
   end
 
-  scenario "notifies observers of changes" do
+  scenario "notifies observers of changes", email: true do
     user = create(:user, client_slug: "ncr", email_address: "observer@example.com")
     @work_order.add_observer(user)
     visit edit_ncr_work_order_path(@work_order)
@@ -80,7 +77,7 @@ feature "Requester edits their NCR work order", :js do
     expect(deliveries.last).to have_content(user.full_name)
   end
 
-  scenario "does not resave unchanged requests" do
+  scenario "does not resave unchanged requests", email: true do
     visit edit_ncr_work_order_path(@work_order)
     click_on "Update"
 
@@ -113,7 +110,7 @@ feature "Requester edits their NCR work order", :js do
     expect(proposal.approvers.second.email_address).to eq(Ncr::Mailboxes.ba80_budget.email_address)
   end
 
-  context "proposal changes from BA80 to BA61" do
+  context "proposal changes from BA80 to BA61", email: true do
     scenario "removed tier 1 approver is notified if approval is not pending" do
       @work_order.update(expense_type: "BA61")
       tier_one_approver = Ncr::Mailboxes.ba61_tier1_budget

--- a/spec/features/proposals/complete_spec.rb
+++ b/spec/features/proposals/complete_spec.rb
@@ -36,9 +36,7 @@ describe "Completing a proposal" do
     expect(page).to have_content(I18n.t("errors.policies.proposal.step_complete"))
   end
 
-  it "sends email to observers and requester when proposal is complete" do
-    ENV["DISABLE_EMAIL"] = nil
-
+  it "sends email to observers and requester when proposal is complete", email: true do
     proposal = create(:proposal, :with_approver)
     proposal.add_observer(create(:user))
 
@@ -48,7 +46,5 @@ describe "Completing a proposal" do
 
     expect(proposal.observers.length).to eq(1)
     expect(deliveries.length).to eq(2)
-
-    ENV["DISABLE_EMAIL"] = nil
   end
 end

--- a/spec/features/proposals/complete_spec.rb
+++ b/spec/features/proposals/complete_spec.rb
@@ -36,7 +36,7 @@ describe "Completing a proposal" do
     expect(page).to have_content(I18n.t("errors.policies.proposal.step_complete"))
   end
 
-  it "sends email to observers and requester when proposal is complete", email: true do
+  it "sends email to observers and requester when proposal is complete", :email do
     proposal = create(:proposal, :with_approver)
     proposal.add_observer(create(:user))
 

--- a/spec/mailers/attachment_mailer_spec.rb
+++ b/spec/mailers/attachment_mailer_spec.rb
@@ -1,8 +1,5 @@
-describe AttachmentMailer do
+describe AttachmentMailer, email: true do
   include MailerSpecHelper
-
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
 
   describe "#new_attachment_notification" do
     let(:mail) { AttachmentMailer.new_attachment_notification(requester, proposal, attachment) }

--- a/spec/mailers/attachment_mailer_spec.rb
+++ b/spec/mailers/attachment_mailer_spec.rb
@@ -1,4 +1,4 @@
-describe AttachmentMailer, email: true do
+describe AttachmentMailer, :email do
   include MailerSpecHelper
 
   describe "#new_attachment_notification" do

--- a/spec/mailers/cancelation_mailer_spec.rb
+++ b/spec/mailers/cancelation_mailer_spec.rb
@@ -1,4 +1,4 @@
-describe CancelationMailer, email: true do
+describe CancelationMailer, :email do
 
   describe "#cancelation_notification" do
     let(:proposal) { create(:proposal) }

--- a/spec/mailers/cancelation_mailer_spec.rb
+++ b/spec/mailers/cancelation_mailer_spec.rb
@@ -1,6 +1,4 @@
-describe CancelationMailer do
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
+describe CancelationMailer, email: true do
 
   describe "#cancelation_notification" do
     let(:proposal) { create(:proposal) }

--- a/spec/mailers/comment_mailer_spec.rb
+++ b/spec/mailers/comment_mailer_spec.rb
@@ -1,11 +1,8 @@
-describe CommentMailer do
+describe CommentMailer, email: true do
   include MailerSpecHelper
   include EnvVarSpecHelper
 
   let(:user) { create(:user) }
-
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
 
   describe "#comment_added_notification" do
     it_behaves_like "a proposal email" do

--- a/spec/mailers/comment_mailer_spec.rb
+++ b/spec/mailers/comment_mailer_spec.rb
@@ -1,4 +1,4 @@
-describe CommentMailer, email: true do
+describe CommentMailer, :email do
   include MailerSpecHelper
   include EnvVarSpecHelper
 

--- a/spec/mailers/feedback_mailer_spec.rb
+++ b/spec/mailers/feedback_mailer_spec.rb
@@ -1,8 +1,5 @@
-describe FeedbackMailer do
+describe FeedbackMailer, email: true do
   include EnvVarSpecHelper
-
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
 
   describe 'feedback' do
     it "sends from the submitter" do

--- a/spec/mailers/feedback_mailer_spec.rb
+++ b/spec/mailers/feedback_mailer_spec.rb
@@ -1,4 +1,4 @@
-describe FeedbackMailer, email: true do
+describe FeedbackMailer, :email do
   include EnvVarSpecHelper
 
   describe 'feedback' do

--- a/spec/mailers/observer_mailer_spec.rb
+++ b/spec/mailers/observer_mailer_spec.rb
@@ -1,8 +1,5 @@
-describe ObserverMailer do
+describe ObserverMailer, email: true do
   include MailerSpecHelper
-
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
 
   describe "#observer_added_notification" do
     it "sends to the observer" do

--- a/spec/mailers/observer_mailer_spec.rb
+++ b/spec/mailers/observer_mailer_spec.rb
@@ -1,4 +1,4 @@
-describe ObserverMailer, email: true do
+describe ObserverMailer, :email do
   include MailerSpecHelper
 
   describe "#observer_added_notification" do

--- a/spec/mailers/proposal_mailer_spec.rb
+++ b/spec/mailers/proposal_mailer_spec.rb
@@ -1,4 +1,4 @@
-describe ProposalMailer, email: true do
+describe ProposalMailer, :email do
   include MailerSpecHelper
 
   describe "#proposal_created_confirmation" do

--- a/spec/mailers/proposal_mailer_spec.rb
+++ b/spec/mailers/proposal_mailer_spec.rb
@@ -1,8 +1,5 @@
-describe ProposalMailer do
+describe ProposalMailer, email: true do
   include MailerSpecHelper
-
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
 
   describe "#proposal_created_confirmation" do
     let(:mail) { ProposalMailer.proposal_created_confirmation(proposal) }

--- a/spec/mailers/report_mailer_spec.rb
+++ b/spec/mailers/report_mailer_spec.rb
@@ -1,8 +1,5 @@
-describe ReportMailer do
+describe ReportMailer, email: true do
   include EnvVarSpecHelper
-
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
 
   describe "#daily_budget_report" do
     it "works with no data" do

--- a/spec/mailers/report_mailer_spec.rb
+++ b/spec/mailers/report_mailer_spec.rb
@@ -1,4 +1,4 @@
-describe ReportMailer, email: true do
+describe ReportMailer, :email do
   include EnvVarSpecHelper
 
   describe "#daily_budget_report" do

--- a/spec/mailers/step_mailer_spec.rb
+++ b/spec/mailers/step_mailer_spec.rb
@@ -1,8 +1,5 @@
-describe StepMailer do
+describe StepMailer, email: true do
   include MailerSpecHelper
-
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
 
   describe "#step_user_reply" do
     let(:mail) { StepMailer.step_reply_received(approval) }

--- a/spec/mailers/step_mailer_spec.rb
+++ b/spec/mailers/step_mailer_spec.rb
@@ -1,4 +1,4 @@
-describe StepMailer, email: true do
+describe StepMailer, :email do
   include MailerSpecHelper
 
   describe "#step_user_reply" do

--- a/spec/mailers/welcome_mailer_spec.rb
+++ b/spec/mailers/welcome_mailer_spec.rb
@@ -1,8 +1,5 @@
-describe WelcomeMailer do
+describe WelcomeMailer, email: true do
   include Rails.application.routes.url_helpers
-
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
 
   describe "#welcome_notification" do
     it "includes the welcome text" do

--- a/spec/mailers/welcome_mailer_spec.rb
+++ b/spec/mailers/welcome_mailer_spec.rb
@@ -1,4 +1,4 @@
-describe WelcomeMailer, email: true do
+describe WelcomeMailer, :email do
   include Rails.application.routes.url_helpers
 
   describe "#welcome_notification" do

--- a/spec/models/dispatcher_spec.rb
+++ b/spec/models/dispatcher_spec.rb
@@ -1,7 +1,4 @@
-describe Dispatcher do
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
-
+describe Dispatcher, email: true do
   describe "#deliver_new_proposal_emails" do
     it "sends emails to the requester and first approver" do
       proposal = create(:proposal, :with_approver, :with_observer)

--- a/spec/models/dispatcher_spec.rb
+++ b/spec/models/dispatcher_spec.rb
@@ -1,4 +1,4 @@
-describe Dispatcher, email: true do
+describe Dispatcher, :email do
   describe "#deliver_new_proposal_emails" do
     it "sends emails to the requester and first approver" do
       proposal = create(:proposal, :with_approver, :with_observer)

--- a/spec/models/incoming_mail_handler_spec.rb
+++ b/spec/models/incoming_mail_handler_spec.rb
@@ -1,4 +1,4 @@
-describe "Handles incoming email", email: true do
+describe "Handles incoming email", :email do
   include EnvVarSpecHelper
 
   it "should forward non-app email to NOTIFICATION_FALLBACK_EMAIL" do

--- a/spec/models/incoming_mail_handler_spec.rb
+++ b/spec/models/incoming_mail_handler_spec.rb
@@ -1,8 +1,5 @@
-describe "Handles incoming email" do
+describe "Handles incoming email", email: true do
   include EnvVarSpecHelper
-
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
 
   it "should forward non-app email to NOTIFICATION_FALLBACK_EMAIL" do
     with_env_vars(NOTIFICATION_FALLBACK_EMAIL: "nowhere@example.com", NOTIFICATION_FROM_EMAIL: "noreply@example.com") do

--- a/spec/models/ncr_dispatcher_spec.rb
+++ b/spec/models/ncr_dispatcher_spec.rb
@@ -144,7 +144,7 @@ describe NcrDispatcher do
       end
     end
 
-    it "does not notify observer if they are the one making the update" do
+    it "does not notify observer if they are the one making the update", :email do
       work_order = create(:ncr_work_order, :with_approvers)
       user = create(:user, client_slug: "ncr")
       proposal = work_order.proposal
@@ -158,7 +158,7 @@ describe NcrDispatcher do
       expect(email_recipients).to_not include(user.email_address)
     end
 
-    it "does not notify approver if they are the one making the update" do
+    it "does not notify approver if they are the one making the update", :email do
       work_order = create(:ncr_work_order, :with_approvers)
       step_1 = work_order.individual_steps.first
       comment = create(:comment, proposal: work_order.proposal, user: step_1.user)

--- a/spec/models/ncr_dispatcher_spec.rb
+++ b/spec/models/ncr_dispatcher_spec.rb
@@ -1,4 +1,4 @@
-describe NcrDispatcher, email: true do
+describe NcrDispatcher, :email do
   describe "#deliver_new_proposal_emails" do
     context "work order is emergency" do
       it "sends the emergency proposal created confirmation do the requester" do

--- a/spec/models/ncr_dispatcher_spec.rb
+++ b/spec/models/ncr_dispatcher_spec.rb
@@ -1,4 +1,4 @@
-describe NcrDispatcher, :email do
+describe NcrDispatcher do
   describe "#deliver_new_proposal_emails" do
     context "work order is emergency" do
       it "sends the emergency proposal created confirmation do the requester" do
@@ -145,7 +145,7 @@ describe NcrDispatcher, :email do
     end
 
     it "does not notify observer if they are the one making the update" do
-      work_order =  create(:ncr_work_order, :with_approvers)
+      work_order = create(:ncr_work_order, :with_approvers)
       user = create(:user, client_slug: "ncr")
       proposal = work_order.proposal
       proposal.add_observer(user)
@@ -159,7 +159,7 @@ describe NcrDispatcher, :email do
     end
 
     it "does not notify approver if they are the one making the update" do
-      work_order =  create(:ncr_work_order, :with_approvers)
+      work_order = create(:ncr_work_order, :with_approvers)
       step_1 = work_order.individual_steps.first
       comment = create(:comment, proposal: work_order.proposal, user: step_1.user)
       proposal = work_order.proposal
@@ -172,8 +172,8 @@ describe NcrDispatcher, :email do
       expect(email_recipients).to_not include(email)
     end
 
-    it "notifies requester if they are not the one making the update" do
-      work_order =  create(:ncr_work_order, :with_approvers)
+    it "notifies requester if they are not the one making the update", :email do
+      work_order = create(:ncr_work_order, :with_approvers)
       step_1 = work_order.individual_steps.first
       comment = create(:comment, proposal: work_order.proposal, user: step_1.user)
       proposal = work_order.proposal

--- a/spec/models/ncr_dispatcher_spec.rb
+++ b/spec/models/ncr_dispatcher_spec.rb
@@ -1,7 +1,4 @@
-describe NcrDispatcher do
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
-
+describe NcrDispatcher, email: true do
   describe "#deliver_new_proposal_emails" do
     context "work order is emergency" do
       it "sends the emergency proposal created confirmation do the requester" do

--- a/spec/models/test/client_request_spec.rb
+++ b/spec/models/test/client_request_spec.rb
@@ -48,7 +48,7 @@ describe Test::ClientRequest do
     end
   end
 
-  describe "#setup_and_email_subscribers" do
+  describe "#setup_and_email_subscribers", :email do
     it "currently does nothing" do
       client_request = create(:test_client_request)
       expect(client_request.setup_and_email_subscribers("hello world")).to eq nil

--- a/spec/queries/ncr/last_week_count_query_spec.rb
+++ b/spec/queries/ncr/last_week_count_query_spec.rb
@@ -1,7 +1,4 @@
 describe Ncr::LastWeekCountQuery do
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
-
   describe ".find" do
     it "returns the count of NCR proposals created in the past week" do
       orig_count = Ncr::LastWeekCountQuery.new.find

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,10 +1,13 @@
 ENV["RAILS_ENV"] ||= "test"
-ENV["DISABLE_EMAIL"] = "Yes"
 
 require "spec_helper"
 require File.expand_path("../../config/environment", __FILE__)
 require "rspec/rails"
 require "shoulda/matchers"
+
+# Disable email sending by default. We can selectively enable it on specs and example
+# groups with the `:email` tag.
+ActionMailer::Base.perform_deliveries = false
 
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 

--- a/spec/requests/set_user_after_login_spec.rb
+++ b/spec/requests/set_user_after_login_spec.rb
@@ -1,67 +1,66 @@
-describe 'User creation when logging in with Oauth to view a protected page' do
+describe "User creation when logging in with Oauth to view a protected page" do
   include EnvVarSpecHelper
 
   StructUser = Struct.new(:email_address, :first_name, :last_name)
 
   before do
-    user = StructUser.new('george-test@example.com', 'Georgie', 'Jetsonian')
+    user = StructUser.new("george-test@example.com", "Georgie", "Jetsonian")
     setup_mock_auth(:myusa, user)
   end
 
-  it 'creates a new user if the current user does not already exist' do
-    expect {
-      get '/auth/myusa/callback'
-    }.to change { User.count }.by(1)
+  it "creates a new user if the current user does not already exist" do
+    expect do
+      get "/auth/myusa/callback"
+    end.to change { User.count }.by(1)
 
     new_user = User.last
-    expect(new_user.email_address).to eq('george-test@example.com')
+    expect(new_user.email_address).to eq("george-test@example.com")
     expect(new_user.first_name).to eq("Georgie")
     expect(new_user.last_name).to eq("Jetsonian")
   end
 
-  it "sends welcome email to a new user" do
+  it "sends welcome email to a new user", :email do
     with_env_var("WELCOME_EMAIL", "true") do
-      deliveries.clear
-      expect { get '/auth/myusa/callback' }.to change { deliveries.length }.from(0).to(1)
+      expect { get "/auth/myusa/callback" }.to change { deliveries.length }.from(0).to(1)
       welcome_mail = deliveries.first
       expect(welcome_mail.subject).to eq("Welcome to C2!")
     end
   end
 
   it "absence of first/last name does not throw error" do
-    user = StructUser.new('somebody@example.com', nil, nil)
+    user = StructUser.new("somebody@example.com", nil, nil)
     setup_mock_auth(:myusa, user)
-    expect {
-      get '/auth/myusa/callback'
-    }.to change { User.count }.by(1)
+    expect do
+      get "/auth/myusa/callback"
+    end.to change { User.count }.by(1)
   end
 
-  it 'does not create a user if the current user already exists' do
-    create(:user, email_address: 'george-test@example.com')
+  it "does not create a user if the current user already exists" do
+    create(:user, email_address: "george-test@example.com")
 
-    expect {
-      get '/auth/myusa/callback'
-    }.to_not change { User.count }
+    expect do
+      get "/auth/myusa/callback"
+    end.to_not change { User.count }
   end
 
   it "does not send welcome email to existing user" do
     deliveries.clear
-    create(:user, email_address: 'george-test@example.com')
+    create(:user, email_address: "george-test@example.com")
 
     Timecop.travel(Time.current + 1.minute) do
-      expect {
-        get '/auth/myusa/callback'
-      }.to_not change { deliveries.length }
+      expect do
+        get "/auth/myusa/callback"
+      end.to_not change { deliveries.length }
     end
   end
 
-  it 'redirects a newly logged in user to the carts screen' do
-    create(:user, email_address: 'george-test@example.com')
+  it "redirects a newly logged in user to the carts screen" do
+    create(:user, email_address: "george-test@example.com")
 
-    expect {
-      get '/auth/myusa/callback'
-    }.to_not change { User.count }
+    expect do
+      get "/auth/myusa/callback"
+    end.to_not change { User.count }
 
-    expect(response).to redirect_to('/proposals')
+    expect(response).to redirect_to("/proposals")
   end
 end

--- a/spec/services/client_data_creator_spec.rb
+++ b/spec/services/client_data_creator_spec.rb
@@ -1,9 +1,6 @@
 describe ClientDataCreator do
   include ActionDispatch::TestProcess
 
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
-
   describe "#run" do
     # TODO: Fix this brittle test
     #

--- a/spec/services/observation_creator_spec.rb
+++ b/spec/services/observation_creator_spec.rb
@@ -1,7 +1,4 @@
 describe ObservationCreator do
-  before(:all) { ENV["DISABLE_EMAIL"] = nil }
-  after(:all)  { ENV["DISABLE_EMAIL"] = "Yes" }
-
   describe "#run" do
     it "creates a new observation for the user id and proposal id passed in" do
       proposal = create(:proposal)
@@ -16,7 +13,7 @@ describe ObservationCreator do
     end
 
     context "with an adder but no reason" do
-      it "sends an observer added email" do
+      it "sends an observer added email", email: true do
         proposal = create(:proposal)
         observer = create(:user)
         adder = create(:user)
@@ -67,7 +64,7 @@ describe ObservationCreator do
         expect(proposal.comments.first.comment_text).to include reason
       end
 
-      it "sends a comment email" do
+      it "sends a comment email", email: true do
         proposal = create(:proposal)
         observer = create(:user)
         adder = create(:user)

--- a/spec/services/observation_creator_spec.rb
+++ b/spec/services/observation_creator_spec.rb
@@ -13,7 +13,7 @@ describe ObservationCreator do
     end
 
     context "with an adder but no reason" do
-      it "sends an observer added email", email: true do
+      it "sends an observer added email", :email do
         proposal = create(:proposal)
         observer = create(:user)
         adder = create(:user)
@@ -64,7 +64,7 @@ describe ObservationCreator do
         expect(proposal.comments.first.comment_text).to include reason
       end
 
-      it "sends a comment email", email: true do
+      it "sends a comment email", :email do
         proposal = create(:proposal)
         observer = create(:user)
         adder = create(:user)

--- a/spec/services/scheduled_reporter_spec.rb
+++ b/spec/services/scheduled_reporter_spec.rb
@@ -14,12 +14,12 @@ describe ScheduledReporter do
     end
   end
 
-  describe "#run", :elasticsearch do
+  describe "#run", elasticsearch: true, email: true do
     it "always sends dailes" do
       deliveries.clear
       owner = create(:user)
       report = create(:report, query: { text: "something" }.to_json, user: owner)
-      scheduled_report = create(:scheduled_report, frequency: "daily", user: owner, report: report)
+      create(:scheduled_report, frequency: "daily", user: owner, report: report)
 
       scheduled_reporter = ScheduledReporter.new(Time.current)
 
@@ -31,8 +31,7 @@ describe ScheduledReporter do
     end
 
     it "sends weeklies on Mondays" do
-      deliveries.clear
-      scheduled_report = weekly_scheduled_report
+      create_weekly_scheduled_report
       monday = Time.zone.parse("2016-03-07")
       reporter = ScheduledReporter.new(monday)
 
@@ -45,7 +44,7 @@ describe ScheduledReporter do
 
     it "only sends weeklies on Mondays" do
       deliveries.clear
-      scheduled_report = weekly_scheduled_report
+      create_weekly_scheduled_report
       tuesday = Time.zone.parse("2016-03-08")
       reporter = ScheduledReporter.new(tuesday)
 
@@ -58,7 +57,7 @@ describe ScheduledReporter do
 
     it "sends monthlies on first day of the month" do
       deliveries.clear
-      scheduled_report = monthly_scheduled_report
+      create_monthly_scheduled_report
       first_day_of_month = Time.zone.parse("2016-04-01")
       reporter = ScheduledReporter.new(first_day_of_month)
 
@@ -71,7 +70,7 @@ describe ScheduledReporter do
 
     it "sends monthlies only on first day of the month" do
       deliveries.clear
-      scheduled_report = monthly_scheduled_report
+      create_monthly_scheduled_report
       second_day_of_month = Time.zone.parse("2016-04-02")
       reporter = ScheduledReporter.new(second_day_of_month)
 
@@ -83,15 +82,15 @@ describe ScheduledReporter do
     end
   end
 
-  def weekly_scheduled_report
+  def create_weekly_scheduled_report
     owner = create(:user)
     report = create(:report, query: { text: "something" }.to_json, user: owner)
-    scheduled_report = create(:scheduled_report, frequency: "weekly", user: owner, report: report)
+    create(:scheduled_report, frequency: "weekly", user: owner, report: report)
   end
 
-  def monthly_scheduled_report
+  def create_monthly_scheduled_report
     owner = create(:user)
     report = create(:report, query: { text: "something" }.to_json, user: owner)
-    scheduled_report = create(:scheduled_report, frequency: "monthly", user: owner, report: report)
+    create(:scheduled_report, frequency: "monthly", user: owner, report: report)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,13 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.around(:example, email: true) do |example|
+    default_value = ENV["DISABLE_EMAIL"]
+    ENV["DISABLE_EMAIL"] = nil
+    example.run
+    ENV["DISABLE_EMAIL"] = default_value
+  end
+
   config.include FactoryGirl::Syntax::Methods
   config.raise_errors_for_deprecations!
   config.backtrace_exclusion_patterns << %r{/gems/}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,11 +46,19 @@ RSpec.configure do |config|
   end
 
   config.around(:example, email: true) do |example|
-    default_value = ENV["DISABLE_EMAIL"]
-    ENV["DISABLE_EMAIL"] = nil
+    orig_value = ActionMailer::Base.perform_deliveries
+    ActionMailer::Base.perform_deliveries = true
+
     example.run
-    ENV["DISABLE_EMAIL"] = default_value
+
+    ActionMailer::Base.deliveries.clear
+    ActionMailer::Base.perform_deliveries = orig_value
   end
+
+  # config.after(:each) do |example|
+  #   deliveries = ActionMailer::Base.deliveries
+  #   puts "#{deliveries.size} deliveries after #{example.inspect}" if deliveries.size > 0
+  # end
 
   config.include FactoryGirl::Syntax::Methods
   config.raise_errors_for_deprecations!

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,6 +1,7 @@
 RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
+    ActionMailer::Base.deliveries.clear
     Role.ensure_system_roles_exist
     Test.setup_models
     Rails.application.load_seed
@@ -21,7 +22,6 @@ RSpec.configure do |config|
   end
 
   config.after(:each) do
-    ActionMailer::Base.deliveries.clear
     Proposal.clear_index_tracking
     DatabaseCleaner.clean
   end

--- a/spec/support/deliveries.rb
+++ b/spec/support/deliveries.rb
@@ -3,5 +3,5 @@ def deliveries
 end
 
 def email_recipients
-  deliveries.map {|email| email.to[0] }.sort
+  deliveries.map { |email| email.to[0] }.sort
 end


### PR DESCRIPTION
A slightly easier way of enabling email sending, continuing the work @dogweather did in #1361.