### PR TITLE
expire session after 15 minutes

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -3,7 +3,7 @@
 C2::Application.config.session_store(
   :cookie_store,
   key: "_c2_session",
-  expire_after: 8.hours,
+  expire_after: 15.minutes,
   secure: Rails.env.production?
   # domain: 'localhost'
 )


### PR DESCRIPTION
When a user closes browser or is inactive for 15 minutes, expire session.