### PR TITLE
Fix the pending state on the list view

### DIFF
--- a/app/assets/javascripts/details/views/list/list_view.js
+++ b/app/assets/javascripts/details/views/list/list_view.js
@@ -163,7 +163,7 @@ ListViewDataTable = (function(){
   }
 
   ListViewDataTable.prototype.viewPending = function(){
-    this.statusColumn.search('Pending').draw();
+    this.statusColumn.search('Waiting for|Pending|review').draw();
   }
 
   ListViewDataTable.prototype.viewCanceled = function(){

--- a/app/assets/javascripts/details/views/list/list_view.js
+++ b/app/assets/javascripts/details/views/list/list_view.js
@@ -163,7 +163,7 @@ ListViewDataTable = (function(){
   }
 
   ListViewDataTable.prototype.viewPending = function(){
-    this.statusColumn.search('Waiting for|Pending|review').draw();
+    this.statusColumn.search('Waiting for|Pending|Please review|Please purchase').draw();
   }
 
   ListViewDataTable.prototype.viewCanceled = function(){

--- a/app/assets/javascripts/details/views/list/list_view.js
+++ b/app/assets/javascripts/details/views/list/list_view.js
@@ -57,7 +57,7 @@ ListViewDataTable = (function(){
           }
       };
       this.dataTable = this.el.DataTable(config);
-  
+
       this.statusColumn = this.dataTable.column(':contains(Status)');
       this._events();
       this.prepList();
@@ -85,7 +85,7 @@ ListViewDataTable = (function(){
 
   ListViewDataTable.prototype.renderConfig = function(){
     var config = [];
-    var count = this.el.find('thead th').length - 1;  
+    var count = this.el.find('thead th').length - 1;
     for (var i = count - 1; i >= 0; i--) {
       if (i === 0 || i === 1 || i === 5){ continue; }
       var el = {
@@ -121,7 +121,7 @@ ListViewDataTable = (function(){
       if(!$(el).parents('.public_id').length && !$(el).hasClass('public_id')){
         var link = $(this).closest('tr').find('a').first().attr('href');
         if(link){
-          window.location.href = link;  
+          window.location.href = link;
         }
       }
     });
@@ -163,7 +163,7 @@ ListViewDataTable = (function(){
   }
 
   ListViewDataTable.prototype.viewPending = function(){
-    this.statusColumn.search('Waiting for review from').draw();
+    this.statusColumn.search('Pending').draw();
   }
 
   ListViewDataTable.prototype.viewCanceled = function(){

--- a/app/assets/stylesheets/redesign/_list.scss.erb
+++ b/app/assets/stylesheets/redesign/_list.scss.erb
@@ -104,6 +104,7 @@ div.dt-button-collection.dt-button-collection{
 
 .tabular-data{
   display: block;
+  background: #f7f7f7;
   overflow: hidden;
   border-radius: 4px 4px 0px 0px;
 }

--- a/config/locales/decorators/en.yml
+++ b/config/locales/decorators/en.yml
@@ -28,7 +28,10 @@ en:
         completed: "Purchased"
         status:
           please_act: "Please purchase"
-          waiting: "Waiting for purchase from:"
+          waiting: |
+            Pending
+
+            Waiting for purchase from:
     gsa18f/procurement:
       amount: "Total"
       additional_info: "Additional Info"

--- a/spec/features/proposals/index_spec.rb
+++ b/spec/features/proposals/index_spec.rb
@@ -133,7 +133,7 @@ feature "Proposals index" do
         @page.load
 
         expect(@page.pending.requests[0].public_id_link.text).to eq purchase_proposal.public_id
-        expect(@page.pending.requests[0].status.text).to eq "Waiting for purchase from: #{purchaser.full_name}"
+        expect(@page.pending.requests[0].status.text).to eq "Pending Waiting for purchase from: #{purchaser.full_name}"
       end
     end
   end


### PR DESCRIPTION
# What

The filter for list view sidebar buttons uses the `status` column to display/hide. The conditions for hiding were cased on `ncr` status attributes. The conditions are now updated for the `gsa18f` status attributes for pending.

![screen shot 2016-09-13 at 12 30 30 am](https://cloud.githubusercontent.com/assets/1332366/18461632/8aa14296-7949-11e6-8162-cc4f7363b43e.png)

# What

The Pending option for one user was not displaying. This is because the text in the pending area was changed.


# Reference

https://trello.com/c/iJdSnPAP/786-redesign-pending-navigation-indicates-a-collection-of-requests-but-does-not-contain-any-in-the-body
