### PR TITLE
Silence hakiri etc to pass build

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,7 +70,8 @@ GEM
       activerecord (>= 3.2, < 5)
     acts_as_list (0.7.2)
       activerecord (>= 3.0)
-    addressable (2.4.0)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     ahoy_matey (1.4.2)
       addressable
       browser (~> 2.0)
@@ -113,9 +114,9 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.9.0)
     callsite (0.0.11)
-    capybara (2.6.2)
+    capybara (2.15.1)
       addressable
-      mime-types (>= 1.16)
+      mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
@@ -143,7 +144,8 @@ GEM
     concurrent-ruby (1.0.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    css_parser (1.3.7)
+    crass (1.0.2)
+    css_parser (1.6.0)
       addressable
     daemons (1.2.3)
     database_cleaner (1.5.3)
@@ -251,7 +253,7 @@ GEM
       github-markdown
       html-pipeline
     htmlentities (4.3.4)
-    i18n (0.7.0)
+    i18n (0.8.6)
     inherited_resources (1.6.0)
       actionpack (>= 3.2, < 5)
       has_scope (~> 0.6.0.rc)
@@ -264,7 +266,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
-    json (1.8.3)
+    json (1.8.6)
     jwt (1.5.1)
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
@@ -292,7 +294,8 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.0.3)
+    loofah (2.1.1)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.10)
     mail (2.6.4)
@@ -308,15 +311,16 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mimemagic (0.3.2)
-    mini_portile2 (2.1.0)
-    minitest (5.9.1)
+    mini_mime (0.1.4)
+    mini_portile2 (2.3.0)
+    minitest (5.10.3)
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     nenv (0.3.0)
     newrelic_rpm (3.17.1.326)
-    nokogiri (1.6.8.1)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     notiffany (0.1.0)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -367,12 +371,13 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.4)
       pry (>= 0.9.10)
+    public_suffix (3.0.0)
     puma (2.16.0)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.4)
+    rack (1.6.8)
     rack-attack (5.0.1)
       rack
     rack-contrib (1.4.0)
@@ -400,9 +405,9 @@ GEM
       sprockets-rails
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.7)
+    rails-dom-testing (1.0.8)
       activesupport (>= 4.2.0.beta, < 5.0)
-      nokogiri (~> 1.6.0)
+      nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
@@ -431,9 +436,9 @@ GEM
     request_store (1.3.1)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
-    roadie (3.1.1)
-      css_parser (~> 1.3.4)
-      nokogiri (>= 1.5.0, < 1.7.0)
+    roadie (3.2.2)
+      css_parser (~> 1.4)
+      nokogiri (~> 1.5)
     roadie-rails (1.1.0)
       railties (>= 3.0, < 4.3)
       roadie (~> 3.1)
@@ -505,10 +510,10 @@ GEM
     test_after_commit (1.0.0)
       activerecord (>= 3.2)
     thor (0.19.1)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     tilt (2.0.5)
     timecop (0.8.1)
-    tzinfo (1.2.2)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
       execjs (>= 0.3.0)
@@ -526,7 +531,7 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
     workflow (1.2.0)
-    xpath (2.0.0)
+    xpath (2.1.0)
       nokogiri (~> 1.3)
     zonebie (0.6.1)
 
@@ -626,7 +631,7 @@ DEPENDENCIES
   zonebie
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.3.3p222
 
 BUNDLED WITH
-   1.13.6
+   1.15.4

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,12 +1,33 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "348c8a382df7e795a35237a5c73a4bf711da65aa03e1e7e1859c39cfa4ec3881",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/models/concerns/proposal_steps.rb",
+      "line": 19,
+      "link": "http://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "steps.find_by(\"(#{ProposalServices.new(self).sql_for_step_user_or_delegate}) AND status = :actionable\", :user_id => user.id, :actionable => :actionable)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ProposalSteps",
+        "method": "existing_or_delegated_actionable_step_for"
+      },
+      "user_input": "ProposalServices.new(self).sql_for_step_user_or_delegate",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
       "fingerprint": "f80c20fad3f53c3fbd0b4f51ab1c5ad4d09fddba4548f56f6007f7581568b428",
+      "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/controllers/help_controller.rb",
-      "line": 11,
+      "line": 15,
       "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => \"help/#{params[:id]}\", {})",
       "render_path": null,
@@ -20,6 +41,6 @@
       "note": ""
     }
   ],
-  "updated": "2015-07-10 01:57:39 +0100",
-  "brakeman_version": "3.0.5"
+  "updated": "2017-10-03 20:30:58 -0600",
+  "brakeman_version": "3.7.2"
 }


### PR DESCRIPTION
## Nokogiri warning
- update nokogiri via `bundle update capybara loofah rails-dom-testing roadie xpath`

## SQL Injection warning
Here is where Hakiri found a `WEAK` confidence SQL injection warning:
https://github.com/18F/C2/blob/master/app/models/concerns/proposal_steps.rb#L19

The WHERE clause of the query comes from another class, but is static in nature:
https://github.com/18F/C2/blob/master/app/services/proposal_services.rb#L15

I don’t see how this code could be used for SQL injection, which supports Hakiri’s weak confidence.


To silence the warning I tried to sanitize the query various ways using `ActiveRecord::Base.sanitize`.  Each attempt made Hakiri happy but broke tests.
Because there doesn’t seem to be any risk of SQL injection here I added a brakeman exception to the [`brakeman.ignore`](https://github.com/18F/C2/blob/master/config/brakeman.ignore) file using `brakeman -I` which lets you add exceptions interactively.
