### PR TITLE
Configure poltergeist to continue on JS errors

### DIFF
--- a/config/initializers/konacha.rb
+++ b/config/initializers/konacha.rb
@@ -2,7 +2,7 @@ require "tilt/coffee"
 
 if defined?(Konacha)
   Capybara.register_driver :slow_poltergeist do |app|
-    Capybara::Poltergeist::Driver.new(app, timeout: 2.minutes, debug: true)
+    Capybara::Poltergeist::Driver.new(app, timeout: 2.minutes, debug: true, js_errors: false)
   end
   Konacha.configure do |config|
     require "capybara/poltergeist"


### PR DESCRIPTION
This lets the test suite finish, but still displays the errors encountered.
It doesn't fix any errors, but at least displays them.

docs: https://github.com/teampoltergeist/poltergeist#customization
![before](https://user-images.githubusercontent.com/11878/30890756-0f64283c-a2ec-11e7-88b6-2f33f9c237cf.png)
![after](https://user-images.githubusercontent.com/11878/30890757-0f6809c0-a2ec-11e7-9789-b0b31a41b4ff.png)

