### PR TITLE
Prevent the function for action bar from unnecesarrily running

### DIFF
--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -76,10 +76,14 @@ C2 = (function() {
   C2.prototype._setupEditMode = function(){
     var self = this;
     this.formState.el.on('form:dirty', function(){
-      self.actionBar.barState('.save-button', false);
+      if(self.actionBar.el.find('.save-button button').attr('disabled') === "disabled" ){
+        self.actionBar.barState('.save-button', false);
+      }
     });
     this.formState.el.on('form:clean', function(){
-      self.actionBar.barState('.save-button', "disabled");
+      if(self.actionBar.el.find('.save-button button').attr('disabled') === undefined ){
+        self.actionBar.barState('.save-button', "disabled");
+      }
     });
   }
 


### PR DESCRIPTION
# What

When a form is changed, the action bar save/cancel buttons are spammed with updates. This creates a condition check to see whether or not the buttons need to be updated. By preventing the DOM from being touched, the application performs much better.