### PR TITLE
Setup sidebar active states for new request/reports

### DIFF
--- a/app/assets/stylesheets/redesign/_sidebar-nav.scss.erb
+++ b/app/assets/stylesheets/redesign/_sidebar-nav.scss.erb
@@ -55,6 +55,7 @@ span.request-count {
   @media screen and (max-width: 60em){
     padding: 0px;
     width: 100%;
+    li:not(.request-related-button),
     .request-related-button.active{
       a{
         margin-left: 0px !important;
@@ -277,5 +278,17 @@ span.request-count {
         text-decoration: none;
       }
     }
+  }
+}
+li.requests-button:hover {
+  margin-bottom: -1px;
+  border-bottom: 1px solid #71737a;
+}
+
+a.new-request-button.active {
+  background: #C5DCED;
+  color: #333541!important;
+  &:hover{
+    background: #DBEAF5;
   }
 }

--- a/app/assets/stylesheets/redesign/_sidebar-nav.scss.erb
+++ b/app/assets/stylesheets/redesign/_sidebar-nav.scss.erb
@@ -285,10 +285,13 @@ li.requests-button:hover {
   border-bottom: 1px solid #71737a;
 }
 
-a.new-request-button.active {
-  background: #C5DCED;
-  color: #333541!important;
-  &:hover{
-    background: #DBEAF5;
+a.new-request-button,
+a.reports-button{
+  &.active{
+    background: #C5DCED;
+    color: #333541!important;
+    &:hover{
+      background: #DBEAF5;
+    }
   }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,7 +45,7 @@ module ApplicationHelper
   end
 
   def is_new_report_page
-    if (controller.is_a?(ReportsController) || controller.is_a?(DashboardController))
+    if controller.is_a?(ReportsController) || controller.is_a?(Ncr::DashboardController)  || controller.is_a?(Gsa18f::DashboardController)
       "active"
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,7 +38,7 @@ module ApplicationHelper
   end
 
   def is_new_request_page
-    if (controller.is_a?(Ncr::WorkOrdersController)  || controller.is_a?(Gsa18f::ProcurementsController)) && params[:action] != "new"
+    if (controller.is_a?(Ncr::WorkOrdersController) || controller.is_a?(Gsa18f::ProcurementsController)) && params[:action] == "new"
       "active"
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,8 +38,7 @@ module ApplicationHelper
   end
 
   def is_new_request_page
-    if controller.is_a?(ClientDataController) ||
-      (controller.is_a?(ProposalsController) && params[:action] != "new")
+    if (controller.is_a?(ClientDataController) && params[:action] != "new")
       "active"
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,6 +37,13 @@ module ApplicationHelper
     end
   end
 
+  def is_new_request_page
+    if controller.is_a?(ClientDataController) ||
+      (controller.is_a?(ProposalsController) && params[:action] != "new")
+      "active"
+    end
+  end
+
   def proposal_count(type)
     if @current_user.nil?
       return 0

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,7 +45,7 @@ module ApplicationHelper
   end
 
   def is_new_report_page
-    if (controller.is_a?(ReportsController))
+    if (controller.is_a?(ReportsController) || controller.is_a?(DashboardController))
       "active"
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,7 +38,7 @@ module ApplicationHelper
   end
 
   def is_new_request_page
-    if (controller.is_a?(ClientDataController) && params[:action] != "new")
+    if (controller.is_a?(Ncr::WorkOrdersController)  || controller.is_a?(Gsa18f::ProcurementsController)) && params[:action] != "new"
       "active"
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,6 +44,12 @@ module ApplicationHelper
     end
   end
 
+  def is_new_report_page
+    if (controller.is_a?(ReportsController))
+      "active"
+    end
+  end
+
   def proposal_count(type)
     if @current_user.nil?
       return 0

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,7 +44,7 @@ module ApplicationHelper
   end
 
   def new_report_page?
-    if controller.is_a?(ReportsController) || controller.is_a?(Ncr::DashboardController)  || controller.is_a?(Gsa18f::DashboardController)
+    if controller.is_a?(ReportsController) || controller.is_a?(Ncr::DashboardController) || controller.is_a?(Gsa18f::DashboardController)
       "active"
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,13 +37,13 @@ module ApplicationHelper
     end
   end
 
-  def is_new_request_page
+  def new_request_page?
     if (controller.is_a?(Ncr::WorkOrdersController) || controller.is_a?(Gsa18f::ProcurementsController)) && params[:action] == "new"
       "active"
     end
   end
 
-  def is_new_report_page
+  def new_report_page?
     if controller.is_a?(ReportsController) || controller.is_a?(Ncr::DashboardController)  || controller.is_a?(Gsa18f::DashboardController)
       "active"
     end

--- a/app/views/ncr/_header_links_next.html.haml
+++ b/app/views/ncr/_header_links_next.html.haml
@@ -1,5 +1,5 @@
 %li
-  = link_to "New request", new_ncr_work_order_path, class: "new-request-button"
+  = link_to "New request", new_ncr_work_order_path, class: "new-request-button #{is_new_request_page}"
 
 = render 'layouts/sidebar_shared'
 

--- a/app/views/ncr/_header_links_next.html.haml
+++ b/app/views/ncr/_header_links_next.html.haml
@@ -1,7 +1,7 @@
 %li
-  = link_to "New request", new_ncr_work_order_path, class: "new-request-button #{is_new_request_page}"
+  = link_to "New request", new_ncr_work_order_path, class: "new-request-button #{new_request_page?}"
 
 = render 'layouts/sidebar_shared'
 
 %li
-  = link_to 'Reports', ncr_dashboard_path, class: "reports-button #{is_new_report_page}"
+  = link_to 'Reports', ncr_dashboard_path, class: "reports-button #{new_report_page?}"

--- a/app/views/ncr/_header_links_next.html.haml
+++ b/app/views/ncr/_header_links_next.html.haml
@@ -4,4 +4,4 @@
 = render 'layouts/sidebar_shared'
 
 %li
-  = link_to 'Reports', ncr_dashboard_path, class: "reports-button"
+  = link_to 'Reports', ncr_dashboard_path, class: "reports-button #{is_new_report_page}"


### PR DESCRIPTION
# What

When new request or reports is active, change the sidebar styling on the links

<img width="963" alt="screen shot 2016-08-30 at 2 03 33 pm" src="https://cloud.githubusercontent.com/assets/1332366/18100899/a7e8fd38-6eba-11e6-87e3-4caa7dbe011b.png">

<img width="672" alt="screen shot 2016-08-30 at 2 06 02 pm" src="https://cloud.githubusercontent.com/assets/1332366/18100960/e8650226-6eba-11e6-9d5b-d9399ee43977.png">

