### PR TITLE
Fix initialization error in populate:ncr:for_user method

### DIFF
--- a/db/chores/populator.rb
+++ b/db/chores/populator.rb
@@ -28,13 +28,13 @@ class Populator
 
   private
 
-  def create_proposal(requester: create(:user, client_slug: "ncr"), requested_at: Time.zone.now)
+  def create_proposal(requester:, requested_at: Time.zone.now)
     create(
       :proposal,
       :with_serial_approvers,
       :with_observers,
       client_slug: "ncr",
-      requester: requester,
+      requester: create(:user, client_slug: "ncr"),
       created_at: requested_at,
       updated_at: requested_at,
     )


### PR DESCRIPTION
**Current Behavior**
Running this command fails:

$→   bin/rake populate:ncr:for_user[test12345@gsa.gov]
Running via Spring preloader in process 60585
D, [2018-06-21T13:40:24.747211 #60585] DEBUG -- :   User Load (0.7ms)  SELECT  "users".* FROM "users" WHERE "users"."email_address" = $1 LIMIT 1  [["email_address", "test12345@gsa.gov"]]
D, [2018-06-21T13:40:24.775324 #60585] DEBUG -- :    (0.4ms)  BEGIN
D, [2018-06-21T13:40:24.791413 #60585] DEBUG -- :   Proposal Exists (0.7ms)  SELECT  1 AS one FROM "proposals" WHERE "proposals"."public_id" = 'PUBLIC1' LIMIT 1
D, [2018-06-21T13:40:24.793991 #60585] DEBUG -- :    (0.3ms)  ROLLBACK
rake aborted!
ActiveRecord::RecordInvalid: Validation failed: Requester can't be blank, Public has already been taken
/Users/eddie/.rvm/gems/ruby-2.3.5/gems/activerecord-4.2.7.1/lib/active_record/validations.rb:79:in `raise_record_invalid'
/Users/eddie/.rvm/gems/ruby-2.3.5/gems/activerecord-4.2.7.1/lib/active_record/validations.rb:43:in `save!'
/Users/eddie/.rvm/gems/ruby-2.3.5/gems/activerecord-4.2.7.1/lib/active_record/attribute_methods/dirty.rb:29:in `save!'
/Users/eddie/.rvm/gems/ruby-2.3.5/gems/activerecord-4.2.7.1/lib/active_record/transactions.rb:291:in `block in save!'

**Why this happens**
The 'create' does not set default requester value when it's called as part of the definition.

**Fix**
Calling the 'create' method inside the definition resolves the issue: 'ActiveRecord::RecordInvalid: Validation failed: Requester can't be blank' error. 