### PR TITLE
Update the table layout on mobile viewport

### DIFF
--- a/app/assets/stylesheets/redesign/_list.scss.erb
+++ b/app/assets/stylesheets/redesign/_list.scss.erb
@@ -206,12 +206,36 @@ table#tabular-data {
   .m-search-ui.expanded .adv-controls{
     padding-left: 0px;
   }
+  @media screen and (max-width: 40em){
+    .dt-buttons.button-group{
+      text-align: left;
+    }
+    th:first-child{
+      width: auto !important;
+    }
+    th{
+      width: 100%;
+    }
+  }
   div.search{
     position: relative;
     height: 4em;
     margin-bottom: 1em;
+    @media screen and (max-width: 40em){
+      height: auto;
+    }
     .m-search-ui.row{
       margin-right: 0px;
+
+      @media screen and (max-width: 40em){
+        margin: 0px;
+        width: 100%;
+        padding: 0px;
+        fieldset.basic{
+          padding: 0px;
+          margin: 0px;
+        }
+      }
       fieldset.basic{
         padding-right: 0em;
       }


### PR DESCRIPTION
<img width="400" alt="screen shot 2016-08-26 at 10 05 14 am" src="https://cloud.githubusercontent.com/assets/1332366/18008087/c2f79894-6b74-11e6-805a-ad6b1310bfe3.png">

# What

Change the arrangement of elements using the mobile viewport, based on trello ticket.

# Reference

https://trello.com/c/gE4RPCVf/714-mobile-design-of-table-should-match-sketch-file-for-order-of-search-title-and-column-visibility