### PR TITLE
Add tock project reference and billability

### DIFF
--- a/app/assets/javascripts/details/views/details_request_card.js
+++ b/app/assets/javascripts/details/views/details_request_card.js
@@ -76,19 +76,20 @@ DetailsRequestCard = (function(){
     this.el.trigger('update:' + type, { field: field, value: value });
   }
 
+  DetailsRequestCard.prototype.updateBoolean = function(value, yesCondition, noCondition){
+    if(value){
+      return yesCondition;
+    } else {
+      return noCondition;
+    }
+  }
+
   DetailsRequestCard.prototype.defineValue = function(key, value){
+    var self = this;
     if(key === "not_to_exceed") {
-      if (value === true){
-        value = "Not to exceed";
-      } else {
-        value = "Exact";
-      }
+      value = self.updateBoolean(value, 'Not to exceed', 'Exact');
     } else if(key === "is_tock_billable") {
-      if (value === true){
-        value = "Yes";
-      } else {
-        value = "No";
-      }
+      value = self.updateBoolean(value, 'Yes', 'No');
     } else if(key === "date_requested") {
       value = moment(value).format("MMM Do, YYYY")
     } else if(key === "ncr_organization_id") {

--- a/app/assets/javascripts/details/views/details_request_card.js
+++ b/app/assets/javascripts/details/views/details_request_card.js
@@ -83,14 +83,12 @@ DetailsRequestCard = (function(){
       } else {
         value = "Exact";
       }
-    } else if(key === "tock_project") {
+    } else if(key === "is_tock_billable") {
       if (value === true){
         value = "Yes";
       } else {
         value = "No";
       }
-    } else if(key === "is_tock_billable") {
-      console.log(key, value);
     } else if(key === "date_requested") {
       value = moment(value).format("MMM Do, YYYY")
     } else if(key === "ncr_organization_id") {

--- a/app/assets/javascripts/details/views/details_request_card.js
+++ b/app/assets/javascripts/details/views/details_request_card.js
@@ -83,6 +83,14 @@ DetailsRequestCard = (function(){
       } else {
         value = "Exact";
       }
+    } else if(key === "tock_project") {
+      if (value === true){
+        value = "Yes";
+      } else {
+        value = "No";
+      }
+    } else if(key === "is_tock_billable") {
+      console.log(key, value);
     } else if(key === "date_requested") {
       value = moment(value).format("MMM Do, YYYY")
     } else if(key === "ncr_organization_id") {

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -22,19 +22,7 @@ module Gsa18f
     end
 
     def display
-      [
-        [translated_key("product_name_and_description"), object.product_name_and_description],
-        [translated_key("purchase_type"), object.purchase_type],
-        [translated_key("justification"), object.justification],
-        [translated_key("date_requested"), object.date_requested],
-        [translated_key("quantity"), object.quantity],
-        [translated_key("total_price"), object.total_price],
-        [translated_key("office"), object.office],
-        [translated_key("urgency"), object.urgency_string],
-        [translated_key("link_to_product"), object.link_to_product],
-        [translated_key("additional_info"), object.additional_info],
-        [translated_key("cost_per_unit"), object.cost_per_unit]
-      ] + recurring_fields + tock_fields
+      basic_fields + recurring_fields + tock_fields
     end
 
     def new_display
@@ -49,6 +37,22 @@ module Gsa18f
     end
 
     private
+
+    def basic_fields
+      [
+        [translated_key("product_name_and_description"), object.product_name_and_description],
+        [translated_key("purchase_type"), object.purchase_type],
+        [translated_key("justification"), object.justification],
+        [translated_key("date_requested"), object.date_requested],
+        [translated_key("quantity"), object.quantity],
+        [translated_key("total_price"), object.total_price],
+        [translated_key("office"), object.office],
+        [translated_key("urgency"), object.urgency_string],
+        [translated_key("link_to_product"), object.link_to_product],
+        [translated_key("additional_info"), object.additional_info],
+        [translated_key("cost_per_unit"), object.cost_per_unit]
+      ]
+    end
 
     def recurring_fields
       if recurring

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -18,7 +18,7 @@ module Gsa18f
       translate_strings(new_display)
     end
 
-    def translate_strings element_array
+    def translate_strings(element_array)
       stored_displays = []
       element_array.each do |display_el|
         display_string = obj.public_send(display_el) if obj.respond_to? display_el

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -14,6 +14,9 @@ module Gsa18f
       %w(purchase_type date_requested quantity urgency cost_per_unit office total_price justification link_to_product additional_info)
     end
 
+    def top_email_field
+    end
+
     def display
       translate_strings(new_display)
     end

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -7,7 +7,7 @@ module Gsa18f
     end
 
     def email_display
-      translate_strings email_display_fields
+      translate_strings(email_display_fields)
     end
 
     def email_display_fields
@@ -15,7 +15,7 @@ module Gsa18f
     end
 
     def display
-      translate_strings new_display
+      translate_strings(new_display)
     end
 
     def translate_strings element_array
@@ -35,6 +35,5 @@ module Gsa18f
     def translated_key(key)
       I18n.t("decorators.gsa18f/procurement.#{key}")
     end
-
   end
 end

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -7,22 +7,25 @@ module Gsa18f
     end
 
     def email_display
-      [
-        [translated_key("purchase_type"), object.purchase_type],
-        [translated_key("date_requested"), object.date_requested],
-        [translated_key("quantity"), object.quantity],
-        [translated_key("urgency"), object.urgency_string],
-        [translated_key("cost_per_unit"), object.cost_per_unit],
-        [translated_key("office"), object.office],
-        [translated_key("total_price"), object.total_price],
-        [translated_key("justification"), object.justification],
-        [translated_key("link_to_product"), object.link_to_product],
-        [translated_key("additional_info"), object.additional_info]
-      ]
+      translate_strings email_display_fields
+    end
+
+    def email_display_fields
+      %w(purchase_type date_requested quantity urgency cost_per_unit office total_price justification link_to_product additional_info)
     end
 
     def display
-      basic_fields + recurring_fields + tock_fields
+      translate_strings new_display
+    end
+
+    def translate_strings element_array
+      stored_displays = []
+      element_array.each do |display_el|
+        display_string = obj.public_send(display_el) if obj.respond_to? display_el
+        translated_el = [translated_key(display_el), display_string]
+        stored_displays << translated_el
+      end
+      stored_displays
     end
 
     def new_display
@@ -36,40 +39,5 @@ module Gsa18f
       I18n.t("decorators.gsa18f/procurement.#{key}")
     end
 
-    private
-
-    def basic_fields
-      [
-        [translated_key("product_name_and_description"), object.product_name_and_description],
-        [translated_key("purchase_type"), object.purchase_type],
-        [translated_key("justification"), object.justification],
-        [translated_key("date_requested"), object.date_requested],
-        [translated_key("quantity"), object.quantity],
-        [translated_key("total_price"), object.total_price],
-        [translated_key("office"), object.office],
-        [translated_key("urgency"), object.urgency_string],
-        [translated_key("link_to_product"), object.link_to_product],
-        [translated_key("additional_info"), object.additional_info],
-        [translated_key("cost_per_unit"), object.cost_per_unit]
-      ]
-    end
-
-    def recurring_fields
-      if recurring
-        [
-          [translated_key("recurring_interval"), object.recurring_interval],
-          [translated_key("recurring_length"), object.recurring_length]
-        ]
-      else
-        []
-      end
-    end
-
-    def tock_fields
-      [
-        [translated_key("is_tock_billable"), object.is_tock_billable],
-        [translated_key("tock_project"), object.tock_project]
-      ]
-    end
   end
 end

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -7,7 +7,7 @@ module Gsa18f
     end
 
     def email_display
-      translate_strings(email_display_fields)
+      translate_strings(email_display_fields, object)
     end
 
     def email_display_fields
@@ -18,10 +18,10 @@ module Gsa18f
     end
 
     def display
-      translate_strings(new_display)
+      translate_strings(new_display, object)
     end
 
-    def translate_strings(element_array)
+    def translate_strings(element_array, obj)
       stored_displays = []
       element_array.each do |display_el|
         display_string = obj.public_send(display_el) if obj.respond_to? display_el

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -31,6 +31,8 @@ module Gsa18f
         [translated_key("total_price"), object.total_price],
         [translated_key("office"), object.office],
         [translated_key("urgency"), object.urgency_string],
+        [translated_key("is_tock_billable"), object.is_tock_billable],
+        [translated_key("tock_project"), object.tock_project],
         [translated_key("link_to_product"), object.link_to_product],
         [translated_key("additional_info"), object.additional_info],
         [translated_key("cost_per_unit"), object.cost_per_unit]
@@ -38,7 +40,7 @@ module Gsa18f
     end
 
     def new_display
-      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info recurring recurring_interval recurring_length total_price)
+      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project recurring recurring_interval recurring_length total_price)
     end
 
     def top_email_field

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -32,9 +32,6 @@ module Gsa18f
       %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project recurring recurring_interval recurring_length total_price)
     end
 
-    def top_email_field
-    end
-
     def translated_key(key)
       I18n.t("decorators.gsa18f/procurement.#{key}")
     end

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -31,12 +31,10 @@ module Gsa18f
         [translated_key("total_price"), object.total_price],
         [translated_key("office"), object.office],
         [translated_key("urgency"), object.urgency_string],
-        [translated_key("is_tock_billable"), object.is_tock_billable],
-        [translated_key("tock_project"), object.tock_project],
         [translated_key("link_to_product"), object.link_to_product],
         [translated_key("additional_info"), object.additional_info],
         [translated_key("cost_per_unit"), object.cost_per_unit]
-      ] + recurring_fields
+      ] + recurring_fields + tock_fields
     end
 
     def new_display
