### PR TITLE
Remove call to database connection during bootstrap script

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -11,5 +11,5 @@ class Role < ActiveRecord::Base
     SYSTEM_ROLES.each { |r| Role.find_or_create_by!(name: r) }
   end
 
-  ensure_system_roles_exist if connection.table_exists? "roles"
+  ensure_system_roles_exist if connected? && connection.table_exists?("roles")
 end


### PR DESCRIPTION
This is a bug I discovered while trying to get the app running on my local machine.

The fix that I used to get it working is laid out in the commit in this PR.

Prior to this commit, running the bootsrap script with `./script/bootstrap email@gsa.gov`, would fail because of a call to the database which had yet to be created.

The issue in particulair was in the Role model:

```ruby
ensure_system_roles_exist if connection.table_exists?("roles")
```

The error message looked like this:

```shell
/Users/jonathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/bundler/gems/activeadmin-ca94d1ccb189/lib/active_admin/error.rb:43:in `rescue in capture': Your file, app/models/role.rb (line 14), caused a database error while Active Admin was loading. This is most common when your database is missing or doesn't have the latest migrations applied. To prevent this error, move the code to a place where it will only be run when a page is rendered. One solution can be, to wrap the query in a Proc. Original error message: FATAL:  database "c2_development" does not exist
```

To recreate this issue, revert this commit and change the database name in `config/database.yml` and try to run the bootsrap script.

This commit fixes the issue by adding a conditional to check that a database connection exists before calling `connection.table_exists?`.