### PR TITLE
Create a flag for billed tock projects

### DIFF
--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -34,7 +34,7 @@ module Gsa18f
     end
 
     def new_display
-      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project client_billed recurring recurring_interval  pegasys_document_number recurring_length total_price)
+      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project client_billed recurring recurring_interval pegasys_document_number recurring_length total_price)
     end
 
     def translated_key(key)

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -34,7 +34,7 @@ module Gsa18f
     end
 
     def new_display
-      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project recurring recurring_interval  pegasys_document_number client_billed recurring_length total_price)
+      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project client_billed recurring recurring_interval  pegasys_document_number recurring_length total_price)
     end
 
     def translated_key(key)

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -34,7 +34,7 @@ module Gsa18f
     end
 
     def new_display
-      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project recurring recurring_interval recurring_length total_price pegasys_document_number)
+      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project recurring recurring_interval recurring_length total_price pegasys_document_number client_billed)
     end
 
     def translated_key(key)

--- a/app/decorators/gsa18f/procurement_decorator.rb
+++ b/app/decorators/gsa18f/procurement_decorator.rb
@@ -34,7 +34,7 @@ module Gsa18f
     end
 
     def new_display
-      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project recurring recurring_interval recurring_length total_price pegasys_document_number client_billed)
+      %w(purchase_type office date_requested urgency quantity cost_per_unit link_to_product justification additional_info is_tock_billable tock_project recurring recurring_interval  pegasys_document_number client_billed recurring_length total_price)
     end
 
     def translated_key(key)

--- a/app/models/gsa18f/procurement_fields.rb
+++ b/app/models/gsa18f/procurement_fields.rb
@@ -11,9 +11,7 @@ module Gsa18f
         fields += [:recurring, :recurring_interval, :recurring_length]
       end
 
-      fields + [:is_tock_billable, :tock_project]
-
-      fields + [:client_billed]
+      fields + [:is_tock_billable, :tock_project, :client_billed]
     end
 
     private

--- a/app/models/gsa18f/procurement_fields.rb
+++ b/app/models/gsa18f/procurement_fields.rb
@@ -12,6 +12,8 @@ module Gsa18f
       end
 
       fields + [:is_tock_billable, :tock_project]
+
+      fields + [:client_billed]
     end
 
     private

--- a/app/views/gsa18f/_request_details.html.haml
+++ b/app/views/gsa18f/_request_details.html.haml
@@ -5,7 +5,7 @@
   - data[:f] = @form
   - data[:proposal] = @proposal
   - data[:key] = key
-  - data[:t_slug] = "decorators." + @proposal.client_slug + "/work_order."
+  - data[:t_slug] = "decorators." + @proposal.client_slug + "/procurement."
   - data[:client_slug] = @current_user.client_slug
   - data[:client_data] = @client_data_instance
   - data[:client_id] = @client_data_instance.id.to_s

--- a/app/views/gsa18f/fields/_client_billed.html.haml
+++ b/app/views/gsa18f/fields/_client_billed.html.haml
@@ -1,0 +1,12 @@
+.column{ id: key + '-wrapper'}
+  .detail-wrapper.row{ class: key + "-wrapper", id: value_id }
+    .detail-display.column
+      %label.detail-element
+        = t(t_slug + key)
+      %span.detail-value
+        = client_field
+    .detail-edit.column
+      %label.detail-element
+        = t(t_slug + key)
+      %span.detail-value
+        = f.input :client_billed, label: false

--- a/app/views/gsa18f/fields/_client_billed.html.haml
+++ b/app/views/gsa18f/fields/_client_billed.html.haml
@@ -1,4 +1,4 @@
-.column{ id: key + '-wrapper'}
+.column{ id: key + '-wrapper', class: key + '-wrapper', "data-filter-key" => "is_tock_billable", "data-filter-value" => 1 }
   .detail-wrapper.row{ class: key + "-wrapper", id: value_id }
     .detail-display.column
       %label.detail-element

--- a/app/views/gsa18f/fields/_client_billed.html.haml
+++ b/app/views/gsa18f/fields/_client_billed.html.haml
@@ -4,7 +4,8 @@
       %label.detail-element
         = t(t_slug + key)
       %span.detail-value
-        = client_field
+        - if client_field == true
+          Yes
     .detail-edit.column
       %label.detail-element
         = t(t_slug + key)

--- a/app/views/shared/_search_form_next.html.haml
+++ b/app/views/shared/_search_form_next.html.haml
@@ -60,6 +60,17 @@
         value: @adv_search.value_for("client_data.amount"),
       }
 
+  %h1
+    = current_user.client_model.to_s == "Gsa::Procurement"
+
+  - if current_user.client_model.expense_type_options.any?
+    .form-group
+      %label.control-label{for: "select_building_number"}
+        Building Number
+      %select.form-control{name: "#{current_user.client_model_slug}[client_data.building_number]", id: "select_building_number"}
+        = proposal_building_number_options(@adv_search.value_for("client_data.building_number"))
+
+
   .form-group.contains-field
     .medium-6.column
       %label.control-label{for: "#{current_user.client_model_slug}[created_within]"}