@@ -61,6 +59,13 @@ module Gsa18f
       else
         []
       end
+    end
+
+    def tock_fields
+      [
+        [translated_key("is_tock_billable"), object.is_tock_billable],
+        [translated_key("tock_project"), object.tock_project]
+      ]
     end
   end
 end

--- a/app/models/gsa18f/procurement_fields.rb
+++ b/app/models/gsa18f/procurement_fields.rb
@@ -11,7 +11,7 @@ module Gsa18f
         fields += [:recurring, :recurring_interval, :recurring_length]
       end
 
-      fields
+      fields += [:is_tock_billable, :tock_project]
     end
 
     private
@@ -29,8 +29,6 @@ module Gsa18f
         :product_name_and_description,
         :purchase_type,
         :quantity,
-        :is_tock_billable,
-        :tock_project,
         :urgency
       ]
     end

--- a/app/models/gsa18f/procurement_fields.rb
+++ b/app/models/gsa18f/procurement_fields.rb
@@ -29,6 +29,8 @@ module Gsa18f
         :product_name_and_description,
         :purchase_type,
         :quantity,
+        :is_tock_billable,
+        :tock_project,
         :urgency
       ]
     end

--- a/app/models/gsa18f/procurement_fields.rb
+++ b/app/models/gsa18f/procurement_fields.rb
@@ -11,7 +11,7 @@ module Gsa18f
         fields += [:recurring, :recurring_interval, :recurring_length]
       end
 
