### PR TITLE
Fix issue with NCR not_to_exceed

### DIFF
--- a/app/models/ncr/work_order.rb
+++ b/app/models/ncr/work_order.rb
@@ -206,7 +206,7 @@ module Ncr
     end
 
     def self.special_keys
-      %w(is_tock_billable date_requested)
+      %w(is_tock_billable date_requested not_to_exceed)
     end
 
     def self.display_update_not_to_exceed(obj)

--- a/app/services/prepare_display_fields.rb
+++ b/app/services/prepare_display_fields.rb
@@ -29,7 +29,7 @@ class PrepareDisplayFields
   end
 
   def check_for_blank(value)
-    if value.nil? || value.blank?
+    if value.nil? || (value.blank? && value != false)
       "--"
     else
       value
@@ -42,7 +42,6 @@ class PrepareDisplayFields
     data = @obj[:data]
     key = @obj[:key]
     value = @obj[:value]
-
     if @obj[:special_keys].include?(key) && value != "--"
       Object.const_get(data.class.name).send("display_update_" + key, @obj)
     else

--- a/spec/features/ncr/work_orders/edit_spec.rb
+++ b/spec/features/ncr/work_orders/edit_spec.rb
@@ -21,7 +21,8 @@ feature "Editing NCR work order" do
       fill_in 'ncr_work_order[project_title]', with: "New project title"
       fill_in 'ncr_work_order[description]', with: "New desc content"
       fill_in 'ncr_work_order[rwa_number]', with: 'F0000000'
-      fill_in 'ncr_work_order[amount]', with: 3.45
+      fill_in 'ncr_work_order[not_to_exceed]', with: 3.45
+      fill_in 'ncr_work_order[amount]', with: true
 
       within(".action-bar-container") do
           click_on "SAVE"
@@ -37,6 +38,7 @@ feature "Editing NCR work order" do
       expect(page).to have_content("F0000000")
       expect(page).to have_content("New desc content")
       expect(page).to have_content("3.45")
+      expect(page).to have_content("Not to exceed")
     end
   end
 end

--- a/spec/features/ncr/work_orders/edit_spec.rb
+++ b/spec/features/ncr/work_orders/edit_spec.rb
@@ -22,7 +22,7 @@ feature "Editing NCR work order" do
       fill_in 'ncr_work_order[description]', with: "New desc content"
       fill_in 'ncr_work_order[rwa_number]', with: 'F0000000'
       fill_in 'ncr_work_order[amount]', with: 3.45
-      select true, from: "ncr_work_order_not_to_exceed"
+      select "Not to exceed", from: "ncr_work_order_not_to_exceed"
 
       within(".action-bar-container") do
           click_on "SAVE"

--- a/spec/features/ncr/work_orders/edit_spec.rb
+++ b/spec/features/ncr/work_orders/edit_spec.rb
@@ -21,8 +21,8 @@ feature "Editing NCR work order" do
       fill_in 'ncr_work_order[project_title]', with: "New project title"
       fill_in 'ncr_work_order[description]', with: "New desc content"
       fill_in 'ncr_work_order[rwa_number]', with: 'F0000000'
-      fill_in 'ncr_work_order[not_to_exceed]', with: 3.45
-      fill_in 'ncr_work_order[amount]', with: true
+      fill_in 'ncr_work_order[amount]', with: 3.45
+      select true, from: "ncr_work_order_not_to_exceed"
 
       within(".action-bar-container") do
           click_on "SAVE"
@@ -37,8 +37,8 @@ feature "Editing NCR work order" do
       expect(page).to have_content("BA80")
       expect(page).to have_content("F0000000")
       expect(page).to have_content("New desc content")
-      expect(page).to have_content("3.45")
       expect(page).to have_content("Not to exceed")
+      expect(page).to have_content("3.45")
     end
   end
 end


### PR DESCRIPTION
# What

The `not_to_exceed` value was not being updated when user made changes on frontend. Also when values were being reported at `false` during update, they were returning as blank. 

This fixes both of these issues.

<img width="577" alt="screen shot 2016-11-22 at 6 12 29 pm" src="https://cloud.githubusercontent.com/assets/1332366/20545828/516dbbee-b0df-11e6-83b8-b518e27d98b4.png">

<img width="511" alt="screen shot 2016-11-22 at 6 12 37 pm" src="https://cloud.githubusercontent.com/assets/1332366/20545829/517bc676-b0df-11e6-8295-d9d4cc03c6e8.png">
