### PR TITLE
Fixed attachment card logic

### DIFF
--- a/app/assets/javascripts/details/views/attachment_card.js
+++ b/app/assets/javascripts/details/views/attachment_card.js
@@ -19,7 +19,7 @@ AttachmentCardController = (function(){
   AttachmentCardController.prototype.clientCodeValidation = function(){
     $('#new_gsa18f_event [name="attachments[]"]').first().attr('required', 'required')
     var attachment = document.querySelector('#new_gsa18f_event [name="attachments[]"][required="required"]');
-    if (attachment !== null || attachment !== undefined){
+    if (attachment !== null && attachment !== undefined){
       $('.submit-button [type="submit"]').on('click', function(){
         if (!attachment.validity.valid){
           $('[required="required"]').each(function(i, item){


### PR DESCRIPTION
The logic in this file was flawed. On Non GSA event pages `attachment` would come out null, but `attachment !== undefined` is true, because `null != undefined`

Changed to `(attachment !== null && attachment !== undefined)` so it only proceeds if it isn't `null` and it isn't `undefined. `