### PR TITLE
Update non-turbolink form update

### DIFF
--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -211,7 +211,6 @@ C2 = (function() {
     if ( this.lastNotice !== stringParam){
       this.lastNotice = stringParam;
       this.notification.el.trigger('notification:create', param);
-    } else {
     }
   }
 

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -17,8 +17,9 @@ C2 = (function() {
       modalCard:      '#modal-wrapper',
       updateView:     '#mode-parent',
       summaryBar:     '#summary-card',
-      approvalCard:     '#card-for-approvals'
+      approvalCard:   '#card-for-approvals'
     }
+    this.lastNotice = {};
     this._overrideTestConfig(config);
     this._blastOff();
   }
@@ -206,7 +207,12 @@ C2 = (function() {
       content: content,
       type: type
     }
-    this.notification.el.trigger('notification:create', param);
+    var stringParam = JSON.stringify(param);
+    if ( this.lastNotice !== stringParam){
+      this.lastNotice = stringParam;
+      this.notification.el.trigger('notification:create', param);
+    } else {
+    }
   }
 
   /* End Notice */
@@ -318,3 +324,4 @@ C2 = (function() {
 }());
 
 window.C2 = C2;
+


### PR DESCRIPTION
# What

Update the form with ajax using the `.submit()` function. This tells the browser that the updated form fields are the _new_ fields. This makes sure the browser doesnt flag a "the fields aren't being saved" warning when the user leaves a page.'

# Note

We moved away from this `.submit()` method because the success notification gets called twice. To prevent this, the notification generator has a check that looks to see what the last notification created is. If the content is the same, it doesnt render the new one. 