### PR TITLE
Fix regression around comment box

### DIFF
--- a/app/assets/javascripts/details/views/activity_card.js
+++ b/app/assets/javascripts/details/views/activity_card.js
@@ -26,6 +26,17 @@ ActivityCardController = (function(){
     this.initButton();
     this._setupUpdateEvent();
     this._setupCommentListToggle();
+    this.el.on('focus input propertychange', '[name="comment[comment_text]"]', function(){
+      if ($('[name="comment[comment_text]"]').val() === ""){
+        $(self.buttonSelector).attr('disabled', true);
+      } else {
+        $(self.buttonSelector).attr('disabled', false);
+      }
+    });
+  }
+
+  ActivityCardController.prototype.onButtonPress = function(){
+    $('[name="comment[comment_text]"]').attr('disabled', true);
   }
 
   ActivityCardController.prototype._setupCommentListToggle = function(){
@@ -44,13 +55,18 @@ ActivityCardController = (function(){
     if (opts.focus){
       this.el.find(self.contentselector).focus();
     }
-    this.el.find(self.buttonSelector).attr('disabled', true);
-    this.el.find(self.contentselector).on('input',function(){
-      this.el.find(self.buttonSelector).attr('disabled', false);
-    });
-    self.laddaButton.ladda( 'stop' );
+
+    $('[name="comment[comment_text]"]').attr('disabled', false);
+    this.setupReloadButtonState();
   }
 
+  ActivityCardController.prototype.setupReloadButtonState = function(){
+    var self = this;
+    self.laddaButton.ladda( 'stop' );
+    self.laddaButton = self.laddaButton.ladda();
+    self.laddaButton.attr('disabled', true);
+    $(self.contentselector).focus();
+  }
 
   return ActivityCardController;
 

--- a/app/assets/javascripts/details/views/view_helper.js
+++ b/app/assets/javascripts/details/views/view_helper.js
@@ -8,11 +8,11 @@ ViewHelper = (function(){
   ViewHelper.prototype._setupUpdateEvent = function(){
     var self = this;
     this.el.on(self.updateEvent, function(){
-      $.ajax({ url: self.updateUrl, 
+      $.ajax({ url: self.updateUrl,
         retryLimit: 5,
         success: function(html){
           self.update(html);
-        }, 
+        },
          error : function(xhr, textStatus, errorThrown ) {
           if (textStatus === "timeout") {
             this.tryCount++;
@@ -20,10 +20,10 @@ ViewHelper = (function(){
               //try again
               $.ajax(this);
               return;
-            }            
+            }
             return;
           }
-        } 
+        }
       });
     });
   }
@@ -49,6 +49,9 @@ ViewHelper = (function(){
       if( self.el.find(self.buttonSelector).attr('disabled') !== "disabled" ){
         self.laddaButton.ladda( 'start' );
         self.submitForm();
+        if(self.onButtonPress){
+          self.onButtonPress();
+        }
       } else {
         self.laddaButton.ladda( 'start' );
         window.setTimeout(function(){}, 300);
@@ -69,7 +72,7 @@ ViewHelper = (function(){
       type: "post"
     }
     $.ajax(params);
-  } 
+  }
 
   return ViewHelper;
 }());

--- a/app/assets/stylesheets/redesign/_basic.scss
+++ b/app/assets/stylesheets/redesign/_basic.scss
@@ -69,7 +69,7 @@ label.button.secondary
   &:hover{
     color: white;
     background: $primary-color;
-  } 
+  }
 }
 
 a.status-toggle-all{
@@ -84,8 +84,8 @@ button[type="submit"].button
   line-height: 1;
   cursor: pointer;
   -webkit-appearance: none;
-  -webkit-transition: background-color 0.25s ease-out, color 0.25s ease-out;
-  transition: background-color 0.25s ease-out, color 0.25s ease-out;
+  -webkit-transition: background-color 0.25s ease-out, color 0.25s ease-out, opacity .3s ease-in;;
+  transition: background-color 0.25s ease-out, color 0.25s ease-out, opacity .3s ease-in;;
   vertical-align: middle;
   border: 1px solid transparent;
   border-radius: 4px;

--- a/app/assets/stylesheets/redesign/_card-activity.scss
+++ b/app/assets/stylesheets/redesign/_card-activity.scss
@@ -74,7 +74,10 @@
     height: 80px;
   }
   #add_a_comment:disabled {
-    // visibility: hidden;
+    opacity: 0;
+    &[data-loading]{
+      opacity: 1;
+    }
   }
   .item-block {
     color: map-get($c2black-swatch, secondary);


### PR DESCRIPTION
# What

The comment box send button can now reinitialize after sending. The button design is also updated to transition between visible/hidden state with a change in opacity. A callback option is now available for button submissions too.

![comment](https://cloud.githubusercontent.com/assets/1332366/17229212/a769e614-54e4-11e6-926c-93911a24b8e2.gif)


# Why

https://docs.google.com/spreadsheets/d/1ZpzCwhExizevhZhS-g3rZQmE9ihXyRv-uGGbjUVCweo/edit#gid=0

# Card

https://trello.com/c/Kl6vCjBv/643-fix-regressions-on-comment-box