### PR TITLE
Add Pegasys Document Number to gsa18f

### DIFF
--- a/app/assets/stylesheets/redesign/_card-request_details.scss
+++ b/app/assets/stylesheets/redesign/_card-request_details.scss
@@ -2,6 +2,14 @@
   position: absolute;
 }
 
+#pegasys_document_number-wrapper{
+  display: none;
+}
+
+.status-completed #pegasys_document_number-wrapper{
+  display: block;
+}
+
 .card#request-details-card{
   .detail-edit{
     display: none;

--- a/app/decorators/gsa18f/event_decorator.rb
+++ b/app/decorators/gsa18f/event_decorator.rb
@@ -17,12 +17,10 @@ module Gsa18f
     end
 
     def new_display
-      %w(
-        duty_station supervisor_id title_of_event
+      %w(duty_station supervisor_id title_of_event
         event_provider type_of_event cost_per_unit start_date
         end_date purpose justification link instructions
-        free_event nfs_form travel_required estimated_travel_expenses
-      )
+        free_event nfs_form travel_required estimated_travel_expenses)
     end
 
     def top_email_field

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -31,7 +31,7 @@ module Gsa18f
         translated_el = [translated_key(display_el), display_string]
         stored_displays << translated_el
       end
-      stored_displays
+      returned_value = stored_displays
     end
 
     def new_display

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -32,7 +32,7 @@ module Gsa18f
     end
 
     def new_display
-      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project recurring recurring_interval recurring_length total_price pegasys_display_number)
+      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project recurring recurring_interval recurring_length total_price pegasys_document_number)
     end
 
     def translated_key(key)

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -11,7 +11,10 @@ module Gsa18f
     end
 
     def email_display_fields
-      %w(purchase_type date_requested quantity urgency cost_per_unit office total_price justification link_to_product additional_info)
+      %w(purchase_type date_requested
+         quantity urgency cost_per_unit
+         office total_price justification
+         link_to_product additional_info)
     end
 
     def top_email_field

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -28,10 +28,9 @@ module Gsa18f
       stored_displays = []
       element_array.each do |display_el|
         display_string = obj.public_send(display_el) if obj.respond_to? display_el
-        translated_el = [translated_key(display_el), display_string]
-        stored_displays << translated_el
+        stored_displays << [translated_key(display_el), display_string]
       end
-      returned_value = stored_displays
+      stored_displays
     end
 
     def new_display

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -10,7 +10,6 @@ module Gsa18f
       translate_strings(email_display_fields, object)
     end
 
-
     def email_display_fields
       %w(purchase_type date_requested quantity urgency cost_per_unit office total_price justification link_to_product additional_info)
     end
@@ -33,7 +32,7 @@ module Gsa18f
     end
 
     def new_display
-      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project recurring recurring_interval recurring_length total_price, pegasys_display_number)
+      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project recurring recurring_interval recurring_length total_price pegasys_display_number)
     end
 
     def translated_key(key)

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -33,7 +33,7 @@ module Gsa18f
     end
 
     def new_display
-      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project recurring recurring_interval recurring_length total_price)
+      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project recurring recurring_interval recurring_length total_price, pegasys_display_number)
     end
 
     def translated_key(key)

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -35,12 +35,13 @@ module Gsa18f
         [translated_key("tock_project"), object.tock_project],
         [translated_key("link_to_product"), object.link_to_product],
         [translated_key("additional_info"), object.additional_info],
+        [translated_key("pegasys_document_number"), object.pegasys_document_number],
         [translated_key("cost_per_unit"), object.cost_per_unit]
       ] + recurring_fields
     end
 
     def new_display
-      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project recurring recurring_interval recurring_length total_price)
+      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project pegasys_document_number recurring recurring_interval recurring_length total_price)
     end
 
     def top_email_field

--- a/app/views/gsa18f/fields/_pegasys_document_number.html.haml
+++ b/app/views/gsa18f/fields/_pegasys_document_number.html.haml
@@ -1,0 +1,12 @@
+.column{ id: key + '-wrapper'}
+  .detail-wrapper.row{ class: key + "-wrapper", id: value_id }
+    .detail-display.column
+      %label.detail-element
+        = t(t_slug + key)
+      %span.detail-value
+        = client_field
+    .detail-edit.column
+      %label.detail-element
+        = t(t_slug + key)
+      %span.detail-value
+        = f.input :pegasys_document_number, label: false

--- a/app/views/proposals/show_next.html.haml
+++ b/app/views/proposals/show_next.html.haml
@@ -9,7 +9,7 @@
       .medium-12.column.wrap-hard
         = render partial: "proposals/details/summary", locals: { proposal: @proposal }
 
