### PR TITLE
Fixes an ungraceful error that occurs when the user

### DIFF
--- a/app/controllers/client_data_controller.rb
+++ b/app/controllers/client_data_controller.rb
@@ -2,6 +2,7 @@
 # * model_class
 # * permitted_params
 class ClientDataController < ApplicationController
+  include TokenAuth
   before_action -> { authorize model_class }, only: [:new, :create]
   before_action -> { authorize proposal }, only: [:edit, :update]
   before_action :build_client_data_instance, only: [:new, :create]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  include TokenAuth
   def update
     if params[:user] && params[:user][:update_beta_active] && current_user
       current_user.toggle_active_beta


### PR DESCRIPTION
  dosen't reload the page after being away for awhile

To recreate, login to a page that triggers an update
  new proposal for example,
  go to chrome settings, and clear recent history including
  cache and cookies.
  Return to the page and attempt a patch action,

  You will now be returned to the home page of the app instead
  of crashing to an error message.