### PR TITLE
Check for event before rendering in the activity feed

### DIFF
--- a/app/views/proposals/details/_comment_list.html.haml
+++ b/app/views/proposals/details/_comment_list.html.haml
@@ -7,13 +7,14 @@
           - history_style = index > 4 ? "contracted" : "expanded"
           - index_class = index == events.count - 1 ? "status-index-last" : "status-index-" + index.to_s
           - classes = "status-#{history_style} #{index_class}"
-          .medium-12.column.status-feed-wrapper.row.comment{ class: classes }
-            .medium-table-row.medium-12.status-feed-item.no-margin-bottom
-              .hide-for-small-only.medium-table-cell.medium-activity-icon-col.background-color-column
-                .dot-circle
-              .medium-table-cell.medium-auto-column.status-feed-content
-                = render partial: event, locals: { event: event }
-          - index = index + 1
+          - if !event.nil?
+            .medium-12.column.status-feed-wrapper.row.comment{ class: classes }
+              .medium-table-row.medium-12.status-feed-item.no-margin-bottom
+                .hide-for-small-only.medium-table-cell.medium-activity-icon-col.background-color-column
+                  .dot-circle
+                .medium-table-cell.medium-auto-column.status-feed-content
+                  = render partial: event, locals: { event: event }
+            - index = index + 1
 
 - if events.length > 5
   .row.status-feed-actions


### PR DESCRIPTION
# What

The activity feed elements are rendering based on expecting the event elements to be present. For activity events that are created via the command line, some key elements like user_id are missing. When the events element is not complete, dont render any of the activity feed item. This will prevent the blank row with a activity feed dot.

# Example

https://c2-dev.18f.gov/proposals/295

![screen shot 2016-06-24 at 3 15 31 pm](https://cloud.githubusercontent.com/assets/13986595/16348101/85d84c60-3a1e-11e6-98a0-5b31e1904459.png)


# Reference

https://trello.com/c/im1npxle/563-timeline-dots-are-not-lining-up-with-events