### PR TITLE
Fix really long titles on summary card

### DIFF
--- a/app/assets/stylesheets/redesign/_card-summary.scss
+++ b/app/assets/stylesheets/redesign/_card-summary.scss
@@ -35,7 +35,7 @@
       font-size: 28px;
       vertical-align: sub;
       vertical-align: -webkit-baseline-middle;
-      height: 39px;
+      height: auto;
     }
     .form-group{
       margin-bottom: 0px;


### PR DESCRIPTION
Titles were being cut off if they took more than one line

<img width="1039" alt="c2" src="https://cloud.githubusercontent.com/assets/5296248/19704722/c4f74518-9ad6-11e6-918c-8863565e95a9.png">
