### PR TITLE
show description field label

### DIFF
--- a/app/assets/stylesheets/ncr/_fields.scss
+++ b/app/assets/stylesheets/ncr/_fields.scss
@@ -4,8 +4,6 @@
     .detail-value {
       font-size: 17px;
     }
-    .detail-element {
-      display: none;
-    }
+    
   }
 }


### PR DESCRIPTION
https://trello.com/c/w2PoepWN/608-move-text-below-description-to-be-under-description-or-in-the-form-field