-      fields += [:is_tock_billable, :tock_project]
+      fields + [:is_tock_billable, :tock_project]
     end
 
     private

--- a/app/views/gsa18f/fields/_is_tock_billable.html.haml
+++ b/app/views/gsa18f/fields/_is_tock_billable.html.haml
@@ -1,0 +1,15 @@
+.column{ id: key + '-wrapper'}
+  .detail-wrapper.row{ class: key + "-wrapper", id: value_id }
+    .detail-display.column
+      %label.detail-element
+        = t(t_slug + key)
+      %span.detail-value
+        - if client_field != "--"
+          %input{type: "checkbox", checked: true, disabled: true, label: false}
+        - else
+          %input{type: "checkbox", checked: false, disabled: true, label: false}
+    .detail-edit.column
+      %label.detail-element
+        = t(t_slug + key)
+      %span.detail-value
+        = f.input :is_tock_billable, input_html: { "data-filter-control" => "is_tock_billable" }, label: false

--- a/app/views/gsa18f/fields/_is_tock_billable.html.haml
+++ b/app/views/gsa18f/fields/_is_tock_billable.html.haml
@@ -4,7 +4,7 @@
       %label.detail-element
         = t(t_slug + key)
       %span.detail-value
-        - if client_field == true
+        - if client_field != "--"
           Yes
         - else
           No

--- a/app/views/gsa18f/fields/_is_tock_billable.html.haml
+++ b/app/views/gsa18f/fields/_is_tock_billable.html.haml
@@ -4,10 +4,10 @@
       %label.detail-element
         = t(t_slug + key)
       %span.detail-value
