### PR TITLE
Extract mail config

### DIFF
--- a/app/credentials/email_credentials.rb
+++ b/app/credentials/email_credentials.rb
@@ -18,4 +18,36 @@ class EmailCredentials
       credentials(base_name("email"))["SMTP_USERNAME"]
     end
   end
+
+  def self.smtp_domain
+    if use_env_var?
+      ENV["SMTP_DOMAIN"]
+    else
+      credentials(base_name("email"))["SMTP_DOMAIN"]
+    end
+  end
+
+  def self.smtp_server
+    if use_env_var?
+      ENV["SMTP_SERVER"]
+    else
+      credentials(base_name("email"))["SMTP_SERVER"]
+    end
+  end
+
+  def self.smtp_port
+    if use_env_var?
+      ENV["SMTP_PORT"]
+    else
+      credentials(base_name("email"))["SMTP_PORT"]
+    end
+  end
+
+  def self.smtp_auth
+    if use_env_var?
+      ENV["SMTP_AUTH"]
+    else
+      credentials(base_name("email"))["SMTP_AUTH"]
+    end
+  end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,7 +5,7 @@ C2::Application.configure do
   config.action_mailer.smtp_settings = {
     address: EmailCredentials.smtp_server,
     port: EmailCredentials.smtp_port,
-    domain: EmailCredentials.smtp_domain || "18f.gsa.gov",
+    domain: EmailCredentials.smtp_domain || "18f.gov",
     user_name: EmailCredentials.smtp_username,
     password: EmailCredentials.smtp_password,
     authentication: EmailCredentials.smtp_auth || "login",

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,12 +3,12 @@ C2::Application.configure do
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.asset_host = AppParamCredentials.asset_host
   config.action_mailer.smtp_settings = {
-    address: "smtp.mandrillapp.com",
-    port: 587,
-    domain: ENV["SMTP_DOMAIN"] || "18f.gsa.gov",
+    address: EmailCredentials.smtp_server,
+    port: EmailCredentials.smtp_port,
+    domain: EmailCredentials.smtp_domain || "18f.gsa.gov",
     user_name: EmailCredentials.smtp_username,
     password: EmailCredentials.smtp_password,
-    authentication: "login",
+    authentication: EmailCredentials.smtp_auth || "login",
     enable_starttls_auto: true
   }
   config.active_support.deprecation = :notify


### PR DESCRIPTION
So that it's easier to move from MailChimp/Mandrill to Amazon SES (#1663), or to any other mail service, this moves more config into the CF service.

Note that this changes our default `From:` domain from `18f.gsa.gov` to `18f.gov`, purely because it's easier to add Amazon SES to that domain.