### PR TITLE
Fix css error on redesigned home page

### DIFF
--- a/app/views/home/home_redesign.html.haml
+++ b/app/views/home/home_redesign.html.haml
@@ -7,7 +7,6 @@
     = favicon_link_tag
     %meta{"http-equiv" => "content-type", content: "text/html; charset=utf-8"}
     = stylesheet_link_tag "redesign/app"
-    = stylesheet_link_tag "home_redesign"
     = render "layouts/analytics"
     %noscript
   %body.home_redesign


### PR DESCRIPTION
Removed call directly for home_redesign.css as its already in the app css file