### PR TITLE
Remove `user_is_not_requester` validation from Purchase steps

### DIFF
--- a/app/models/steps/approval.rb
+++ b/app/models/steps/approval.rb
@@ -1,4 +1,13 @@
 module Steps
   class Approval < Steps::Individual
+    validate :user_is_not_requester
+
+    private
+
+    def user_is_not_requester
+      if user && user == proposal.requester
+        errors.add(:user, "Cannot be Requester")
+      end
+    end
   end
 end

--- a/app/models/steps/individual.rb
+++ b/app/models/steps/individual.rb
@@ -3,7 +3,6 @@ module Steps
     has_many :delegations, through: :user, source: :outgoing_delegations
     has_many :delegates, through: :delegations, source: :assignee
 
-    validate :user_is_not_requester
     validates :user, presence: true
     delegate :full_name, :email_address, to: :user, prefix: true
 
@@ -52,12 +51,6 @@ module Steps
         api_token.try(:expire!)
         update_attributes!(completer_id: nil, completed_at: nil)
         super
-      end
-    end
-
-    def user_is_not_requester
-      if user && user == proposal.requester
-        errors.add(:user, "Cannot be Requester")
       end
     end
   end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -10,27 +10,6 @@ describe Proposal do
 
   describe "Validations" do
     it { should validate_uniqueness_of(:public_id).allow_nil }
-
-    it "disallows requester from also being approver" do
-      user = create(:user)
-      expect {
-        create(:proposal, :with_approver, requester: user, approver_user: user)
-      }.to raise_error(ActiveRecord::RecordNotSaved)
-    end
-
-    it "disallows assigning requester as approver" do
-      proposal = create(:proposal)
-      expect {
-        proposal.add_initial_steps([Steps::Approval.new(user: proposal.requester)])
-      }.to raise_error(ActiveRecord::RecordNotSaved)
-    end
-
-    it "disallows assigning approver as requester" do
-      proposal = create(:proposal, :with_approver)
-      expect {
-        proposal.add_requester(proposal.individual_steps.first.user.email_address)
-      }.to raise_error(/cannot also be Requester/)
-    end
   end
 
   describe "CLIENT_MODELS" do

--- a/spec/models/steps/approval_spec.rb
+++ b/spec/models/steps/approval_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe Steps::Approval do
+  describe "Validations" do
+    it "disallows assigning approver as requester" do
+      proposal = create(:proposal, :with_approver)
+      expect {
+        create(:approval_step, user: proposal.requester, proposal: proposal)
+      }.to raise_error(/User Cannot be Requester/)
+    end
+  end
+end


### PR DESCRIPTION
* Was causing Micro-purchase requests to not have steps because Alan D
  is both the MP requester and Purchaser
* Closes https://rpm.newrelic.com/accounts/921394/applications/5480870/traced_errors/2713dca3-5e58-11e6-9456-f8bc12425498_0_18136?original_error_id=2713dca3-5e58-11e6-9456-f8bc12425498_0_18136