-      .medium-6.medium-push-6.column
+      .medium-6.medium-push-6.column{class: "status-" + @proposal.status.downcase}
         = render partial: "proposals/details/request_details", locals: { proposal: @proposal }
         #card-for-attachments
           = render partial: "proposals/details/attachment", locals: { proposal: @proposal }

--- a/config/locales/decorators/en.yml
+++ b/config/locales/decorators/en.yml
@@ -48,6 +48,7 @@ en:
       is_tock_billable: "Is this is a billable project?"
       tock_project: "Tock project number"
       product_name_and_description: "Product name and description"
+      pegasys_document_number: "Pegasys Document Number"
       recurring_interval: "Recurring interval"
       recurring_length: "Recurring length"
     ncr/work_order:

--- a/config/tables/proposals.yml
+++ b/config/tables/proposals.yml
@@ -123,6 +123,5 @@ gsa18f:
     - urgency
     - is_tock_billable
     - tock_project
-    - urgency
     - purchase_type
     - pegasys_document_number

--- a/config/tables/proposals.yml
+++ b/config/tables/proposals.yml
@@ -73,9 +73,9 @@ default: &DEFAULT
     function_code:
       header: Function
       display: client_data.function_code
-    soc_code:
-      header: SOC
-      display: client_data.soc_code
+    pegasys_document_number:
+      header: Pegasys
+      display: client_data.pegasys_document_number
   columns:
     - public_id
     - name
@@ -113,3 +113,4 @@ gsa18f:
     - created_at
     - urgency
     - purchase_type
+    - pegasys_document_number

--- a/db/migrate/20160923023903_add_pegasys_document_number_to18f.rb
+++ b/db/migrate/20160923023903_add_pegasys_document_number_to18f.rb
@@ -1,0 +1,8 @@
+class AddPegasysDocumentNumberTo18f < ActiveRecord::Migration
+  def up
+    add_column :gsa18f_procurements, :pegasys_document_number, :string
+  end
+  def down
+    drop_column :gsa18f_procurements, :pegasys_document_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160922210540) do
+ActiveRecord::Schema.define(version: 20160923023903) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -185,6 +185,7 @@ ActiveRecord::Schema.define(version: 20160922210540) do
     t.integer  "purchase_type",                                  null: false
     t.boolean  "is_tock_billable"
     t.string   "tock_project"
+    t.string   "pegasys_document_number"
   end
 
   create_table "ncr_organizations", force: :cascade do |t|

--- a/spec/factories/gsa18f/procurements.rb
+++ b/spec/factories/gsa18f/procurements.rb
@@ -20,5 +20,6 @@ FactoryGirl.define do
         requester.roles << Role.find_by!(name: ROLE_BETA_ACTIVE)
       end
     end
+
   end
 end

--- a/spec/factories/gsa18f/procurements.rb
+++ b/spec/factories/gsa18f/procurements.rb
@@ -15,6 +15,19 @@ FactoryGirl.define do
 
     trait :with_beta_requester do
       after(:create) do |procurement|
+        procurement.initialize_steps
+        requester = procurement.requester
+        requester.roles << Role.find_by!(name: ROLE_BETA_USER)
+        requester.roles << Role.find_by!(name: ROLE_BETA_ACTIVE)
+      end
+    end
+
+    trait :with_beta_steps do
+      after(:create) do |procurement|
+        procurement.initialize_steps
+        proposal = procurement.proposal
+        ind = 3.times.map { Steps::Approval.new(user: create(:user, client_slug: "gsa18f")) }
+        proposal.add_initial_steps(ind)
         requester = procurement.requester
         requester.roles << Role.find_by!(name: ROLE_BETA_USER)
         requester.roles << Role.find_by!(name: ROLE_BETA_ACTIVE)

--- a/spec/features/gsa18f/procurements/show_spec.rb
+++ b/spec/features/gsa18f/procurements/show_spec.rb
@@ -12,17 +12,14 @@ feature "View Gsa18F procurement" do
   end
 
 
-  scenario "last step is completed" do
-    it "shows the pegasys document number", js: true do
-      create_and_visit_proposal_beta_last_step
+  scenario "after last step is completed shows the pegasys document number", js: true do
+    create_and_visit_proposal_beta_last_step
 
-      expect(page).not_to have_content("Pegasys Document Number")
-      click_on("Mark as Purchased")
+    expect(page).not_to have_content("Pegasys Document Number")
+    click_on("Mark as Purchased")
 
-      visit proposal_path(proposal)
-      expect(page).to have_content("Pegasys Document Number")
-
-    end
+    visit proposal_path(proposal)
+    expect(page).to have_content("Pegasys Document Number")
   end
 
   scenario "requester cant see tock_project unless is_tock_billable is true", js: true do

