### PR TITLE
Add the specifier for search condition

### DIFF
--- a/app/assets/javascripts/details/views/list/list_view.js
+++ b/app/assets/javascripts/details/views/list/list_view.js
@@ -163,7 +163,7 @@ ListViewDataTable = (function(){
   }
 
   ListViewDataTable.prototype.viewPending = function(){
-    this.statusColumn.search('Waiting for|Pending|Please review|Please purchase').draw();
+    this.statusColumn.search('Waiting for|Pending|Please review|Please purchase', true, false, true).draw();
   }
 
   ListViewDataTable.prototype.viewCanceled = function(){


### PR DESCRIPTION
# What

Add the condition to treat search variable as a regex statement.

# Reference

https://trello.com/c/iJdSnPAP/786-redesign-pending-navigation-indicates-a-collection-of-requests-but-does-not-contain-any-in-the-body