### PR TITLE
Add a paragraph wrapper around the content in comment field

### DIFF
--- a/app/views/proposals/details/history/_attachment.html.haml
+++ b/app/views/proposals/details/history/_attachment.html.haml
@@ -7,9 +7,10 @@
     %span.time-from
       = date_with_tooltip(event.created_at, true, { truncate: true })
   .item-block.attachment
-    %a{href: proposal_attachment_path(@proposal, event.item)}
-      = image_tag "icon-attachment.svg"
-      = event.item.file_file_name
+    %p
+      %a{href: proposal_attachment_path(@proposal, event.item)}
+        = image_tag "icon-attachment.svg"
+        = event.item.file_file_name
 - else
   - attachment = event.reify
   .title-block

--- a/app/views/proposals/details/history/_comment.html.haml
+++ b/app/views/proposals/details/history/_comment.html.haml
@@ -3,4 +3,5 @@
   %span.time-from
     = date_with_tooltip(event.created_at, true, { truncate: true })
 .item-block
-  = event.item.comment_text
+  %p
+    = event.item.comment_text

--- a/app/views/proposals/details/history/_event.html.haml
+++ b/app/views/proposals/details/history/_event.html.haml
@@ -6,4 +6,5 @@
   %span.time-from
     = date_with_tooltip(event.created_at, true, { truncate: true })
 .item-block
-  = event.safe_html_diff
+  %p
+    = event.safe_html_diff

--- a/app/views/proposals/details/history/_procurement.html.haml
+++ b/app/views/proposals/details/history/_procurement.html.haml
@@ -6,4 +6,5 @@
   %span.time-from
     = date_with_tooltip(event.created_at, true, { truncate: true })
 .item-block
-  = event.safe_html_diff
+  %p
+    = event.safe_html_diff

--- a/app/views/proposals/details/history/_proposal.html.haml
+++ b/app/views/proposals/details/history/_proposal.html.haml
@@ -6,4 +6,5 @@
   %span.time-from
     = date_with_tooltip(event.created_at, true, { truncate: true })
 .item-block
-  = event.object
+  %p
+    = event.object

--- a/app/views/proposals/details/history/_step.html.haml
+++ b/app/views/proposals/details/history/_step.html.haml
@@ -1,7 +1,8 @@
 .title-block
-  %span.status-action 
+  %span.status-action
     #{event.item_type} #{event.event_type}d by #{event.user.full_name}
   %span.time-from
     = date_with_tooltip(event.created_at, true, { truncate: true })
 .item-block
-  = event.object
+  %p
+    = event.object

--- a/app/views/proposals/details/history/_workorder.html.haml
+++ b/app/views/proposals/details/history/_workorder.html.haml
@@ -6,4 +6,5 @@
   %span.time-from
     = date_with_tooltip(event.created_at, true, { truncate: true })
 .item-block
-  = event.safe_html_diff
+  %p
+    = event.safe_html_diff


### PR DESCRIPTION
# What

Fix overflow issue due to table-cell display type.

Example: https://cap.18f.gov/proposals/5770

**Fix**

![screen shot 2016-10-18 at 3 30 59 pm](https://cloud.githubusercontent.com/assets/1332366/19493297/10ab40f2-9548-11e6-8d90-5b2ef4cfd089.png)

# Reference

https://trello.com/c/l5P1QDfF/878-redesign-overflow-layout