### PR TITLE
Replace the form tag in the remove attachment/observer

### DIFF
--- a/app/assets/javascripts/details/shell/action_bar_bridge.js
+++ b/app/assets/javascripts/details/shell/action_bar_bridge.js
@@ -61,7 +61,7 @@ ActionBarBridge = (function() {
   }
 
   ActionBarBridge.prototype.setEditMode = function(){
-    this.editMode.el.trigger('details:edit-mode');  
+    this.editMode.el.trigger('details:edit-mode');
   }
 
   ActionBarBridge.prototype.enableModalButtons = function(){
@@ -93,13 +93,25 @@ ActionBarBridge = (function() {
     var self = this,
       events = "attachment_confirm-modal:confirm observer_confirm-modal:confirm";
     this.modals.el.on(events, function(event, item, sourceEl){
+      console.log("sourceEl: ", sourceEl);
       self._submitAndClose(sourceEl);
     });
   }
 
   ActionBarBridge.prototype._submitAndClose = function(sourceEl){
     var self = this;
-    $(sourceEl).parent().submit();
+    var url = $(sourceEl).data('delete-url');
+    $.ajax({
+      url: url,
+      headers: {
+        Accept : "text/javascript; charset=utf-8",
+        "Content-Type": 'application/x-www-form-urlencoded; charset=UTF-8'
+      },
+      type: 'POST',
+      data: {
+        _method: "delete"
+      }
+    });
     self._closeModal();
   }
 

--- a/app/assets/javascripts/details/shell/action_bar_bridge.js
+++ b/app/assets/javascripts/details/shell/action_bar_bridge.js
@@ -93,7 +93,6 @@ ActionBarBridge = (function() {
     var self = this,
       events = "attachment_confirm-modal:confirm observer_confirm-modal:confirm";
     this.modals.el.on(events, function(event, item, sourceEl){
-      console.log("sourceEl: ", sourceEl);
       self._submitAndClose(sourceEl);
     });
   }

--- a/app/assets/javascripts/details/views/attachment_card.js
+++ b/app/assets/javascripts/details/views/attachment_card.js
@@ -42,7 +42,6 @@ AttachmentCardController = (function(){
     }
   }
 
-
   AttachmentCardController.prototype._setDefaults = function(opts){
     opts = opts || {};
     var self = this;
@@ -65,6 +64,7 @@ AttachmentCardController = (function(){
       }
     })
   }
+
 
   AttachmentCardController.prototype.getFileName = function(){
     var self = this;

--- a/app/views/gsa18f/fields/_title.html.haml
+++ b/app/views/gsa18f/fields/_title.html.haml
@@ -4,5 +4,4 @@
     %span.detail-value
       = @client_data_instance.product_name_and_description
     %span.detail-edit
-      %form
-        = f.input :product_name_and_description, label: false
+      = f.input :product_name_and_description, label: false

--- a/app/views/ncr/fields/_title.html.haml
+++ b/app/views/ncr/fields/_title.html.haml
@@ -5,5 +5,4 @@
       %span.detail-value
         = @client_data_instance.project_title
       %span.detail-edit
-        %form
-          = f.input :project_title, label: false
+        = f.input :project_title, label: false

--- a/app/views/proposals/details/_attachment_list.html.haml
+++ b/app/views/proposals/details/_attachment_list.html.haml
@@ -13,7 +13,7 @@
               #{attachment.file_file_name}
           %div.remove-attachment-btn.text-right.small-1.columns
           - if policy(attachment).can_destroy?
-            = button_to "", proposal_attachment_path(proposal, attachment), method: :delete, data: {"modal-type": "attachment_confirm"}, remote: true, class: "remove-button", "aria-label": "Remove #{ attachment.file_file_name } attachment"
+            %input{type: "button", class: "remove-button", "aria-label": "Remove #{attachment.file_file_name}", data: {"delete-url": "#{proposal_attachment_path(proposal, attachment)}", "modal-type": "attachment_confirm"}}
   - if proposal.attachments.empty?
     .content-content.no-attachments.column
       .row

--- a/app/views/proposals/details/_observer_row.html.haml
+++ b/app/views/proposals/details/_observer_row.html.haml
@@ -3,4 +3,4 @@
   - if role_str.present?
     = "(#{role_str})"
   - if observation && policy(observation).can_destroy?
-    = button_to "", proposal_observation_path(proposal, observation), method: :delete, data: {"modal-type": "observer_confirm"}, remote: true, class: "observer-remove-button remove-button"
+    %input{type: "button", class: "observer-remove-button remove-button", "aria-label": "Remove #{user.full_name}", data: {"delete-url": "#{proposal_observation_path(proposal, observation)}", "modal-type": "observer_confirm"}}


### PR DESCRIPTION
# What

Remove the `form` tag that was used in removing attachment/observers. Replace with JavaScript ajax call, using the `data-delete-url` attribute to target.

# Why

Following procedure to make "one form" to rule them all.