### PR TITLE
Limit attachment size to 30 MB

### DIFF
--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -18,11 +18,10 @@ class Attachment < ActiveRecord::Base
   belongs_to :proposal
   belongs_to :user
 
-  validates :file, presence: true
+  validates :file, presence: true,
+    size: { in: 0..30.megabytes }
   validates :proposal, presence: true
   validates :user, presence: true
-
-  validates_with AttachmentSizeValidator, attributes: :file, less_than: 30.megabytes
 
   scope :with_users, -> { includes :user }
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -22,7 +22,7 @@ class Attachment < ActiveRecord::Base
   validates :proposal, presence: true
   validates :user, presence: true
 
-  validates_with AttachmentSizeValidator, attributes: :avatar, less_than: 30.megabytes
+  validates_with AttachmentSizeValidator, attributes: :file, less_than: 30.megabytes
 
   scope :with_users, -> { includes :user }
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -18,10 +18,11 @@ class Attachment < ActiveRecord::Base
   belongs_to :proposal
   belongs_to :user
 
-  validates :file, presence: true,
-    size: { in: 0..30.megabytes }
+  validates :file, presence: true
   validates :proposal, presence: true
   validates :user, presence: true
+
+  validates_attachment :file, size: { in: 0..30.megabytes }
 
   scope :with_users, -> { includes :user }
 

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -22,6 +22,8 @@ class Attachment < ActiveRecord::Base
   validates :proposal, presence: true
   validates :user, presence: true
 
+  validates_with AttachmentSizeValidator, attributes: :avatar, less_than: 30.megabytes
+
   scope :with_users, -> { includes :user }
 
   # Default url for attachments expires after 10 minutes


### PR DESCRIPTION
30 MB is around 5 MB larger than the largest two uploaded in the past, but I'd be happy to reduce it for the future.