### PR TITLE
Show current expense type when editing

### DIFF
--- a/app/views/ncr/fields/_expense_type.html.haml
+++ b/app/views/ncr/fields/_expense_type.html.haml
@@ -9,7 +9,4 @@
       %label.detail-element
         = t(t_slug + key) 
       %span.detail-value
-        = field_set_tag do
-          = expense_type_radio_button(f, "BA60", true)
-          = expense_type_radio_button(f, "BA61", true)
-          = expense_type_radio_button(f, "BA80", true)
+        = client_data[:expense_type]


### PR DESCRIPTION
When modifying a current proposal, instead of showing disabled radio buttons
just show the current expense type.
Card: https://trello.com/c/JXHxpEpD/610-only-display-expense-type-of-request-remove-radio-button-and-other-expense-types