### PR TITLE
Added radio select to event type

### DIFF
--- a/app/assets/stylesheets/redesign/_forms.scss
+++ b/app/assets/stylesheets/redesign/_forms.scss
@@ -197,3 +197,7 @@ input[type="radio"][disabled],input[type="radio"].disabled,fieldset[disabled] in
 .radio.disabled label,fieldset[disabled] .radio label,.checkbox.disabled label,fieldset[disabled] .checkbox label {
     cursor: not-allowed
 }
+
+.gsa18f_event_type_of_event .radio {
+    display: block !important;
+}

--- a/app/models/gsa18f/event.rb
+++ b/app/models/gsa18f/event.rb
@@ -22,6 +22,13 @@ module Gsa18f
 
     RECURRENCE = %w(Daily Monthly Yearly).freeze
 
+    EVENT_TYPES = {
+      "Conference" => 0,
+      "Training" => 1
+    }.freeze
+
+    enum type_of_event: EVENT_TYPES
+
     PURCHASE_TYPES = {
       "Software" => 0,
       "Training/Event" => 1,

--- a/app/views/gsa18f/events/_form_new.html.haml
+++ b/app/views/gsa18f/events/_form_new.html.haml
@@ -35,7 +35,10 @@
     .detail-edit.column
       %span.detail-value
         = f.input :type_of_event,
-         label_html: { class: "detail-element" }
+          collection: Gsa18f::Event::EVENT_TYPES.keys,
+          as: :radio_buttons,
+          include_blank: true,
+          label_html: { class: "detail-element" }
 
 .column{ id: "duty_station-wrapper"}
   .detail-wrapper.row{ class: "duty_station-wrapper"}

--- a/app/views/gsa18f/fields/_type_of_event.html.haml
+++ b/app/views/gsa18f/fields/_type_of_event.html.haml
@@ -4,7 +4,11 @@
       %label.detail-element
         = t(t_slug + key)
       %span.detail-value
-        = client_field
+        = Gsa18f::Event::EVENT_TYPES.keys[client_field.to_i]
     .detail-edit.column
       %span.detail-value
-        = f.input :type_of_event, as: :text, label_html: { class: "detail-element "}
+        = f.input :type_of_event,
+          collection: Gsa18f::Event::EVENT_TYPES.keys,
+          as: :radio_buttons,
+          label_html: { class: "detail-element" },
+          checked: Gsa18f::Event::EVENT_TYPES.keys[client_field.to_i]


### PR DESCRIPTION
WHAT: Add radio select to event type
WHY: https://trello.com/c/G4L6WbB4/823-18f-event-type-of-event-radio-buttons

<img width="518" alt="c2" src="https://cloud.githubusercontent.com/assets/5296248/18851576/9fb6c130-840a-11e6-8be9-24bbce7f418e.png">

<img width="629" alt="18f_events_-_c2" src="https://cloud.githubusercontent.com/assets/5296248/18851603/be8f36e6-840a-11e6-98ce-cfe044e784f1.png">
