### PR TITLE
Limit CORS to API routes

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ module C2
       allow do
         origins '*'
 
-        resource '/api/*',
+        resource "/api/*",
           headers: :any,
           methods: [:get, :post, :delete, :put, :options, :head],
           max_age: 1728000

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ module C2
       allow do
         origins '*'
 
-        resource '*',
+        resource '/api/*',
           headers: :any,
           methods: [:get, :post, :delete, :put, :options, :head],
           max_age: 1728000


### PR DESCRIPTION
Previously, CORS was permitted for all resources. This should limit it to just API calls, which are the only ones that should require CORS.