### PR TITLE
Updated logins on redesigned home page

### DIFF
--- a/app/views/home/home_redesign.html.haml
+++ b/app/views/home/home_redesign.html.haml
@@ -39,7 +39,10 @@
             %a{:href => "/help/new_features"} New Features
           - unless signed_in?
             %li
-              = link_to "Sign in with MyUSA", auth_path
+              - if ENV['BETA_CLOUD_GOV_LOGIN'] == 'true'
+                = link_to "Sign in with Cloud.gov", auth_url(provider: :cg)
+              - else
+                = link_to "Sign in with MyUSA", auth_url(provider: :myusa)
     .row.full-width-row
       %section.small-12.header
         .small-10.medium-6.small-centered


### PR DESCRIPTION
This issue comes from the new login changes and only occurs on the redesign. 

https://trello.com/c/PwMsDlXZ/923-login-links-on-home-page-redesign-causing-an-error