### PR TITLE
temporarily disable profile message

### DIFF
--- a/app/views/layouts/_c2_header.html.erb
+++ b/app/views/layouts/_c2_header.html.erb
@@ -2,7 +2,7 @@
   <%= render partial: "shared/sandbox_warning" %>
 <% end %>
 <% if display_profile_warning? %>
-  <%= render partial: "shared/user_profile_warning" %>
+  <!-- #render partial: "shared/user_profile_warning" -->
 <% end %>
 <header>
   <div class="container">


### PR DESCRIPTION
## WHAT
Remove "missing profile information" message temporarily 

## WHY

https://trello.com/c/ejtsgNbb/553-deactivate-the-fill-out-your-profile-mesage