### PR TITLE
Sidebar on request details

### DIFF
--- a/app/assets/stylesheets/redesign/_card-action.scss
+++ b/app/assets/stylesheets/redesign/_card-action.scss
@@ -182,6 +182,7 @@ $action-bar-wrapper-height-small: 60px;
     min-height: 65px;
     justify-content: center;
     .row{
+      margin: 0 auto;
       width: 100%;
     }
     &.notice-type-notice{

--- a/app/assets/stylesheets/redesign/_card-action.scss
+++ b/app/assets/stylesheets/redesign/_card-action.scss
@@ -54,6 +54,13 @@ ul.request-actions{
   border-top: 0px;
 }
 
+.action-bar-wrapper.action-bar-template{
+  .row.row {
+    margin: 0 auto;
+    float: none;
+  }
+}
+
 .action-bar-wrapper.user-can-complete .cancel-button,
 .action-bar-wrapper.user-can-complete .save-button,
 .action-bar-wrapper.user-can-complete.edit-actions .action-approve{

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,6 +32,9 @@ module ApplicationHelper
   end
 
   def list_view_conditions
-    (controller_name == "proposals" && params[:action] == "index" && !@current_user.nil? && @current_user.should_see_beta?("BETA_FEATURE_LIST_VIEW"))
+    user_condition = (!@current_user.nil? && @current_user.should_see_beta?("BETA_FEATURE_LIST_VIEW"))
+    action_condition = (params[:action] == "index" || params[:action] == "show")
+    controller_condition = (controller_name == "proposals")
+    (controller_condition && action_condition && user_condition)
   end
 end


### PR DESCRIPTION
# What

Move the logic for sidebar. Change the sidebar view condition to include request details.

<img width="1277" alt="screen shot 2016-08-09 at 11 07 21 am" src="https://cloud.githubusercontent.com/assets/1332366/17521494/95883234-5e21-11e6-9368-2ef1a36299e8.png">
