### PR TITLE
New details page/prevent duplicate notification

### DIFF
--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -131,7 +131,13 @@ C2 = (function() {
 
   C2.prototype.detailsCancelled = function(){
     this.detailsMode('view');
-    this.createNotification("Your modifications have not been saved. Click modify to continue.", "", "notice");
+    var message;
+    if(this.formState.el.dirrty("isDirty")){
+      message = "Your modifications have not been saved. Click modify to continue.";
+    } else {
+      message = "Modification canceled. No changes were made.";
+    }
+    this.createNotification(message, "", "notice");
   }
 
   C2.prototype.detailsSaved = function(data){

--- a/app/assets/javascripts/details/views/notifications.js
+++ b/app/assets/javascripts/details/views/notifications.js
@@ -3,7 +3,9 @@ var Notifications;
 Notifications = (function(){
   function Notifications(el) {
     this.data = {
-      noticeId: 0
+      noticeId: 0,
+      lastNotice: "",
+      currentNotice: ""
     }
     this.el = $(el);
     this._setup();
@@ -35,8 +37,8 @@ Notifications = (function(){
   }
 
   Notifications.prototype.create = function(params){
-    var notice = this._prepare(params);
-    this._postNotification(notice);
+    this._prepare(params);
+    this._postNotification();
   }
 
   Notifications.prototype._closeButton = function(el){
@@ -53,14 +55,16 @@ Notifications = (function(){
     })
   }
 
-  Notifications.prototype._postNotification = function(notice){
+  Notifications.prototype._postNotification = function(){
     var self = this;
     var id = this.data.noticeId;
-    var noticeBar = $(notice);
-
-    this.data.noticeId = this.data.noticeId + 1;
-    this.el.find('ul').append(noticeBar);
-    this.initClose(id)
+    var noticeBar = $(self.data.currentNotice);
+    if(self.data.currentNotice !== self.data.pastNotice){
+      this.data.pastNotice = self.data.currentNotice;
+      this.data.noticeId = this.data.noticeId + 1;
+      this.el.find('ul').append(noticeBar);
+      this.initClose(id)
+    }
   }
 
   Notifications.prototype.initClose = function(id){
@@ -120,7 +124,7 @@ Notifications = (function(){
                     '</div>' +
                   '</li>';
     
-    return notice
+    this.data.currentNotice = notice;
   }
 
   Notifications.prototype.clearOne = function(el){


### PR DESCRIPTION
# What

Prevent potential for multiple notifications to pop up, if the content is the same as last rendered notification.

Change cancel notification text when there is no modifications made to field.

# Reference 

https://trello.com/c/WGKNAzEP/496-when-saving-a-change-to-a-request-the-notification-bar-repeats-multiple-times