### PR TITLE
Hide new features help

### DIFF
--- a/app/helpers/help_helper.rb
+++ b/app/helpers/help_helper.rb
@@ -4,7 +4,7 @@ module HelpHelper
   end
 
   def set_new_feature_date(set_it, feature_date)
-    if set_it
+    if set_it && current_user
       current_user.new_features_date = feature_date
       current_user.save
     end

--- a/app/views/help/index.html.haml
+++ b/app/views/help/index.html.haml
@@ -1,6 +1,11 @@
 %ul
   - @pages.each do |page|
     - # this is a hack to capture the :title from each page: render the template, without actually outputting it
+
+    - #Skip New Features article for now
+    - if page == "new_features"
+      - next
+
     - render template: "help/#{page}"
     %li
       - # @todo: approvers: As an approver, how do I manage requests?


### PR DESCRIPTION
This does two things

- Hide the new features article from the list of help articles because there isn't content for it yet
- The help articles can be viewed without signing in, so the tracking now checks for a logged in user before attempting to set that variable. 