### PR TITLE
Give legacy reports page the new table design

### DIFF
--- a/app/assets/stylesheets/redesign/_list.scss.erb
+++ b/app/assets/stylesheets/redesign/_list.scss.erb
@@ -24,7 +24,7 @@ div.dt-button-background.dt-button-background{
 
 .dataTables_wrapper{
   table.dataTable thead .sorting, table.dataTable thead .sorting_asc, table.dataTable thead .sorting_desc, table.dataTable thead .sorting_asc_disabled, table.dataTable thead .sorting_desc_disabled {
-    background-position: 100% center;
+    background-position: 95% center;
   }
 }
 

--- a/app/views/proposals/show.html.haml
+++ b/app/views/proposals/show.html.haml
@@ -29,7 +29,7 @@
   .row
     = render partial: "shared/proposal_properties", locals: { proposal: @proposal }
   .row
-    %table.tabular-data.observers
+    %table.tabular-data.observers#tabular-data
       %thead
         %tr.header
           %th{colspan: "2"}

--- a/app/views/shared/_table.html.haml
+++ b/app/views/shared/_table.html.haml
@@ -1,5 +1,5 @@
 - # Requires the "container" variable
-%table.tabular-data
+%table.tabular-data#tabular-data
   %thead
     %tr
       - container.columns.each do |column|


### PR DESCRIPTION
<img width="1277" alt="screen shot 2016-08-26 at 4 42 22 pm" src="https://cloud.githubusercontent.com/assets/1332366/18019851/1a0dbe2e-6bac-11e6-981d-cea66c8e7b11.png">

# What

Add the new table layout from proposals#index to the search result page

# Reference

https://trello.com/c/HCVdy5pl/738-reports-table-legacy-apperance
