### PR TITLE
Can now close ethnio screener consistently

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "clockwork", require: false
 gem "daemons" # for delayed_job
 gem "delayed_job_active_record"
 gem "doorkeeper"
+gem "dotenv-rails", require: "dotenv/rails-now"
 gem "draper"
 gem "elasticsearch-dsl"
 gem "elasticsearch-model"
@@ -71,7 +72,6 @@ end
 group :test, :development do
   gem "bullet", require: false # use BULLET_ENABLED=true
   gem "database_cleaner"
-  gem "dotenv-rails", require: "dotenv/rails-now"
   gem "konacha"
   gem "pry-byebug"
   gem "rspec-rails"

--- a/app/assets/javascripts/details/force_ethnio.js
+++ b/app/assets/javascripts/details/force_ethnio.js
@@ -4,5 +4,8 @@ window.Ethnio = {
   debug_mode : false,
   display_interval : 1,
   check_cookies: false,
-  fast_start: true
+  fast_start: true,
+  close: function(){
+    $("[id*=ethnio-screener-]").remove();
+  }
 }

--- a/app/views/proposals/details/_top_notification.html.haml
+++ b/app/views/proposals/details/_top_notification.html.haml
@@ -8,7 +8,7 @@
       %p
         - if cookies[:beta_reverted_survey] == "true"
           - cookies.delete :beta_reverted_survey
-          = javascript_include_tag "force_ethnio"
+          = javascript_include_tag "details/force_ethnio"
           = javascript_include_tag "https://www.ethn.io/55009.js", async: true
           
           = t("proposals.details.notification.beta.reverted", link: activate_design_proposal_path(proposal) ).html_safe


### PR DESCRIPTION
bug where the ethnio screener (when user reverts to the old design) couldn't be closed. 

This resolves that issue. 