### PR TITLE
Env sets users to default beta users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ DEFAULT_URL_HOST: "localhost:3000"
 #
 # BETA_FEATURE_DETAIL_VIEW: true
 # BETA_FEATURE_LIST_VIEW: true
+# REDESIGN_DEFAULT_VIEW: true
 
 # optional
 #

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -134,6 +134,7 @@ class ApplicationController < ActionController::Base
   def sign_in(user)
     session[:user] ||= {}
     session[:user]["email"] = user.email_address
+    user.check_beta_state
     @current_user = user
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -161,6 +161,13 @@ class User < ActiveRecord::Base
     end
   end
 
+  def check_beta_state
+    if ENV["REDESIGN_DEFAULT_VIEW"] == "true" && !in_beta_program?
+      add_role(ROLE_BETA_USER)
+      add_role(ROLE_BETA_ACTIVE)
+    end
+  end
+
   def not_admin?
     !admin?
   end

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -1,4 +1,5 @@
 feature "Login" do
+  include EnvVarSpecHelper
   scenario "inactive user" do
     inactive_user = create(:user, active: false)
 
@@ -21,4 +22,21 @@ feature "Login" do
 
     expect(page).to have_content("There was a problem signing you in")
   end
+
+  scenario "user logs in without env REDESIGN_DEFAULT_VIEW without being beta user" do
+    user = create(:user)
+    login_as(user)
+    expect(user.in_beta_program?).to eq(false)
+    expect(user.active_beta_user?).to eq(false)
+  end
+
+  scenario "user logs in with env REDESIGN_DEFAULT_VIEW becomes beta user" do
+    with_env_var('REDESIGN_DEFAULT_VIEW', 'true') do
+      user = create(:user)
+      login_as(user)
+      expect(user.in_beta_program?).to eq(true)
+      expect(user.active_beta_user?).to eq(true)
+    end
+  end
+
 end


### PR DESCRIPTION
https://trello.com/c/7qm3GpCQ/484-as-a-user-i-automatically-see-new-detail-page-designs-after-logging-in

After logging in, it checks for `ENV["REDESIGN_DEFAULT_VIEW"]` 

if thats true, and the user is not a beta user, its sets them to a beta user and active. 