### PR TITLE
Create validation flow and action bar

### DIFF
--- a/app/assets/javascripts/details/data/details_save.js
+++ b/app/assets/javascripts/details/data/details_save.js
@@ -3,7 +3,7 @@ DetailsSave = (function() {
 
   function DetailsSave(el, dataEl) {
     this.el = $(el);
-    this.dataEl = this.el.find('form.request-details-form');
+    this.dataEl = $(dataEl);
     this._blastOff();
   }
 
@@ -19,11 +19,21 @@ DetailsSave = (function() {
     this.el.on( "details-form:respond", function( event, data ) {
       self.receiveResponse(data);
     });
+    this.el.on( "details-form:validate", function( event, data ) {
+      switch (data['status']){
+        case "success":
+          self.el.find('form').submit();
+          break;
+        case "error":
+          self.el.trigger( "details-form:error", data );
+          break;
+        default:
+          break;
+      }
+    });
     this.el.on( "details-form:success", function( event, data ) {
-
     });
     this.el.on( "details-form:error", function( event, data ) {
-
     });
   }
 
@@ -41,9 +51,30 @@ DetailsSave = (function() {
     }
   }
 
+  DetailsSave.prototype._prepareFormData = function(){
+    var formData = this.el.find('form').serialize();
+    var dataEl = this.dataEl;
+    formData = formData + '&' + dataEl.find('form [data-is-dirrty]').serialize();
+    return formData;
+  }
+
+  DetailsSave.prototype.validateFields = function(url, formData){
+    $.ajax({
+      url: url + "?validate=true",
+      headers: {
+        Accept : "text/javascript; charset=utf-8",
+        "Content-Type": 'application/x-www-form-urlencoded; charset=UTF-8'
+      },
+      type: 'POST',
+      data: formData
+    });
+  }
+
   DetailsSave.prototype.saveDetailsForm = function(data){
     var self = this;
-    this.dataEl.submit();
+    var formData = this._prepareFormData();
+    var url = self.el.find('form').attr("action");
+    self.validateFields(url, formData);
   }
 
   return DetailsSave;

--- a/app/assets/javascripts/details/data/details_save.js
+++ b/app/assets/javascripts/details/data/details_save.js
@@ -22,7 +22,7 @@ DetailsSave = (function() {
     this.el.on( "details-form:validate", function( event, data ) {
       switch (data['status']){
         case "success":
-          self.el.find('form').submit();
+          self.el.find('form.request-details-form').submit();
           break;
         case "error":
           self.el.trigger( "details-form:error", data );
@@ -52,9 +52,8 @@ DetailsSave = (function() {
   }
 
   DetailsSave.prototype._prepareFormData = function(){
-    var formData = this.el.find('form').serialize();
+    var formData = this.el.find('form.request-details-form').serialize();
     var dataEl = this.dataEl;
-    formData = formData + '&' + dataEl.find('form [data-is-dirrty]').serialize();
     return formData;
   }
 
@@ -73,7 +72,7 @@ DetailsSave = (function() {
   DetailsSave.prototype.saveDetailsForm = function(data){
     var self = this;
     var formData = this._prepareFormData();
-    var url = self.el.find('form').attr("action");
+    var url = self.el.find('form.request-details-form').attr("action");
     self.validateFields(url, formData);
   }
 

--- a/app/assets/javascripts/details/shell/action_bar_bridge.js
+++ b/app/assets/javascripts/details/shell/action_bar_bridge.js
@@ -1,4 +1,5 @@
 var ActionBarBridge;
+
 ActionBarBridge = (function() {
 
   function ActionBarBridge(c2, config){

--- a/app/assets/javascripts/details/shell/action_bar_bridge.js
+++ b/app/assets/javascripts/details/shell/action_bar_bridge.js
@@ -1,0 +1,116 @@
+var ActionBarBridge;
+ActionBarBridge = (function() {
+
+  function ActionBarBridge(c2, config){
+    this.c2 = c2;
+    config = config || {};
+    this.config = {
+      actionBar:      '#action-bar-wrapper',
+      detailsSave:    '#request-details-card',
+      notifications:  '#action-bar-status',
+      editMode:       '#mode-parent',
+      modalCard:      '#modal-wrapper',
+      updateView:     '#mode-parent'
+    }
+    this._overrideTestConfig(config);
+    this._blastOff();
+  }
+
+  ActionBarBridge.prototype._blastOff = function(){
+    var config = this.config;
+
+
+    // Data
+    this.detailsSave = this.c2.detailsSave;
+    this.updateView = this.c2.updateView;
+
+    // State
+    this.editMode = this.c2.editMode;
+
+    // Views
+    this.modals = this.c2.modals;
+    this.actionBar = this.c2.actionBar;
+    this.notification = this.c2.notification;
+    this._setupEvents();
+  }
+
+  ActionBarBridge.prototype._overrideTestConfig = function(config){
+    this.config = config;
+  }
+
+  ActionBarBridge.prototype._setupEvents = function(){
+    this._setupActionBar();
+    this._setupSaveModal();
+    this._setupFormSubmitModal();
+  }
+
+  /* Action Bar */
+
+  ActionBarBridge.prototype._setupActionBar = function(){
+    var self = this;
+    this.actionBar.el.on("action-bar-clicked:cancel", function(){
+      self.editMode.el.trigger('details:cancelled');
+    });
+    this.actionBar.el.on("action-bar-clicked:save", function(){
+      self.notification.clearAll();
+    });
+    this.actionBar.el.on("action-bar-clicked:edit", function(){
+      self.setEditMode();
+    });
+  }
+
+  ActionBarBridge.prototype.setEditMode = function(){
+    this.editMode.el.trigger('details:edit-mode');  
+  }
+
+  ActionBarBridge.prototype.enableModalButtons = function(){
+    this.modals.el.find('button').attr('disabled', false).css('opacity', 1);
+  }
+
+  ActionBarBridge.prototype.disableModalButtons = function(){
+    this.modals.el.find('button').attr('disabled', 'disabled').css('opacity', 0.5);
+  }
+
+  ActionBarBridge.prototype._setupSaveModal = function(){
+    var self = this;
+    this.modals.el.on("save_confirm-modal:confirm", function(event, item){
+      var l = $(item).ladda();
+      l.ladda( 'start' );
+      self.disableModalButtons();
+      self.actionBar.el.trigger("action-bar-clicked:saving");
+      self.detailsSave.el.trigger("details-form:save");
+    });
+    this.modals.el.on("save_confirm-modal:cancel", function(event, item){
+      self._closeModal();
+    });
+    this.modals.el.on("modal:cancel", function(){
+      self.actionBar.stopLadda();
+    });
+  }
+
+  ActionBarBridge.prototype._setupFormSubmitModal = function(){
+    var self = this,
+      events = "attachment_confirm-modal:confirm observer_confirm-modal:confirm";
+    this.modals.el.on(events, function(event, item, sourceEl){
+      self._submitAndClose(sourceEl);
+    });
+  }
+
+  ActionBarBridge.prototype._submitAndClose = function(sourceEl){
+    var self = this;
+    $(sourceEl).parent().submit();
+    self._closeModal();
+  }
+
+  ActionBarBridge.prototype._closeModal = function(){
+    this.modals.el.trigger("modal:close");
+    this.actionBar.stopLadda();
+  }
+  /* End Action Bar */
+
+
+  return ActionBarBridge;
+
+}());
+
+window.ActionBarBridge = ActionBarBridge;

--- a/app/assets/javascripts/details/shell/c2.js
+++ b/app/assets/javascripts/details/shell/c2.js
@@ -20,6 +20,7 @@ C2 = (function() {
 
   C2.prototype._blastOff = function(){
     var config = this.config;
+    var self = this;
     // Data
     this.detailsSave = new DetailsSave(config.formContainer);
     this.updateView = new UpdateView(config.formContainer);
@@ -37,6 +38,7 @@ C2 = (function() {
     this.modals = new ModalController(config.modalCard);
     this.actionBar = new ActionBar(config.actionBar);
     this.notification = new Notifications(config.notifications);
+    this.actionBridge = new ActionBarBridge(self);
     this._setupEvents();
   }
 
@@ -51,7 +53,6 @@ C2 = (function() {
   }
 
   C2.prototype._setupEvents = function(){
-    this._setupActionBar();
     this._setupEditToggle();
     this._setupDetailsData();
     this._setupDetailsForm();
@@ -59,8 +60,6 @@ C2 = (function() {
     this._setupNotifications();
     this._setupAttachmentEvent();
     this._setupObserverEvent();
-    this._setupSaveModal();
-    this._setupFormSubmitModal();
   }
 
   /* Form */
@@ -76,6 +75,12 @@ C2 = (function() {
       if(self.actionBar.el.find('.save-button button').attr('disabled') === undefined ){
         self.actionBar.barState('.save-button', "disabled");
       }
+    });
+    this.editMode.el.on('details:edit-mode', function(){
+      self.detailsMode('edit');
+    });
+    this.editMode.el.on('details:cancelled', function(){
+      self.detailsCancelled();
     });
   }
 
@@ -242,61 +247,6 @@ C2 = (function() {
   }
 
   /* End Activity */
-
-   /* Action Bar */
-
-  C2.prototype._setupActionBar = function(){
-    var self = this;
-    this.actionBar.el.on("action-bar-clicked:cancel", function(){
-      self.detailsCancelled();
-    });
-    this.actionBar.el.on("action-bar-clicked:save", function(){
-      self.notification.clearAll();
-      // triggers save_confirm-modal
-    });
-    this.actionBar.el.on("action-bar-clicked:edit", function(){
-      self.detailsMode('edit');
-    });
-  }
-
-  C2.prototype._setupSaveModal = function(){
-    var self = this,
-        confirm = "save_confirm-modal:confirm reapproval_confirm-modal:confirm",
-        cancel = "save_confirm-modal:cancel reapproval_confirm-modal:cancel";
-    this.modals.el.on(confirm, function(event, item){
-      var l = $(item).ladda();
-      l.ladda( 'start' );
-      self.modals.el.find('button').attr('disabled', 'disabled').css('opacity', 0.5);
-      self.actionBar.el.trigger("action-bar-clicked:saving");
-      self.detailsSave.el.trigger("details-form:save");
-    });
-    this.modals.el.on(cancel, function(event, item){
-      self._closeModal();
-    });
-    this.modals.el.on("modal:cancel", function(){
-      self.actionBar.stopLadda();
-    });
-  }
-
-  C2.prototype._setupFormSubmitModal = function(){
-    var self = this,
-      events = "attachment_confirm-modal:confirm observer_confirm-modal:confirm";
-    this.modals.el.on(events, function(event, item, sourceEl){
-      self._submitAndClose(sourceEl);
-    });
-  }
-
-  C2.prototype._submitAndClose = function(sourceEl){
-    var self = this;
-    $(sourceEl).parent().submit();
-    self._closeModal();
-  }
-
-  C2.prototype._closeModal = function(){
-    this.modals.el.trigger("modal:close");
-    this.actionBar.stopLadda();
-  }
-  /* End Action Bar */
 
   return C2;
 

--- a/app/assets/javascripts/details/views/attachment_card.js
+++ b/app/assets/javascripts/details/views/attachment_card.js
@@ -26,7 +26,7 @@ AttachmentCardController = (function(){
       form_id: "#new_attachment",
       gif_src: "/assets/spin.gif",
       attachmentUrl: "/proposals/" + proposalId + "/attachments",
-      buttonSelector: "[for=attachment_file']",
+      buttonSelector: "label.attachment-label",
       contentSelector: "input[type='file']"
     }, this._getDefaultClasses());
   }

--- a/app/views/layouts/_new_javascript.html.haml
+++ b/app/views/layouts/_new_javascript.html.haml
@@ -7,7 +7,6 @@
 = javascript_include_tag "details/views/activity_card"
 = javascript_include_tag "details/views/modal_card"
 = javascript_include_tag "details/views/approvals_card"
-
 = javascript_include_tag "details/state/form_change_state"
 = javascript_include_tag "details/state/edit_mode"
 
@@ -15,6 +14,7 @@
 = javascript_include_tag "details/data/update_view"
 
 = javascript_include_tag "details/shell/c2"
+= javascript_include_tag "details/shell/action_bar_bridge"
 
 = javascript_include_tag "details/app"
 

--- a/spec/javascripts/details/shell/c2_spec.js.coffee
+++ b/spec/javascripts/details/shell/c2_spec.js.coffee
@@ -19,6 +19,7 @@
 #= require details/data/update_view
 #= require details/data/details_save
 #= require details/shell/c2
+#= require details/shell/action_bar_bridge
 #= require details/details_helper
 #= require spec_helper
 


### PR DESCRIPTION
# What

The front-end now sends the form params to the backend for validation. After the validation check, the front-end does a form `submit`. This allows any errors from validation to be properly handled on the front-end, without accidentally updating the `dirrty` fields or getting inconsistent notifications

![screen shot 2016-07-15 at 8 31 08 pm](https://cloud.githubusercontent.com/assets/1332366/16924663/6b6746c8-4cee-11e6-80ca-76d90276567c.png)