-        - if client_field != "--"
-          %input{type: "checkbox", checked: true, disabled: true, label: false}
+        - if client_field == true
+          Yes
         - else
-          %input{type: "checkbox", checked: false, disabled: true, label: false}
+          No
     .detail-edit.column
       %label.detail-element
         = t(t_slug + key)

--- a/app/views/gsa18f/fields/_tock_project.html.haml
+++ b/app/views/gsa18f/fields/_tock_project.html.haml
@@ -1,0 +1,15 @@
+.column{ class: key + "-wrapper ", id: key + '-wrapper', "data-filter-key" => "is_tock_billable", "data-filter-value" => 1 }
+  .detail-wrapper.row{ id: value_id }
+    .detail-display.column
+      %label.detail-element
+        = t(t_slug + key)
+      %span.detail-value
+        = client_field
+    .detail-edit.column
+      %label.detail-element
+        = t(t_slug + key)
+      %span.detail-value
+        %div
+          = f.input :tock_project,
+            include_blank: false,
+            label: false

--- a/app/views/gsa18f/procurements/_form_new.html.haml
+++ b/app/views/gsa18f/procurements/_form_new.html.haml
@@ -59,7 +59,7 @@
         %div{ "data-filter-key" => "is_tock_billable", "data-filter-value" => 1 }
 .column{ id: "tock_project" + '-wrapper'}
   .row{ "data-filter-key" => "is_tock_billable", "data-filter-value" => 1 }
-    .column.medium-5
+    .column.medium-8
       .detail-wrapper.row{ class: "tock_project-wrapper" }
         .detail-edit.column
           %label.detail-element

--- a/app/views/gsa18f/procurements/_form_new.html.haml
+++ b/app/views/gsa18f/procurements/_form_new.html.haml
@@ -49,6 +49,23 @@
           %span.detail-value
             = f.input :quantity, label: false, input_html: { step: 1 }
     .column.medium-2
+.column{ id: "is_tock_billable" + '-wrapper'}
+  .detail-wrapper.row{ class: "is_tock_billable" }
+    .detail-edit.column
+      %label.detail-element
+        = t(t_slug + "is_tock_billable")
+      %span.detail-value
+        = f.input :is_tock_billable, label: false, input_html: { "data-filter-control" => "is_tock_billable" }
+        %div{ "data-filter-key" => "is_tock_billable", "data-filter-value" => 1 }
+.column{ id: "tock_project" + '-wrapper'}
+  .row{ "data-filter-key" => "is_tock_billable", "data-filter-value" => 1 }
+    .column.medium-5
+      .detail-wrapper.row{ class: "tock_project-wrapper" }
+        .detail-edit.column
+          %label.detail-element
+            = t(t_slug + "tock_project")
+          %span.detail-value
+            = f.input :tock_project, label: false
 .column{ id: "recurring" + '-wrapper'}
   .detail-wrapper.row{ class: "recurring-wrapper" }
     .detail-edit.column

--- a/config/locales/decorators/en.yml
+++ b/config/locales/decorators/en.yml
@@ -45,6 +45,8 @@ en:
       total: "Total"
       total_price: "Total Price"
       urgency: "Urgency"
+      is_tock_billable: "Is this is a billable project?"
+      tock_project: "Tock project number"
       product_name_and_description: "Product name and description"
       recurring_interval: "Recurring interval"
       recurring_length: "Recurring length"

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -25,6 +25,7 @@ en:
         approving_official: "Type here to search"
     hints:
       gsa18f_procurement:
+        tock_project: "Billable project numbers can be found at <a href=\"http://tock.18f.gov/projects\" target=\"_blank\">www.tock.18f.gov/projects</a>. Clicking the link will open a new window."
         link_to_product: "Search <a href='https://www.gsaadvantage.gov/advantage/main/start_page.do' target='_blank'>GSA Advantage</a> first; then <a href='http://www.amazon.com' target='_blank'>Amazon;</a> then other vendor. Paste link here."
         recurring_length: "e.g. Number of Days, Months, Years"
       ncr_work_order:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -25,7 +25,7 @@ en:
         approving_official: "Type here to search"
     hints:
       gsa18f_procurement:
