### PR TITLE
Specify allowed content types for attachments

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -3,16 +3,16 @@ class Attachment < ActiveRecord::Base
 
   has_attached_file :file
   validates_attachment_content_type :file, content_type: [
-    /\Aapplication\/vnd\.ms-.*/,
-    /\Aapplication\/vnd\.oasis.*/,
-    /\Aapplication\/vnd\.openxmlformats.*/,
+    %r{\Aapplication\/vnd\.ms-.*},
+    %r{\Aapplication\/vnd\.oasis.*},
+    %r{\Aapplication\/vnd\.openxmlformats.*},
     "application/msword",
     "application/octet-stream",
     "application/pdf",
-    /\Aimage\/p?jpeg\z/,
-    /\Aimage\/(x-)?png\z/,
+    %r{\Aimage\/p?jpeg\z},
+    %r{\Aimage\/(x-)?png\z},
     "image/tiff",
-    "text/rtf",
+    "text/rtf"
   ]
 
   belongs_to :proposal

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -2,7 +2,16 @@ class Attachment < ActiveRecord::Base
   has_paper_trail class_name: "C2Version"
 
   has_attached_file :file
-  do_not_validate_attachment_file_type :file
+  validates_attachment_content_type :file, content_type: [
+    /\Aapplication\/vnd\..*/,
+    "application/msword",
+    "application/octet-stream",
+    "application/pdf",
+    /image\/p?jpeg/,
+    /image\/(x-)?png/,
+    "image/tiff",
+    "text/rtf",
+  ]
 
   belongs_to :proposal
   belongs_to :user

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -3,12 +3,14 @@ class Attachment < ActiveRecord::Base
 
   has_attached_file :file
   validates_attachment_content_type :file, content_type: [
-    /\Aapplication\/vnd\..*/,
+    /\Aapplication\/vnd\.ms-.*/,
+    /\Aapplication\/vnd\.oasis.*/,
+    /\Aapplication\/vnd\.openxmlformats.*/,
     "application/msword",
     "application/octet-stream",
     "application/pdf",
-    /image\/p?jpeg/,
-    /image\/(x-)?png/,
+    /\Aimage\/p?jpeg\z/,
+    /\Aimage\/(x-)?png\z/,
     "image/tiff",
     "text/rtf",
   ]

--- a/spec/features/attachment_spec.rb
+++ b/spec/features/attachment_spec.rb
@@ -45,11 +45,11 @@ describe "Add attachments" do
     login_as(proposal.requester)
 
     visit proposal_path(proposal)
-    page.attach_file("attachment[file]", "#{Rails.root}/app/assets/images/bg_completed_status.gif")
+    page.attach_file("attachment[file]", "#{Rails.root}/app/assets/images/attachment.png")
     click_on "Attach a File"
 
     expect(proposal.attachments.length).to eq 1
-    expect(proposal.attachments.last.file_file_name).to eq "bg_completed_status.gif"
+    expect(proposal.attachments.last.file_file_name).to eq "attachment.png"
   end
 
   it "saves attachments submitted via the webform with js", :js, js_errors: false do
@@ -59,13 +59,13 @@ describe "Add attachments" do
 
     visit proposal_path(proposal)
     page.execute_script("$('#attachment_file').addClass('show-attachment-file');")
-    page.attach_file("attachment[file]", "#{Rails.root}/app/assets/images/bg_completed_status.gif", visible: false)
+    page.attach_file("attachment[file]", "#{Rails.root}/app/assets/images/attachment.png", visible: false)
     wait_for_ajax
     within(".attachment-list") do
-      expect(page).to have_content("bg_completed_status.gif")
+      expect(page).to have_content("attachment.png")
     end
     within("#card-for-activity") do
-      expect(page).to have_content("bg_completed_status.gif")
+      expect(page).to have_content("attachment.png")
     end
   end
 
@@ -89,7 +89,7 @@ describe "Add attachments" do
     proposal.add_observer(create(:user))
 
     visit proposal_path(proposal)
-    page.attach_file("attachment[file]", "#{Rails.root}/app/assets/images/bg_completed_status.gif")
+    page.attach_file("attachment[file]", "#{Rails.root}/app/assets/images/attachment.png")
     click_on "Attach a File"
 
     expect(dispatcher).to have_received(:deliver_attachment_emails)

--- a/spec/features/gsa18f/events/create_spec.rb
+++ b/spec/features/gsa18f/events/create_spec.rb
@@ -28,7 +28,7 @@ feature "Create a Gsa18F event" do
       fill_in "Link to purchase event", with: "www.gsa.gov"
       fill_in "Instructions to purchase event", with: "go buy it"
       execute_script("$('[name=\"attachments[]\"][required=\"required\"]').css('display', 'block')")
-      page.attach_file("attachments[]", "#{Rails.root}/app/assets/images/bg_completed_status.gif")
+      page.attach_file("attachments[]", "#{Rails.root}/app/assets/images/attachment.png")
 
       click_on "SUBMIT"
 


### PR DESCRIPTION
This adds content type checking for uploaded attachments using Paperclip's [security validations](https://github.com/thoughtbot/paperclip#security-validations).

The list of file types is based on the types of files that past users have uploaded, so there shouldn't be any noticeable difference for users.