--- a/spec/features/gsa18f/procurements/show_spec.rb
+++ b/spec/features/gsa18f/procurements/show_spec.rb
@@ -10,4 +10,24 @@ feature "View Gsa18F procurement" do
 
     expect(page).to have_content(procurement.purchase_type)
   end
+
+  scenario "last step is completed" do
+    it "shows the pegasys document number" do
+      purchaser = Gsa18f::Procurement.user_with_role("gsa18f_purchaser")
+      procurement = create(:gsa18f_procurement, :with_steps)
+      proposal = procurement.proposal
+
+      procurement.individual_steps.first.complete!
+      deliveries.clear
+
+      login_as(purchaser)
+      visit proposal_path(proposal)
+      expect(page).not_to have_content("Pegasys Document Number")
+      click_on("Mark as Purchased")
+
+      visit proposal_path(proposal)
+      expect(page).to have_content("Pegasys Document Number")
+
+    end
+  end
 end

--- a/spec/features/gsa18f/procurements/show_spec.rb
+++ b/spec/features/gsa18f/procurements/show_spec.rb
@@ -13,13 +13,19 @@ feature "View Gsa18F procurement" do
 
 
   scenario "after last step is completed shows the pegasys document number", js: true do
-    create_and_visit_proposal_beta_last_step
-
+    procurement = create(:gsa18f_procurement, :with_beta_requester)
+    proposal = procurement.proposal
+    login_as(proposal.requester)
+    visit proposal_path(proposal)
     expect(page).not_to have_content("Pegasys Document Number")
-    click_on("Mark as Purchased")
+
+    proposal.individual_steps.each do |step|
+      step.complete!
+    end
 
     visit proposal_path(proposal)
     expect(page).to have_content("Pegasys Document Number")
+    save_and_open_page
   end
 
   scenario "requester cant see tock_project unless is_tock_billable is true", js: true do
@@ -53,15 +59,4 @@ feature "View Gsa18F procurement" do
     return proposal
   end
 
-  def create_and_visit_proposal_beta_last_step
-    procurement = create(:gsa18f_procurement, :with_beta_requester)
-    proposal = procurement.proposal
-
-    procurement.individual_steps.first.complete!
-    deliveries.clear
-
-    login_as(proposal.requester)
-    visit proposal_path(proposal)
-    return proposal
-  end
 end

--- a/spec/features/gsa18f/procurements/show_spec.rb
+++ b/spec/features/gsa18f/procurements/show_spec.rb
@@ -13,19 +13,24 @@ feature "View Gsa18F procurement" do
 
 
   scenario "after last step is completed shows the pegasys document number", js: true do
-    procurement = create(:gsa18f_procurement, :with_beta_requester)
+    procurement = create(:gsa18f_procurement, :with_beta_steps)
     proposal = procurement.proposal
+
     login_as(proposal.requester)
     visit proposal_path(proposal)
     expect(page).not_to have_content("Pegasys Document Number")
 
-    proposal.individual_steps.each do |step|
-      step.complete!
+
+    procurement.individual_steps.each do |step|
+      login_as(User.find(step.user_id))
+      visit proposal_path(proposal)
+      wait_for_ajax
+      click_on("Approve")
     end
+
 
     visit proposal_path(proposal)
     expect(page).to have_content("Pegasys Document Number")
-    save_and_open_page
   end
 
   scenario "requester cant see tock_project unless is_tock_billable is true", js: true do

--- a/spec/features/proposals/complete_spec.rb
+++ b/spec/features/proposals/complete_spec.rb
@@ -44,6 +44,7 @@ describe "Completing a proposal" do
     visit proposal_path(proposal)
     click_on("Approve")
 
+    visit proposal_path(proposal)
     expect(proposal.observers.length).to eq(1)
     expect(deliveries.length).to eq(2)
   end

--- a/spec/features/proposals/sort_index_spec.rb
+++ b/spec/features/proposals/sort_index_spec.rb
@@ -54,6 +54,7 @@ feature "Sort proposals on index page" do
       visit proposals_path
 
       expect_order(pending_proposals_table, procurements.reverse.map { |p| p.proposal })
+      save_and_open_page
       within(pending_proposals_section) { click_on "Urgency" }
 
       expect_order(


### PR DESCRIPTION
# What

Add the Pegasys Document Number field in the GSA 18f.

Notes: Not added when request is being created. Only appears after request is already paid.

# Reference 

https://trello.com/c/sjwe7RNt/808-as-an-18f-ops-purchaser-i-can-add-a-pegasys-document-number-field-after-marking-a-request-as-purchased-so-that-i-can-easily-atta