-        tock_project: "Billable project numbers can be found at <a href=\"http://tock.18f.gov/projects\" target=\"_blank\">www.tock.18f.gov/projects</a>. Clicking the link will open a new window."
+        tock_project: "Billable project numbers can be found at <a href=\"http://tock.18f.gov/projects\" target=\"_blank\">www.tock.18f.gov/projects</a>. <i>Clicking the link will open a new window.</i>"
         link_to_product: "Search <a href='https://www.gsaadvantage.gov/advantage/main/start_page.do' target='_blank'>GSA Advantage</a> first; then <a href='http://www.amazon.com' target='_blank'>Amazon;</a> then other vendor. Paste link here."
         recurring_length: "e.g. Number of Days, Months, Years"
       ncr_work_order:

--- a/config/tables/proposals.yml
+++ b/config/tables/proposals.yml
@@ -73,6 +73,12 @@ default: &DEFAULT
     function_code:
       header: Function
       display: client_data.function_code
+    is_tock_billable:
+      header: Billable
+      display: client_data.is_tock_billable
+    tock_project:
+      header: Tock
+      display: client_data.tock_project
     soc_code:
       header: SOC
       display: client_data.soc_code
@@ -111,5 +117,8 @@ gsa18f:
     - total_price
     - status
     - created_at
+    - urgency
+    - is_tock_billable
+    - tock_project
     - urgency
     - purchase_type

--- a/config/tables/proposals.yml
+++ b/config/tables/proposals.yml
@@ -120,5 +120,4 @@ gsa18f:
     - urgency
     - is_tock_billable
     - tock_project
-    - urgency
     - purchase_type

--- a/db/migrate/20160921204321_add_billable_to18_f.rb
+++ b/db/migrate/20160921204321_add_billable_to18_f.rb
@@ -1,0 +1,10 @@
+class AddBillableTo18F < ActiveRecord::Migration
+  def up
+    add_column :gsa18f_procurements, :is_tock_billable, :boolean
+    add_column :gsa18f_procurements, :tock_project, :string
+  end
+  def down
+    drop_column :gsa18f_procurements, :is_tock_billable, :boolean
+    drop_column :gsa18f_procurements, :tock_project, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160922210540) do
+ActiveRecord::Schema.define(version: 20160923023903) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -185,6 +185,7 @@ ActiveRecord::Schema.define(version: 20160922210540) do
     t.integer  "purchase_type",                                  null: false
     t.boolean  "is_tock_billable"
     t.string   "tock_project"
+    t.string   "pegasys_document_number"
   end
 
   create_table "ncr_organizations", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160923023903) do
+ActiveRecord::Schema.define(version: 20160922210540) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -185,7 +185,6 @@ ActiveRecord::Schema.define(version: 20160923023903) do
     t.integer  "purchase_type",                                  null: false
     t.boolean  "is_tock_billable"
     t.string   "tock_project"
-    t.string   "pegasys_document_number"
   end
 
   create_table "ncr_organizations", force: :cascade do |t|
@@ -344,6 +343,14 @@ ActiveRecord::Schema.define(version: 20160923023903) do
   end
 
   add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
+
+  create_table "test_client_requests", force: :cascade do |t|
+    t.decimal  "amount"
+    t.string   "project_title"
+    t.integer  "approving_official_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "user_delegates", force: :cascade do |t|
     t.integer  "assigner_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,7 +60,7 @@ ActiveRecord::Schema.define(version: 20160922210540) do
   add_index "ahoy_messages", ["user_id", "user_type"], name: "index_ahoy_messages_on_user_id_and_user_type", using: :btree
 
   create_table "api_tokens", force: :cascade do |t|
-    t.string   "access_token", limit: 255
+    t.string   "access_token"
     t.datetime "expires_at"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -71,8 +71,8 @@ ActiveRecord::Schema.define(version: 20160922210540) do
   add_index "api_tokens", ["access_token"], name: "index_api_tokens_on_access_token", unique: true, using: :btree
 
   create_table "attachments", force: :cascade do |t|
-    t.string   "file_file_name",    limit: 255
-    t.string   "file_content_type", limit: 255
+    t.string   "file_file_name"
+    t.string   "file_content_type"
     t.integer  "file_file_size"
     t.datetime "file_updated_at"
     t.integer  "proposal_id"
@@ -169,20 +169,22 @@ ActiveRecord::Schema.define(version: 20160922210540) do
 
   create_table "gsa18f_procurements", force: :cascade do |t|
     t.text     "office"
