### PR TITLE
Update flash message when adding a comment

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -7,7 +7,7 @@ class CommentsController < ApplicationController
       comment_params.merge(proposal: proposal, user: current_user)
     )
     if comment.save
-      flash[:success] = "Success! You've added an attachment."
+      flash[:success] = "Success! You've added a comment."
       DispatchFinder.run(comment.proposal).on_comment_created(comment)
     else
       flash[:error] = comment.errors.full_messages

--- a/spec/features/comment_spec.rb
+++ b/spec/features/comment_spec.rb
@@ -7,7 +7,7 @@ feature "commenting" do
 
     expect(current_path).to eq(proposal_path(proposal))
     expect(page).to have_content(comment_text)
-    expect(page).to have_content("Success! You've added an attachment.")
+    expect(page).to have_content("Success! You've added a comment.")
   end
 
   scenario "saves the comment with javascript", js: true do


### PR DESCRIPTION
On the old page adding a comment displayed a "you've added an attachment" message.

Updated message and test to "You've added a comment"

https://trello.com/c/4ljZWuNa/729-message-after-adding-a-comment-is-you-successfully-added-an-attachment