--- a/config/locales/decorators/en.yml
+++ b/config/locales/decorators/en.yml
@@ -51,6 +51,7 @@ en:
       pegasys_document_number: "Pegasys Document Number"
       recurring_interval: "Recurring interval"
       recurring_length: "Recurring length"
+      client_billed: "Client has been billed"
     ncr/work_order:
       project_title: "Project title"
       description: "Description"

--- a/config/tables/proposals.yml
+++ b/config/tables/proposals.yml
@@ -82,6 +82,9 @@ default: &DEFAULT
     tock_project:
       header: Tock
       display: client_data.tock_project
+    client_billed:
+      header: Billed
+      display: client_data.client_billed
     soc_code:
       header: SOC
       display: client_data.soc_code
@@ -125,3 +128,4 @@ gsa18f:
     - tock_project
     - purchase_type
     - pegasys_document_number
+    - client_billed

--- a/db/migrate/20160926221019_add_client_billed_to_gsa18f.rb
+++ b/db/migrate/20160926221019_add_client_billed_to_gsa18f.rb
@@ -1,0 +1,4 @@
+class AddClientBuildToGsa18f < ActiveRecord::Migration
+  def change
+  end
+end

--- a/db/migrate/20160926221019_add_client_billed_to_gsa18f.rb
+++ b/db/migrate/20160926221019_add_client_billed_to_gsa18f.rb
@@ -1,4 +1,8 @@
-class AddClientBuildToGsa18f < ActiveRecord::Migration
-  def change
+class AddClientBilledToGsa18f < ActiveRecord::Migration
+  def up
+    add_column :gsa18f_procurements, :client_billed, :boolean
+  end
+  def down
+    drop_column :gsa18f_procurements, :client_billed, :boolean
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160923202931) do
+ActiveRecord::Schema.define(version: 20160926221019) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -189,6 +189,7 @@ ActiveRecord::Schema.define(version: 20160923202931) do
     t.boolean  "is_tock_billable"
     t.string   "tock_project"
     t.string   "pegasys_document_number"
+    t.boolean  "client_billed"
   end
 
   create_table "ncr_organizations", force: :cascade do |t|
@@ -347,14 +348,6 @@ ActiveRecord::Schema.define(version: 20160923202931) do
   end
 
   add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
-
-  create_table "test_client_requests", force: :cascade do |t|
-    t.decimal  "amount"
-    t.string   "project_title"
-    t.integer  "approving_official_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
 
   create_table "user_delegates", force: :cascade do |t|
     t.integer  "assigner_id"

--- a/spec/features/gsa18f/procurements/show_spec.rb
+++ b/spec/features/gsa18f/procurements/show_spec.rb
@@ -36,10 +36,20 @@ feature "View Gsa18F procurement" do
   scenario "requester cant see tock_project unless is_tock_billable is true", js: true do
     proposal = create_and_visit_proposal_beta
     visit proposal_path(proposal)
-    expect(page).not_to have_content("Tock Project")
+    expect(page).not_to have_content("Tock project number")
     js_activate_modify_proposal
     js_modify_checkbox
-    expect(page).to have_content("Tock Project")
+    expect(page).to have_content("Tock project number")
+    visit proposal_path(proposal)
+  end
+
+  scenario "requester cant see client_billed unless is_tock_billable is true", js: true do
+    proposal = create_and_visit_proposal_beta
+    visit proposal_path(proposal)
+    expect(page).not_to have_content("Client has been billed")
+    js_activate_modify_proposal
+    js_modify_checkbox
+    expect(page).to have_content("Client has been billed")
     visit proposal_path(proposal)
   end
 


### PR DESCRIPTION
# What

As an 18F OPS TEAM MEMBER, I can mark an approved billable request as having an invoice generated (the client was billed) so that I can properly report which requests have been billed (Purchase request)

- Add client_billed attribute
- You have unsaved edits on this field. View edits - Discard
- Display Client has been billed + checkbox on the Modify Request page for requests that are 1) billable and 2) approved. Decide where to enforce #2 (frontend hiding of the checkbox or database level)
- User can save the request with this attribute. Do not show this attribute when creating a new request
- Reporting should allow the query of the client_billed attribute (preset or ability to create one through the search interface)

![screen shot 2016-09-26 at 5 06 29 pm](https://cloud.githubusercontent.com/assets/1332366/18855937/a8c09ef8-840b-11e6-8bd5-87b10d55c0df.png)
![screen shot 2016-09-26 at 5 06 56 pm](https://cloud.githubusercontent.com/assets/1332366/18855938/a93db58c-840b-11e6-8949-9b49ca4dee89.png)