-    t.text     "justification",                            default: "",      null: false
-    t.text     "link_to_product",                          default: "",      null: false
+    t.text     "justification",                default: "",      null: false
+    t.text     "link_to_product",              default: "",      null: false
     t.integer  "quantity"
     t.datetime "date_requested"
     t.text     "additional_info"
     t.decimal  "cost_per_unit"
     t.text     "product_name_and_description"
-    t.boolean  "recurring",                                default: false,   null: false
-    t.string   "recurring_interval",           limit: 255, default: "Daily"
+    t.boolean  "recurring",                    default: false,   null: false
+    t.string   "recurring_interval",           default: "Daily"
     t.integer  "recurring_length"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "urgency"
-    t.integer  "purchase_type",                                              null: false
+    t.integer  "purchase_type",                                  null: false
+    t.boolean  "is_tock_billable"
+    t.string   "tock_project"
   end
 
   create_table "ncr_organizations", force: :cascade do |t|
@@ -194,21 +196,21 @@ ActiveRecord::Schema.define(version: 20160922210540) do
 
   create_table "ncr_work_orders", force: :cascade do |t|
     t.decimal  "amount"
-    t.string   "expense_type",          limit: 255
-    t.string   "vendor",                limit: 255
-    t.boolean  "not_to_exceed",                     default: false, null: false
-    t.string   "building_number",       limit: 255
-    t.boolean  "emergency",                         default: false, null: false
-    t.string   "rwa_number",            limit: 255
-    t.string   "work_order_code",       limit: 255
-    t.string   "project_title",         limit: 255
+    t.string   "expense_type"
+    t.string   "vendor"
+    t.boolean  "not_to_exceed",         default: false, null: false
+    t.string   "building_number"
+    t.boolean  "emergency",             default: false, null: false
+    t.string   "rwa_number"
+    t.string   "work_order_code"
+    t.string   "project_title"
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "direct_pay",                        default: false, null: false
-    t.string   "cl_number",             limit: 255
-    t.string   "function_code",         limit: 255
-    t.string   "soc_code",              limit: 255
+    t.boolean  "direct_pay",            default: false, null: false
+    t.string   "cl_number"
+    t.string   "function_code"
+    t.string   "soc_code"
     t.integer  "ncr_organization_id"
     t.integer  "approving_official_id"
   end
@@ -266,17 +268,17 @@ ActiveRecord::Schema.define(version: 20160922210540) do
   add_index "proposal_roles", ["role_id", "user_id", "proposal_id"], name: "index_proposal_roles_on_role_id_and_user_id_and_proposal_id", unique: true, using: :btree
 
   create_table "proposals", force: :cascade do |t|
-    t.string   "status",           limit: 255
+    t.string   "status"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "client_data_id"
-    t.string   "client_data_type", limit: 255
+    t.string   "client_data_type"
     t.integer  "requester_id"
     t.string   "public_id",        limit: 255
     t.uuid     "visit_id"
   end
 
-  add_index "proposals", ["client_data_id", "client_data_type"], name: "index_proposals_on_client_data_id_and_client_data_type", using: :btree
+  add_index "proposals", ["client_data_type", "client_data_id"], name: "index_proposals_on_client_data_type_and_client_data_id", using: :btree
 
   create_table "reports", force: :cascade do |t|
     t.string   "name",                       null: false
@@ -307,7 +309,7 @@ ActiveRecord::Schema.define(version: 20160922210540) do
 
   create_table "steps", force: :cascade do |t|
     t.integer  "user_id"
-    t.string   "status",              limit: 255
+    t.string   "status"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "position"
@@ -357,12 +359,12 @@ ActiveRecord::Schema.define(version: 20160922210540) do
   add_index "user_roles", ["user_id", "role_id"], name: "index_user_roles_on_user_id_and_role_id", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "email_address",     limit: 255
-    t.string   "first_name",        limit: 255
-    t.string   "last_name",         limit: 255
+    t.string   "email_address"
+    t.string   "first_name"
+    t.string   "last_name"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "client_slug",       limit: 255
+    t.string   "client_slug"
     t.boolean  "active",                        default: true
     t.string   "timezone",          limit: 255, default: "Eastern Time (US & Canada)"
     t.string   "new_features_date"

--- a/spec/factories/gsa18f/procurements.rb
+++ b/spec/factories/gsa18f/procurements.rb
@@ -12,5 +12,13 @@ FactoryGirl.define do
     trait :with_steps do
       after(:create) { |procurement| procurement.initialize_steps }
     end
