### PR TITLE
Remove the issue around create notification error persistence

### DIFF
--- a/app/controllers/client_data_controller.rb
+++ b/app/controllers/client_data_controller.rb
@@ -17,7 +17,8 @@ class ClientDataController < ApplicationController
       @flash_manager.show(flash, "success", "Proposal submitted!")
       redirect_to proposal
     else
-      @flash_manager.show(flash, "error", errors)
+      flash_now = FlashWithNow.new
+      flash_now.show(flash, "error", errors)
       render :new
     end
   end


### PR DESCRIPTION
# What

The error notice on creating a new proposal results in a persistent flash notice. 

This uses the notice into a `flash.now` with our class.