+
+    trait :with_beta_requester do
+      after(:create) do |procurement|
+        requester = procurement.requester
+        requester.roles << Role.find_by!(name: ROLE_BETA_USER)
+        requester.roles << Role.find_by!(name: ROLE_BETA_ACTIVE)
+      end
+    end
   end
 end

--- a/spec/features/gsa18f/procurements/show_spec.rb
+++ b/spec/features/gsa18f/procurements/show_spec.rb
@@ -10,4 +10,34 @@ feature "View Gsa18F procurement" do
 
     expect(page).to have_content(procurement.purchase_type)
   end
+
+  scenario "requester cant see tock_project unless is_tock_billable is true" do
+    create_and_visit_proposal_beta
+    visit proposal_path(proposal)
+    expect(page).not_to have_content("Tock Project")
+    js_modify_checkbox
+    expect(page).to have_content("Tock Project")
+    visit proposal_path(proposal)
+  end
+
+  def js_activate_modify_proposal(modify = "ul.request-actions .edit-button button")
+    find(modify).trigger("click")
+  end
+
+
+  def js_modify_checkbox(text = "foo", selector = 'gsa18f_procurement[product_name_and_description]', submit = ".request-actions .save-button button")
+    find(:css, selector).set(true)
+    find(submit).trigger("click")
+    find('.save_confirm-modal-content .form-button[data-modal-event="confirm"]').trigger("click")
+    wait_for_ajax
+  end
+
+
+  def create_and_visit_proposal_beta
+    requester = create(:user, client_slug: "gsa18f")
+    procurement = create(:gsa18f_procurement, :with_steps, requester: requester)
+    proposal = procurement.proposal
+    login_as(proposal.requester)
+    visit proposal_path(proposal)
+  end
 end

--- a/spec/features/gsa18f/procurements/show_spec.rb
+++ b/spec/features/gsa18f/procurements/show_spec.rb
@@ -12,9 +12,9 @@ feature "View Gsa18F procurement" do
   end
 
   scenario "requester cant see tock_project unless is_tock_billable is true" do
-    create_and_visit_proposal_beta
-    visit proposal_path(proposal)
+    proposal = create_and_visit_proposal_beta
     expect(page).not_to have_content("Tock Project")
+    js_activate_modify_proposal
     js_modify_checkbox
     expect(page).to have_content("Tock Project")
     visit proposal_path(proposal)
@@ -39,5 +39,6 @@ feature "View Gsa18F procurement" do
     proposal = procurement.proposal
     login_as(proposal.requester)
     visit proposal_path(proposal)
+    return proposal
   end
 end

--- a/spec/features/gsa18f/procurements/show_spec.rb
+++ b/spec/features/gsa18f/procurements/show_spec.rb
@@ -27,7 +27,7 @@ feature "View Gsa18F procurement" do
   end
 
 
-  def js_modify_checkbox(text = "foo", selector = 'gsa18f_procurement[product_name_and_description]', submit = ".request-actions .save-button button")
+  def js_modify_checkbox(text = "foo", selector = 'gsa18f_procurement[is_tock_billable]', submit = ".request-actions .save-button button")
     find(:css, selector).set(true)
     find(submit).trigger("click")
     find('.save_confirm-modal-content .form-button[data-modal-event="confirm"]').trigger("click")

--- a/spec/features/gsa18f/procurements/show_spec.rb
+++ b/spec/features/gsa18f/procurements/show_spec.rb
@@ -15,6 +15,7 @@ feature "View Gsa18F procurement" do
     proposal = create_and_visit_proposal_beta
     visit proposal_path(proposal)
     expect(page).not_to have_content("Tock Project")
+    save_and_open_screenshot
     js_activate_modify_proposal
     js_modify_checkbox
     expect(page).to have_content("Tock Project")
@@ -35,8 +36,7 @@ feature "View Gsa18F procurement" do
 
 
   def create_and_visit_proposal_beta
-    requester = create(:user, client_slug: "gsa18f")
-    procurement = create(:gsa18f_procurement, :with_steps, requester: requester, urgency: 10)
+    procurement = create(:gsa18f_procurement, :with_beta_requester)
     proposal = procurement.proposal
     login_as(proposal.requester)
     visit proposal_path(proposal)

--- a/spec/features/gsa18f/procurements/show_spec.rb
+++ b/spec/features/gsa18f/procurements/show_spec.rb
@@ -15,7 +15,6 @@ feature "View Gsa18F procurement" do
     proposal = create_and_visit_proposal_beta
     visit proposal_path(proposal)
     expect(page).not_to have_content("Tock Project")
-    save_and_open_screenshot
     js_activate_modify_proposal
     js_modify_checkbox
     expect(page).to have_content("Tock Project")
@@ -27,7 +26,7 @@ feature "View Gsa18F procurement" do
   end
 
 
-  def js_modify_checkbox(text = "foo", selector = 'gsa18f_procurement[is_tock_billable]', submit = ".request-actions .save-button button")
+  def js_modify_checkbox(text = "foo", selector = '#gsa18f_procurement_is_tock_billable', submit = ".request-actions .save-button button")
     find(:css, selector).set(true)
     find(submit).trigger("click")
     find('.save_confirm-modal-content .form-button[data-modal-event="confirm"]').trigger("click")

--- a/spec/features/gsa18f/procurements/show_spec.rb
+++ b/spec/features/gsa18f/procurements/show_spec.rb
@@ -13,6 +13,7 @@ feature "View Gsa18F procurement" do
 
   scenario "requester cant see tock_project unless is_tock_billable is true" do
     proposal = create_and_visit_proposal_beta
+    visit proposal_path(proposal)
     expect(page).not_to have_content("Tock Project")
     js_activate_modify_proposal
     js_modify_checkbox

--- a/spec/features/gsa18f/procurements/show_spec.rb
+++ b/spec/features/gsa18f/procurements/show_spec.rb
@@ -11,7 +11,7 @@ feature "View Gsa18F procurement" do
     expect(page).to have_content(procurement.purchase_type)
   end
 
-  scenario "requester cant see tock_project unless is_tock_billable is true" do
+  scenario "requester cant see tock_project unless is_tock_billable is true", js: true do
     proposal = create_and_visit_proposal_beta
     visit proposal_path(proposal)
     expect(page).not_to have_content("Tock Project")
@@ -36,7 +36,7 @@ feature "View Gsa18F procurement" do
 
   def create_and_visit_proposal_beta
     requester = create(:user, client_slug: "gsa18f")
-    procurement = create(:gsa18f_procurement, :with_steps, requester: requester)
+    procurement = create(:gsa18f_procurement, :with_steps, requester: requester, urgency: 10)
     proposal = procurement.proposal
     login_as(proposal.requester)
     visit proposal_path(proposal)


### PR DESCRIPTION
# What

Add new fields for `is_tock_billable` and `tock_project`. These fields are in the new form and in the request fields template.

Added fields to permitted_params and display_fields. 

Conditionally show `tock_project` if `is_tock_billable` is toggled. 

JavaScript checks `is_tock_billable` value and displays human readable term (yes/no).

# Reference 

https://trello.com/c/DZ0KnDco/807-as-a-user-i-can-indicate-that-my-request-is-billable-and-enter-a-billable-tock-project-so-that-my-approvers-know-how-to-handle-t

# Looks

![screen shot 2016-09-22 at 7 31 26 pm](https://cloud.githubusercontent.com/assets/1332366/18772383/4db46b7e-80fb-11e6-8fbe-b95ab4ec70d6.png)
![screen shot 2016-09-22 at 7 31 30 pm](https://cloud.githubusercontent.com/assets/1332366/18772384/4db63af8-80fb-11e6-8464-50f31389c370.png)
![screen shot 2016-09-22 at 7 31 34 pm](https://cloud.githubusercontent.com/assets/1332366/18772386/4db97952-80fb-11e6-9c91-3835cb1c8f53.png)
![screen shot 2016-09-22 at 7 31 38 pm](https://cloud.githubusercontent.com/assets/1332366/18772385/4db97a42-80fb-11e6-8962-e109c89a819c.png)
![screen shot 2016-09-22 at 7 31 49 pm](https://cloud.githubusercontent.com/assets/1332366/18772387/4db9d5be-80fb-11e6-8ede-b3e8713e2b85.png)
![screen shot 2016-09-22 at 7 31 52 pm](https://cloud.githubusercontent.com/assets/1332366/18772388/4dbf908a-80fb-11e6-9735-5c57e8bf98cb.png)
